### PR TITLE
Replace Task to ToApm wrapper with a leaner implementation

### DIFF
--- a/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
+++ b/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
@@ -48,7 +48,7 @@ namespace CoreWCF.Runtime
                 valueTask.AsTask().ContinueWith((_, asyncResult) =>
                 {
                     ((AsyncResult<T>)asyncResult).ExecuteCallback();
-                }, result, CancellationToken.None, TaskContinuationOptions.RunContinuationsAsynchronously, TaskScheduler.Default);
+                }, result, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
             }
 
             return result;
@@ -69,7 +69,7 @@ namespace CoreWCF.Runtime
                 task.ContinueWith((_, asyncResult) =>
                 {
                     ((AsyncResult)asyncResult).ExecuteCallback();
-                }, result, CancellationToken.None, TaskContinuationOptions.RunContinuationsAsynchronously, TaskScheduler.Default);
+                }, result, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
             }
 
             return result;

--- a/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
+++ b/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using CoreWCF;
 using CoreWCF.Dispatcher;
 using System;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -29,120 +30,155 @@ namespace CoreWCF.Runtime
         // In the EndMethod, you would use ToApmEnd<TResult> to ensure the correct exception handling
         // This will handle throwing exceptions in the correct place and ensure the IAsyncResult contains the provided
         // state object
-        public static Task<TResult> ToApm<TResult>(this Task<TResult> task, AsyncCallback callback, object state)
+        public static IAsyncResult ToApm<T>(this Task<T> task,
+                                   AsyncCallback callback,
+                                   object state)
+            => ToApm<T>(new ValueTask<T>(task), callback, state);
+
+        /// <summary>
+        /// Helper method to convert from Task async method to "APM" (IAsyncResult with Begin/End calls)
+        /// </summary>
+        public static IAsyncResult ToApm<T>(this ValueTask<T> task,
+                                    AsyncCallback callback,
+                                    object state)
         {
-            // When using APM, the returned IAsyncResult must have the passed in state object stored in AsyncState. This
-            // is so the callback can regain state. If the incoming task already holds the state object, there's no need
-            // to create a TaskCompletionSource to ensure the returned (IAsyncResult)Task has the right state object.
-            // This is a performance optimization for this special case.
-            if (task.AsyncState == state)
+            var result = new AsyncResult<T>(task, callback, state);
+            if (result.CompletedSynchronously)
             {
-                if (callback != null)
-                {
-                    task.ContinueWith((antecedent, obj) =>
+                result.ExecuteCallback();
+                return result;
+            }
+            else
+            {
+                task.AsTask()
+                    .ContinueWith((res, asyncResult) =>
                     {
-                        var callbackObj = obj as AsyncCallback;
-                        callbackObj(antecedent);
-                    }, callback, CancellationToken.None, TaskContinuationOptions.HideScheduler, TaskScheduler.Default);
-                }
-                return task;
+                        ((AsyncResult<T>)asyncResult).ExecuteCallback();
+                    },
+                result,
+                CancellationToken.None,
+                TaskContinuationOptions.HideScheduler,
+                TaskScheduler.Default);
             }
 
-            // Need to create a TaskCompletionSource so that the returned Task object has the correct AsyncState value.
-            var tcs = new TaskCompletionSource<TResult>(state);
-            var continuationState = Tuple.Create(tcs, callback);
-            task.ContinueWith((antecedent, obj) =>
-            {
-                var tuple = obj as Tuple<TaskCompletionSource<TResult>, AsyncCallback>;
-                var tcsObj = tuple.Item1;
-                var callbackObj = tuple.Item2;
-                if (antecedent.IsFaulted) tcsObj.TrySetException(antecedent.Exception.InnerException);
-                else if (antecedent.IsCanceled) tcsObj.TrySetCanceled();
-                else tcsObj.TrySetResult(antecedent.Result);
-
-                if (callbackObj != null)
-                {
-                    callbackObj(tcsObj.Task);
-                }
-            }, continuationState, CancellationToken.None, TaskContinuationOptions.HideScheduler, TaskScheduler.Default);
-            return tcs.Task;
+            return result;
         }
 
