### PR TITLE
Add compatibility for using S.SM contract attributes

### DIFF
--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.5.3" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.5.3" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\CoreWCF.NetTcp.csproj" />

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ChannelHandler.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ChannelHandler.cs
@@ -141,6 +141,11 @@ namespace CoreWCF.Dispatcher
 
             await HandleReceiveCompleteAsync(request);
 
+            if (request == null)
+            {
+                return;
+            }
+
             if (HandleRequestAsReply(request))
             {
                 return;

--- a/src/CoreWCF.Primitives/tests/Contracts/ServiceModelContractTests.cs
+++ b/src/CoreWCF.Primitives/tests/Contracts/ServiceModelContractTests.cs
@@ -1,0 +1,61 @@
+﻿using DispatcherClient;
+using Helpers;
+using Xunit;
+
+namespace Contracts
+{
+    public class ServiceModelContractTests
+    {
+        [Fact]
+        public static void AttributeNoPropertiesContract()
+        {
+            var factory = DispatcherHelper.CreateChannelFactory<ServiceModelSimpleService, IServiceModelSimpleService>();
+            factory.Open();
+            var channel = factory.CreateChannel();
+            ((System.ServiceModel.Channels.IChannel)channel).Open();
+            var echo = channel.Echo("hello");
+            Assert.Equal("hello", echo);
+            ((System.ServiceModel.Channels.IChannel)channel).Close();
+            factory.Close();
+            TestHelper.CloseServiceModelObjects((System.ServiceModel.Channels.IChannel)channel, factory);
+        }
+
+        [Fact]
+        public static void AttributeWithNameNamespaceActionReplyActionContract()
+        {
+            var factory = DispatcherHelper.CreateChannelFactory<ServiceModelSimpleService, IServiceModelServiceWithPropertiesSet>();
+            factory.Open();
+            var channel = factory.CreateChannel();
+            ((System.ServiceModel.Channels.IChannel)channel).Open();
+            var echo = channel.Echo("hello");
+            Assert.Equal("hello", echo);
+            ((System.ServiceModel.Channels.IChannel)channel).Close();
+            factory.Close();
+            TestHelper.CloseServiceModelObjects((System.ServiceModel.Channels.IChannel)channel, factory);
+        }
+   }
+
+    [System.ServiceModel.ServiceContract]
+    public interface IServiceModelSimpleService
+    {
+        [System.ServiceModel.OperationContract]
+        string Echo(string echo);
+    }
+
+    [System.ServiceModel.ServiceContract(Name = "NotTheDefaultServiceName", Namespace = "http://tempuri.org/NotTheDefaultServiceNamespace")]
+    public interface IServiceModelServiceWithPropertiesSet
+    {
+        [System.ServiceModel.OperationContract(Name = "NotTheDefaultOperationName", Action = "corewcf://corewcf.corewcf/OddAction", ReplyAction = "corewcf://corewcf.corewcf/OddReplyAction")]
+        string Echo(string echo);
+    }
+
+    public class ServiceModelSimpleService : ServiceModelBaseService, IServiceModelSimpleService, IServiceModelServiceWithPropertiesSet { }
+
+    public class ServiceModelBaseService
+    {
+        public string Echo(string echo)
+        {
+            return echo;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\CoreWCF.Primitives.csproj" />

--- a/src/CoreWCF.Primitives/tests/DependencyInjection/ServiceInstanceContextModeTests.cs
+++ b/src/CoreWCF.Primitives/tests/DependencyInjection/ServiceInstanceContextModeTests.cs
@@ -1,6 +1,7 @@
 ﻿using CoreWCF;
 using CoreWCF.Channels;
 using CoreWCF.Description;
+using DispatcherClient;
 using Extensibility;
 using Helpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,7 +19,7 @@ namespace DependencyInjection
         {
             SingleInstanceContextSimpleService.ClearCounts();
             var serviceInstance = new SingleInstanceContextSimpleService();
-            var factory = ExtensibilityHelper.CreateChannelFactory<SingleInstanceContextSimpleService, ISimpleService>(
+            var factory = DispatcherHelper.CreateChannelFactory<SingleInstanceContextSimpleService, ISimpleService>(
                 (services) =>
                 {
                     services.AddSingleton(serviceInstance);
@@ -42,7 +43,7 @@ namespace DependencyInjection
         public static void InstanceContextMode_Single_NoInjection()
         {
             SingleInstanceContextSimpleService.ClearCounts();
-            var factory = ExtensibilityHelper.CreateChannelFactory<SingleInstanceContextSimpleService, ISimpleService>();
+            var factory = DispatcherHelper.CreateChannelFactory<SingleInstanceContextSimpleService, ISimpleService>();
             factory.Open();
             var channel = factory.CreateChannel();
             ((System.ServiceModel.Channels.IChannel)channel).Open();
@@ -62,7 +63,7 @@ namespace DependencyInjection
         public static void InstanceContextMode_PerCall()
         {
             PerCallInstanceContextSimpleServiceAndBehavior.ClearCounts();
-            var factory = ExtensibilityHelper.CreateChannelFactory<PerCallInstanceContextSimpleServiceAndBehavior, ISimpleService>(
+            var factory = DispatcherHelper.CreateChannelFactory<PerCallInstanceContextSimpleServiceAndBehavior, ISimpleService>(
                 (services) =>
                 {
                     services.AddTransient<PerCallInstanceContextSimpleServiceAndBehavior>();
@@ -92,7 +93,7 @@ namespace DependencyInjection
         public static void InstanceContextMode_PerCall_NoInjection()
         {
             PerCallInstanceContextSimpleService.ClearCounts();
-            var factory = ExtensibilityHelper.CreateChannelFactory<PerCallInstanceContextSimpleService, ISimpleService>();
+            var factory = DispatcherHelper.CreateChannelFactory<PerCallInstanceContextSimpleService, ISimpleService>();
             factory.Open();
             var channel = factory.CreateChannel();
             ((System.ServiceModel.Channels.IChannel)channel).Open();
@@ -113,7 +114,7 @@ namespace DependencyInjection
         public static void InstanceContextMode_PerCall_WithBehavior_NoInjection()
         {
             PerCallInstanceContextSimpleServiceAndBehavior.ClearCounts();
-            var factory = ExtensibilityHelper.CreateChannelFactory<PerCallInstanceContextSimpleServiceAndBehavior, ISimpleService>();
+            var factory = DispatcherHelper.CreateChannelFactory<PerCallInstanceContextSimpleServiceAndBehavior, ISimpleService>();
             factory.Open();
             var channel = factory.CreateChannel();
             ((System.ServiceModel.Channels.IChannel)channel).Open();
@@ -139,7 +140,7 @@ namespace DependencyInjection
         public static void InstanceContextMode_PerSession()
         {
             PerSessionInstanceContextSimpleServiceAndBehavior.ClearCounts();
-            var factory = ExtensibilityHelper.CreateChannelFactory<PerSessionInstanceContextSimpleServiceAndBehavior, ISimpleSessionService>(
+            var factory = DispatcherHelper.CreateChannelFactory<PerSessionInstanceContextSimpleServiceAndBehavior, ISimpleSessionService>(
                 (services) =>
                 {
                     services.AddTransient<PerSessionInstanceContextSimpleServiceAndBehavior>();
@@ -170,7 +171,7 @@ namespace DependencyInjection
         public static void InstanceContextMode_PerSession_NoInjection()
         {
             PerSessionInstanceContextSimpleService.ClearCounts();
-            var factory = ExtensibilityHelper.CreateChannelFactory<PerSessionInstanceContextSimpleService, ISimpleSessionService>();
+            var factory = DispatcherHelper.CreateChannelFactory<PerSessionInstanceContextSimpleService, ISimpleSessionService>();
             factory.Open();
             var channel = factory.CreateChannel();
             ((System.ServiceModel.Channels.IChannel)channel).Open();
@@ -193,7 +194,7 @@ namespace DependencyInjection
         public static void InstanceContextMode_PerSession_WithBehavior_NoInjection()
         {
             PerSessionInstanceContextSimpleServiceAndBehavior.ClearCounts();
-            var factory = ExtensibilityHelper.CreateChannelFactory<PerSessionInstanceContextSimpleServiceAndBehavior, ISimpleSessionService>();
+            var factory = DispatcherHelper.CreateChannelFactory<PerSessionInstanceContextSimpleServiceAndBehavior, ISimpleSessionService>();
             factory.Open();
             var channel = factory.CreateChannel();
             ((System.ServiceModel.Channels.IChannel)channel).Open();

--- a/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherHelper.cs
+++ b/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherHelper.cs
@@ -1,0 +1,30 @@
+﻿using CoreWCF.Description;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.ServiceModel;
+
+namespace DispatcherClient
+{
+    internal static class DispatcherHelper
+    {
+        internal static string s_endpointAddress = "corewcf://localhost/Service.svc";
+
+        internal static ChannelFactory<TContract> CreateChannelFactory<TService, TContract>(Action<IServiceCollection> configure) where TService : class
+        {
+            var binding = new DispatcherBinding<TService, TContract>((services) =>
+            {
+                configure?.Invoke(services);
+                IServerAddressesFeature serverAddressesFeature = new ServerAddressesFeature();
+                serverAddressesFeature.Addresses.Add(new Uri(s_endpointAddress).GetLeftPart(UriPartial.Authority) + "/");
+                services.AddSingleton(serverAddressesFeature);
+            });
+            return new ChannelFactory<TContract>(binding, new EndpointAddress(s_endpointAddress));
+        }
+
+        internal static ChannelFactory<TContract> CreateChannelFactory<TService, TContract>() where TService : class
+        {
+            return CreateChannelFactory<TService, TContract>(null);
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/tests/Extensibility/ExtensibilityHelper.cs
+++ b/src/CoreWCF.Primitives/tests/Extensibility/ExtensibilityHelper.cs
@@ -1,7 +1,5 @@
 ﻿using CoreWCF.Description;
 using DispatcherClient;
-using Extensibility;
-using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.ServiceModel;
@@ -10,32 +8,13 @@ namespace Extensibility
 {
     internal static class ExtensibilityHelper
     {
-        internal static string s_endpointAddress = "corewcf://localhost/Service.svc";
-
         internal static ChannelFactory<TContract> CreateChannelFactory<TService, TContract>(IServiceBehavior serviceBehavior) where TService : class
         {
-            return CreateChannelFactory<TService, TContract>(
+            return DispatcherHelper.CreateChannelFactory<TService, TContract>(
                         (IServiceCollection services) =>
                         {
                             services.AddSingleton(serviceBehavior);
                         });
-        }
-
-        internal static ChannelFactory<TContract> CreateChannelFactory<TService, TContract>() where TService : class
-        {
-            return CreateChannelFactory<TService, TContract>((Action<IServiceCollection>)null);
-        }
-
-        internal static ChannelFactory<TContract> CreateChannelFactory<TService, TContract>(Action<IServiceCollection> configure) where TService : class
-        {
-            var binding = new DispatcherBinding<TService, TContract>((services) =>
-            {
-                configure?.Invoke(services);
-                IServerAddressesFeature serverAddressesFeature = new ServerAddressesFeature();
-                serverAddressesFeature.Addresses.Add(new Uri(s_endpointAddress).GetLeftPart(UriPartial.Authority) + "/");
-                services.AddSingleton(serverAddressesFeature);
-            });
-            return new ChannelFactory<TContract>(binding, new EndpointAddress(s_endpointAddress));
         }
     }
 }

--- a/src/CoreWCF.Primitives/tests/Extensibility/MessageInspectorTests.cs
+++ b/src/CoreWCF.Primitives/tests/Extensibility/MessageInspectorTests.cs
@@ -2,6 +2,7 @@
 using CoreWCF.Channels;
 using CoreWCF.Description;
 using CoreWCF.Dispatcher;
+using DispatcherClient;
 using Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -35,7 +36,7 @@ namespace Extensibility
             var inspector = new MessageReplacingDispatchMessageInspector(replacementEchoString);
             var behavior = new TestServiceBehavior { DispatchMessageInspector = inspector };
             var service = new DispatcherTestService();
-            var factory = ExtensibilityHelper.CreateChannelFactory<DispatcherTestService, ISimpleService>(
+            var factory = DispatcherHelper.CreateChannelFactory<DispatcherTestService, ISimpleService>(
                 (services) =>
                 {
                     services.AddSingleton<IServiceBehavior>(behavior);

--- a/src/CoreWCF.sln
+++ b/src/CoreWCF.sln
@@ -20,8 +20,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreWCF.Primitives.Tests", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DAAE6286-93E2-4F2B-81D2-A32A9F024595}"
 	ProjectSection(SolutionItems) = preProject
+		..\azure-pipelines.yml = ..\azure-pipelines.yml
 		..\Directory.Build.props = ..\Directory.Build.props
 		..\Directory.Build.targets = ..\Directory.Build.targets
+		..\GitVersion.yml = ..\GitVersion.yml
 		..\resources.props = ..\resources.props
 		..\resources.targets = ..\resources.targets
 	EndProjectSection


### PR DESCRIPTION
Runtime conversion of S.SM.[Service|Operation]ContractAttribute applied to contract interface to the CoreWCF conterparts to enable compat.