### PR TITLE
HttpBindingBase contructor

### DIFF
--- a/src/CoreWCF.Http/src/CoreWCF/HttpBindingBase.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/HttpBindingBase.cs
@@ -17,6 +17,7 @@ namespace CoreWCF
         internal HttpBindingBase()
         {
             _httpTransport = new HttpTransportBindingElement();
+            _httpsTransport = new HttpsTransportBindingElement();
             _textEncoding = new TextMessageEncodingBindingElement();
             _textEncoding.MessageVersion = MessageVersion.Soap11;
         }


### PR DESCRIPTION
Summary of the changes
 - The HttpsTransportBindingElement was never initialized which causes exceptions when using BasicHttpSecurityMode.Transport.