-        // Helper method when implementing an APM wrapper around a Task based async method which returns a result. 
-        // In the BeginMethod method, you would call use ToApm to wrap a call to MethodAsync:
-        //     return MethodAsync(params).ToApm(callback, state);
-        // In the EndMethod, you would use ToApmEnd to ensure the correct exception handling
-        // This will handle throwing exceptions in the correct place and ensure the IAsyncResult contains the provided
-        // state object
-        public static Task ToApm(this Task task, AsyncCallback callback, object state)
+        /// <summary>
+        /// Helper method to convert from Task async method to "APM" (IAsyncResult with Begin/End calls)
+        /// </summary>
+        public static IAsyncResult ToApm(this Task task,
+                                    AsyncCallback callback,
+                                    object state)
         {
-            // When using APM, the returned IAsyncResult must have the passed in state object stored in AsyncState. This
-            // is so the callback can regain state. If the incoming task already holds the state object, there's no need
-            // to create a TaskCompletionSource to ensure the returned (IAsyncResult)Task has the right state object.
-            // This is a performance optimization for this special case.
-            if (task.AsyncState == state)
+            var result = new AsyncResult(task, callback, state);
+            if (result.CompletedSynchronously)
             {
-                if (callback != null)
-                {
-                    task.ContinueWith((antecedent, obj) =>
+                result.ExecuteCallback();
+                return result;
+            }
+            else
+            {
+                task.ContinueWith((res, asyncResult) =>
                     {
-                        var callbackObj = obj as AsyncCallback;
-                        callbackObj(antecedent);
-                    }, callback, CancellationToken.None, TaskContinuationOptions.HideScheduler, TaskScheduler.Default);
-                }
-                return task;
+                        ((AsyncResult)asyncResult).ExecuteCallback();
+                    },
+                result,
+                CancellationToken.None,
+                TaskContinuationOptions.HideScheduler,
+                TaskScheduler.Default);
             }
 
-            // Need to create a TaskCompletionSource so that the returned Task object has the correct AsyncState value.
-            // As we intend to create a task with no Result value, we don't care what result type the TCS holds as we
-            // won't be using it. As Task<TResult> derives from Task, the returned Task is compatible.
-            var tcs = new TaskCompletionSource<object>(state);
-            var continuationState = Tuple.Create(tcs, callback);
-            task.ContinueWith((antecedent, obj) =>
+            return result;
+        }
+
+        public static T ToApmEnd<T>(this IAsyncResult asyncResult)
+        {
+            if (asyncResult is AsyncResult<T> asyncResultInstance)
             {
-                var tuple = obj as Tuple<TaskCompletionSource<object>, AsyncCallback>;
-                var tcsObj = tuple.Item1;
-                var callbackObj = tuple.Item2;
-                if (antecedent.IsFaulted)
-                {
-                    tcsObj.TrySetException(antecedent.Exception.InnerException);
-                }
-                else if (antecedent.IsCanceled)
-                {
-                    tcsObj.TrySetCanceled();
-                }
-                else
-                {
-                    tcsObj.TrySetResult(null);
-                }
-
-                if (callbackObj != null)
-                {
-                    callbackObj(tcsObj.Task);
-                }
-            }, continuationState, CancellationToken.None, TaskContinuationOptions.HideScheduler, TaskScheduler.Default);
-            return tcs.Task;
+                return asyncResultInstance.GetResult();
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.SFxInvalidCallbackIAsyncResult));
+            }
         }
 
