### PR TITLE
Allow Kestrel to listen on a random port by delaying CoreWCF initialization

### DIFF
--- a/src/CoreWCF.Http/src/CoreWCF/Channels/RequestDelegateHandler.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/RequestDelegateHandler.cs
@@ -67,7 +67,7 @@ namespace CoreWCF.Channels
 
             _httpSettings = httpSettings;
             WebSocketOptions = CreateWebSocketOptions(tbe);
-            if (WebSocketOptions == null)
+            if (tbe.WebSocketSettings.TransportUsage != WebSocketTransportUsage.Always)
             {
                 _replyChannel = new AspNetCoreReplyChannel(_servicesScopeFactory.CreateScope().ServiceProvider, _httpSettings);
                 _replyChannelDispatcherTask =  _serviceDispatcher.CreateServiceChannelDispatcherAsync(_replyChannel);

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/ServiceModelHttpMiddleware.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/ServiceModelHttpMiddleware.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace CoreWCF.Channels
 {
@@ -14,18 +15,18 @@ namespace CoreWCF.Channels
     {
         private IServiceBuilder _serviceBuilder;
         private RequestDelegate _next;
-        private readonly RequestDelegate _branch;
+        private readonly Lazy<RequestDelegate> _branch;
 
         public ServiceModelHttpMiddleware(RequestDelegate next, IApplicationBuilder app, IServiceBuilder serviceBuilder, IDispatcherBuilder dispatcherBuilder)
         {
             _serviceBuilder = serviceBuilder;
             _next = next;
-            _branch = BuildBranch(app, _serviceBuilder, dispatcherBuilder);
+            _branch = new Lazy<RequestDelegate>(()=> BuildBranch(app, _serviceBuilder, dispatcherBuilder));
         }
 
         public Task InvokeAsync(HttpContext context)
         {
-            return _branch(context);
+            return _branch.Value(context);
         }
 
         private RequestDelegate BuildBranch(IApplicationBuilder app, IServiceBuilder serviceBuilder, IDispatcherBuilder dispatcherBuilder)

--- a/src/CoreWCF.Http/tests/ISimpleService.cs
+++ b/src/CoreWCF.Http/tests/ISimpleService.cs
@@ -3,9 +3,11 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
+[System.ServiceModel.ServiceContract]
 [ServiceContract]
 interface ISimpleService
 {
+    [System.ServiceModel.OperationContract]
     [OperationContract]
     string Echo(string echo);
 }

--- a/src/CoreWCF.Http/tests/IntegrationTests.cs
+++ b/src/CoreWCF.Http/tests/IntegrationTests.cs
@@ -1,0 +1,62 @@
+﻿using CoreWCF.Configuration;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CoreWCF.Http.Tests
+{
+    public class IntegrationTests
+    {
+        [Fact]
+        public async Task NetHttpListenPortZeroWorks()
+        {
+            var host =
+                WebHost.CreateDefaultBuilder()
+                .UseKestrel(o => o.ListenAnyIP(0)) // <-- 0 tells Kestrel to pick any random free port. This is impractical for production, but really great for unit tests!
+                .ConfigureServices((WebHostBuilderContext ctx, IServiceCollection services) =>
+                {
+                    services.AddServiceModelServices();
+                })
+                .Configure(app => {
+
+                    app.UseServiceModel(builder =>
+                    {
+                        builder.AddService<SimpleService>();
+                        builder.AddServiceEndpoint<SimpleService, ISimpleService>(new NetHttpBinding(), "/wcf");
+                    });
+                })
+                .Build();
+
+            try
+            {
+                host.Start();
+
+                // check which port kestrel actually listens on
+                var port = new Uri(host.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First()).Port;
+
+                var factory = new ChannelFactory<ISimpleService>(new System.ServiceModel.NetHttpBinding(), new System.ServiceModel.EndpointAddress($"http://localhost:{port}/wcf"));
+                factory.Open();
+                var channel = factory.CreateChannel();
+                ((System.ServiceModel.IClientChannel)channel).Open();
+
+                var response = channel.Echo("Hello");
+                Assert.Equal("Hello", response);
+
+                ((System.ServiceModel.IClientChannel)channel).Close();
+                factory.Close();
+            }
+            finally
+            {
+                await host.StopAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This implements option 2 of https://github.com/CoreWCF/CoreWCF/issues/119

There is one big downside: If there is a configuration error in CoreWCF, then it no longer fails at startup time, but when the first request is made.

So I opened this Pull Request more for a discussion ...