### PR TITLE
Check for null correct variable

### DIFF
--- a/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
+++ b/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
@@ -283,7 +283,7 @@ namespace CoreWCF.Runtime
         private static void OnAsyncCompletion(object state)
         {
             var tcs = state as TaskCompletionSource<bool>;
-            Fx.Assert(state != null, "Async state should be of type TaskCompletionSource<bool>");
+            Fx.Assert(tcs != null, "Async state should be of type TaskCompletionSource<bool>");
             tcs.TrySetResult(true);
         }
 


### PR DESCRIPTION
Check for null variable after "as" operation, not original state.