### PR TITLE
Add azure pipelines configuration

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
     <SourceDir>$(ProjectDir)src/</SourceDir>
-    
+
     <!-- Output directories -->
     <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)bin/</BinDir>
     <ObjDir Condition="'$(ObjDir)'==''">$(BinDir)obj/</ObjDir>
@@ -26,11 +26,16 @@
     <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)</IntermediateOutputRootPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)/</IntermediateOutputPath>
   </PropertyGroup>
-  
+
   <!-- Disable the default embedded resource behavior as we have a naming convention which is different than what the SDK uses -->
   <PropertyGroup>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
-  
+
+  <!-- Disable packaging for samples project -->
+  <PropertyGroup Condition="'$(IsSampleProject)' == 'true'">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <Import Project="$(ProjectDir)resources.props" Condition="Exists('$(ProjectDir)resources.props')" />
 </Project>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,6 @@
+assembly-versioning-scheme: Major
+mode: ContinuousDeployment
+branches:
+  master: {}
+ignore:
+  sha: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pool:
 variables:
   buildConfiguration: 'Release'
   solution: 'src/CoreWCF.sln'
-  OS: 'Windows' # needed to run both netcore and net472
+#  OS: 'Windows' # needed to run both netcore and net472, not enabled since net472 hangs
 
 steps:
 - task: GitVersion@4
@@ -38,15 +38,8 @@ steps:
   inputs:
     command: test
     projects: '$(solution)'
-    arguments: '--configuration $(buildConfiguration) --no-build --collect "Code coverage" -f netcoreapp2.1'
+    arguments: '--configuration $(buildConfiguration) --no-build --collect "Code coverage"'
 
-
-- task: DotNetCoreCLI@2
-  displayName: Test net472
-  inputs:
-    command: test
-    projects: '$(solution)'
-    arguments: '--configuration $(buildConfiguration) --no-build --collect "Code coverage" -f net472'
 - task: DotNetCoreCLI@2
   displayName: Pack
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,60 @@
+# ASP.NET Core (.NET Framework)
+# Build and test ASP.NET Core projects targeting the full .NET Framework.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+
+trigger:
+- master
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  buildConfiguration: 'Release'
+  solution: 'src/CoreWCF.sln'
+  OS: 'Windows' # needed to run both netcore and net472
+
+steps:
+- task: GitVersion@4
+  displayName: GitVersion
+  inputs:
+    preferBundledVersion: true
+
+- task: DotNetCoreCLI@2
+  displayName: Restore
+  inputs:
+    command: restore
+    projects: '$(solution)'
+
+- task: DotNetCoreCLI@2
+  displayName: Build
+  inputs:
+    command: build
+    projects: '$(solution)'
+    arguments: '--configuration $(buildConfiguration) --no-restore' # Update this to match your need
+    
+- task: DotNetCoreCLI@2
+  displayName: Test netcoreapp2.1
+  inputs:
+    command: test
+    projects: '$(solution)'
+    arguments: '--configuration $(buildConfiguration) --no-build --collect "Code coverage" -f netcoreapp2.1'
+
+
+- task: DotNetCoreCLI@2
+  displayName: Test net472
+  inputs:
+    command: test
+    projects: '$(solution)'
+    arguments: '--configuration $(buildConfiguration) --no-build --collect "Code coverage" -f net472'
+- task: DotNetCoreCLI@2
+  displayName: Pack
+  inputs:
+    command: 'pack'
+    packagesToPack: '$(solution)'
+    nobuild: true
+    versioningScheme: 'byBuildNumber'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathtoPublish: '$(Build.ArtifactStagingDirectory)' 

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows'" >$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.5.3" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows'" >$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows'" >$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/CoreWCF.sln
+++ b/src/CoreWCF.sln
@@ -24,9 +24,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCoreServer", "Samples\Ne
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCoreClient", "Samples\NetCoreClient\NetCoreClient.csproj", "{F270C4F1-6F1D-44B1-B29F-97C8D810C209}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopClient", "Samples\DesktopClient\DesktopClient.csproj", "{AC474D52-EC86-43CC-AE48-579D9465DE2D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DesktopClient", "Samples\DesktopClient\DesktopClient.csproj", "{AC474D52-EC86-43CC-AE48-579D9465DE2D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopServer", "Samples\DesktopServer\DesktopServer.csproj", "{53D7DDAB-757E-42DF-A064-62E97C7AD813}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DesktopServer", "Samples\DesktopServer\DesktopServer.csproj", "{53D7DDAB-757E-42DF-A064-62E97C7AD813}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{70DF61A7-6207-4232-B067-FC11FF43B386}"
+	ProjectSection(SolutionItems) = preProject
+		..\Directory.Build.props = ..\Directory.Build.props
+		..\Directory.Build.targets = ..\Directory.Build.targets
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
* Setup a *basic* build, test and package pipeline using azure pipelins
* Use gitversion to get incremented release numbers based on git tags
* Installs latests Microsoft.Test.SDK into all test projects to enable code coverage
* Disable packaging for sample projects

**net472 is not built and tested** since the tests hangs since #50 

For build status see
https://svensson-daniel.visualstudio.com/CoreWCF/_build/results?buildId=628&view=results

This is *one of the steps* required to fix #21
Once this is in master the azure pipelines github app needs to be installed, a devops project with corresponding build setup, but at least the build can be setup with an existing yml file

Future work could include adding some kind of static analysis (I personally find sonarcloud quite good) support for deterministic builds, sourcelink support as well as building on different os.
 (and maybe a release pipeline to create github releases and push to nuget)