-        // Helper method to implement the End method of an APM method pair which is wrapping a Task based
-        // async method when the Task returns a result. By using task.GetAwaiter.GetResult(), the exception
-        // handling conventions are the same as when await'ing a task, i.e. this throws the first exception
-        // and doesn't wrap it in an AggregateException. It also throws the right exception if the task was
-        // cancelled.
-        public static TResult ToApmEnd<TResult>(this IAsyncResult iar)
+        public static void ToApmEnd(this IAsyncResult asyncResult)
         {
-            Task<TResult> task = iar as Task<TResult>;
-            Fx.Assert(task != null, "IAsyncResult must be an instance of Task<TResult>");
-            return task.GetAwaiter().GetResult();
+            if (asyncResult is AsyncResult asyncResultInstance)
+            {
+                asyncResultInstance.GetResult();
+            }
+            else
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.SFxInvalidCallbackIAsyncResult));
+            }
         }
 
-        // Helper method to implement the End method of an APM method pair which is wrapping a Task based
-        // async method when the Task does not return result.
-        public static void ToApmEnd(this IAsyncResult iar)
+        internal class AsyncResult : IAsyncResult
         {
-            Task task = iar as Task;
-            Fx.Assert(task != null, "IAsyncResult must be an instance of Task");
-            task.GetAwaiter().GetResult();
+            private readonly Task _task;
+            private readonly object _asyncState;
+            private readonly AsyncCallback _asyncCallback;
+
+            public AsyncResult(Task task, AsyncCallback asyncCallback, object asyncState)
+            {
+                Debug.Assert(asyncCallback != null);
+
+                _task = task;
+                _asyncCallback = asyncCallback;
+                _asyncState = asyncState;
+                CompletedSynchronously = task.IsCompleted;
+            }
+
+            public void GetResult() => _task.GetAwaiter().GetResult();
+
+            // Calls the async callback with this
+            public void ExecuteCallback() => _asyncCallback(this);
+
+            #region IAsyncResult implementation forwarded to Task implementation
+            object IAsyncResult.AsyncState => _asyncState;
+            WaitHandle IAsyncResult.AsyncWaitHandle => ((IAsyncResult)_task).AsyncWaitHandle;
+
+            public bool CompletedSynchronously { get; }
+            public bool IsCompleted => _task.IsCompleted;
+
+            #endregion
+        }
+
+        internal class AsyncResult<T> : IAsyncResult
+        {
+            private readonly ValueTask<T> _task;
+            private readonly object _asyncState;
+            private readonly AsyncCallback _asyncCallback;
+
+            public AsyncResult(ValueTask<T> task, AsyncCallback asyncCallback, object asyncState)
+            {
+                Debug.Assert(asyncCallback != null);
+
+                _task = task;
+                _asyncCallback = asyncCallback;
+                _asyncState = asyncState;
+                CompletedSynchronously = task.IsCompleted;
+            }
+
+            public T GetResult() => _task.GetAwaiter().GetResult();
+
+            public bool IsFaulted => _task.IsFaulted;
+            public AggregateException Exception => _task.AsTask().Exception;
+
+            // Calls the async callback with this
+            public void ExecuteCallback() => _asyncCallback(this);
+
+            #region IAsyncResult implementation forwarded to Task implementation
+            object IAsyncResult.AsyncState => _asyncState;
+            WaitHandle IAsyncResult.AsyncWaitHandle => !CompletedSynchronously ? ((IAsyncResult)_task.AsTask()).AsyncWaitHandle : throw new NotImplementedException();
+
+            public bool CompletedSynchronously { get; }
+            public bool IsCompleted => _task.IsCompleted;
+
+            #endregion
         }
 
         // Awaitable helper to await a maximum amount of time for a task to complete. If the task doesn't

--- a/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
+++ b/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
@@ -36,19 +36,19 @@ namespace CoreWCF.Runtime
         /// <summary>
         /// Helper method to convert from Task async method to "APM" (IAsyncResult with Begin/End calls)
         /// </summary>
