### PR TITLE
Update build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Core WCF is built on top of .NET Core 2.2.
 
 ## Building
 
-Run `dotnet restore` and `dotnet build` from the command line inside the src folder. This builds Core WCF.
+Run `dotnet build` from the command line inside the src folder. This builds Core WCF.
 
 ## Other discussions
 


### PR DESCRIPTION
The existing build instructions say to run `dotnet restore`, but as of .NET Core 2.0 this is not necessary as the restore step is run implicitly as part of the `dotnet build` command. Updating the instructions accordingly.