-        public static IAsyncResult ToApm<T>(this ValueTask<T> task, AsyncCallback callback, object state)
+        public static IAsyncResult ToApm<T>(this ValueTask<T> valueTask, AsyncCallback callback, object state)
         {
-            var result = new AsyncResult<T>(task, callback, state);
+            var result = new AsyncResult<T>(valueTask, callback, state);
             if (result.CompletedSynchronously)
             {
                 result.ExecuteCallback();
             }
             else if (callback != null)
             {
-                task.AsTask().ContinueWith((res, asyncResult) =>
+                valueTask.AsTask().ContinueWith((_, asyncResult) =>
                 {
                     ((AsyncResult<T>)asyncResult).ExecuteCallback();
-                }, result, CancellationToken.None, TaskContinuationOptions.HideScheduler, TaskScheduler.Default);
+                }, result, CancellationToken.None, TaskContinuationOptions.RunContinuationsAsynchronously, TaskScheduler.Default);
             }
 
             return result;
@@ -66,10 +66,10 @@ namespace CoreWCF.Runtime
             }
             else if (callback != null)
             {
-                task.ContinueWith((res, asyncResult) =>
+                task.ContinueWith((_, asyncResult) =>
                 {
                     ((AsyncResult)asyncResult).ExecuteCallback();
-                }, result, CancellationToken.None, TaskContinuationOptions.HideScheduler, TaskScheduler.Default);
+                }, result, CancellationToken.None, TaskContinuationOptions.RunContinuationsAsynchronously, TaskScheduler.Default);
             }
 
             return result;

--- a/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
+++ b/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
@@ -45,10 +45,12 @@ namespace CoreWCF.Runtime
             }
             else if (callback != null)
             {
-                valueTask.AsTask().ContinueWith((_, asyncResult) =>
-                {
-                    ((AsyncResult<T>)asyncResult).ExecuteCallback();
-                }, result, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+                // We use OnCompleted rather than ContinueWith in order to avoid running synchronously
+                // if the task has already completed by the time we get here. 
+                // This will allocate a delegate and some extra data to add it as a TaskContinuation
+                valueTask.ConfigureAwait(false)
+                    .GetAwaiter()
+                    .OnCompleted(result.ExecuteCallback);
             }
 
             return result;
@@ -66,10 +68,12 @@ namespace CoreWCF.Runtime
             }
             else if (callback != null)
             {
-                task.ContinueWith((_, asyncResult) =>
-                {
-                    ((AsyncResult)asyncResult).ExecuteCallback();
-                }, result, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+                // We use OnCompleted rather than ContinueWith in order to avoid running synchronously
+                // if the task has already completed by the time we get here. 
+                // This will allocate a delegate and some extra data to add it as a TaskContinuation
+                task.ConfigureAwait(false)
+                    .GetAwaiter()
+                    .OnCompleted(result.ExecuteCallback);
             }
 
             return result;

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/SyncMethodInvoker.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/SyncMethodInvoker.cs
@@ -68,7 +68,6 @@ namespace CoreWCF.Dispatcher
             return tuple.Item1;
         }
 
-        // This should be changed to ValueTuple instead
         private Task<Tuple<object, object[]>> InvokeAsync(object instance, object[] inputs)
         {
             EnsureIsInitialized();

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/SyncMethodInvoker.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/SyncMethodInvoker.cs
@@ -63,17 +63,12 @@ namespace CoreWCF.Dispatcher
 
         public object InvokeEnd(object instance, out object[] outputs, IAsyncResult result)
         {
-            var task = result as Task<Tuple<object, object[]>>;
-            if (task == null)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(SR.SFxInvalidCallbackIAsyncResult));
-            }
-
-            var tuple = task.Result;
+            var tuple = TaskHelpers.ToApmEnd<Tuple<object, object[]>>(result);
             outputs = tuple.Item2;
             return tuple.Item1;
         }
 
+        // This should be changed to ValueTuple instead
         private Task<Tuple<object, object[]>> InvokeAsync(object instance, object[] inputs)
         {
             EnsureIsInitialized();
@@ -145,8 +140,8 @@ namespace CoreWCF.Dispatcher
                 //    {
                 //        WcfEventSource.Instance.OperationInvoked(eventTraceActivity, MethodName, TraceUtility.GetCallerInfo(OperationContext.Current));
                 //    }
-                    returnValue = _invokeDelegate(instance, inputs, outputs);
-                    //callSucceeded = true;
+                returnValue = _invokeDelegate(instance, inputs, outputs);
+                //callSucceeded = true;
                 //}
             }
             catch (FaultException)

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/TaskMethodInvoker.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/TaskMethodInvoker.cs
@@ -80,6 +80,9 @@ namespace CoreWCF.Dispatcher
             {
                 //AsyncMethodInvoker.GetActivityInfo(ref activity, ref boundOperation);
 
+                // This code would benefith from a rewrite to call TaskHelpers.ToApmEnd<Tuple<object, object[]>>
+                // When doing so make sure there is enought test coverage se PR comment at link below for a good starting point
+                // https://github.com/CoreWCF/CoreWCF/pull/54/files/8db6ff9ad6940a1056363defd1f6449adee56e1a#r333826132
                 var asyncResult = result as TaskHelpers.AsyncResult<Tuple<object, object[]>>;
                 if (asyncResult == null)
                 {
@@ -131,6 +134,7 @@ namespace CoreWCF.Dispatcher
                         throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(AuthorizationBehavior.CreateAccessDeniedFaultException());
                     }
 
+                    // Rethrow inner exception as is
                     asyncResult.GetResult();
                 }
 

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/TaskMethodInvoker.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/TaskMethodInvoker.cs
@@ -80,9 +80,8 @@ namespace CoreWCF.Dispatcher
             {
                 //AsyncMethodInvoker.GetActivityInfo(ref activity, ref boundOperation);
 
-                Task<Tuple<object, object[]>> invokeTask = result as Task<Tuple<object, object[]>>;
-
-                if (invokeTask == null)
+                var asyncResult = result as TaskHelpers.AsyncResult<Tuple<object, object[]>>;
+                if (asyncResult == null)
                 {
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(SR.SFxInvalidCallbackIAsyncResult);
                 }
@@ -91,16 +90,16 @@ namespace CoreWCF.Dispatcher
                 Tuple<object, object[]> tuple = null;
                 Task task = null;
 
-                if (invokeTask.IsFaulted)
+                if (asyncResult.IsFaulted)
                 {
-                    Fx.Assert(invokeTask.Exception != null, "Task.IsFaulted guarantees non-null exception.");
-                    ae = invokeTask.Exception;
+                    Fx.Assert(asyncResult.Exception != null, "Task.IsFaulted guarantees non-null exception.");
+                    ae = asyncResult.Exception;
                 }
                 else
                 {
-                    Fx.Assert(invokeTask.IsCompleted, "Task.Result is expected to be completed");
+                    Fx.Assert(asyncResult.IsCompleted, "Task.Result is expected to be completed");
 
-                    tuple = invokeTask.Result;
+                    tuple = asyncResult.GetResult();
                     task = tuple.Item1 as Task;
 
                     if (task == null)
@@ -132,7 +131,7 @@ namespace CoreWCF.Dispatcher
                         throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(AuthorizationBehavior.CreateAccessDeniedFaultException());
                     }
 
-                    invokeTask.GetAwaiter().GetResult();
+                    asyncResult.GetResult();
                 }
 
                 // Task cancellation without an exception indicates failure but we have no


### PR DESCRIPTION
Replace the current ToApm wrapper with a more lightweight approach
* Allocates less (1 allocation instead of TaskCompletionSource + Task + Tuple)
* Performs slightly less work
* Properly implement the `CompletedSynchronously` property of IAsyncResult
* Ready for wrapping `ValueTask` based methods to make it easier to start using it

I understand if this does not have a high priority, but I hade implemented this not to long ago for a project based on WCF and wanted to share it.