### PR TITLE
Add FaultContractName Test.

### DIFF
--- a/src/CoreWCF.Http/tests/ClientContract/ITestFaultContractName.cs
+++ b/src/CoreWCF.Http/tests/ClientContract/ITestFaultContractName.cs
@@ -1,0 +1,95 @@
+﻿using System.IO;
+using System.ServiceModel;
+
+namespace ClientContract
+{
+    #region Contract w/ FaultContract on Operations (ITestFaultContractName)
+    [ServiceContract]
+    public interface ITestFaultContractName
+    {
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "Method1")]
+        string Method1(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "Method2")]
+        string Method2(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "ITestFaultContractAction.Method3")]
+        string Method3(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "<hello>\"\'")]
+        string Method4(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "t t n")]
+        string Method5(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "&lt;&gt;&gt;")]
+        string Method6(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "http://y.c/5")]
+        string Method7(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "İüğmeIiiçeI")]
+        string Method8(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "esÅeoplÀÁð")]
+        string Method9(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "http://hello/\0")]
+        string Method10(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "http://www.yahoo.com")]
+        string Method11(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "null")]
+        string Method12(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "<hello>\"\'\0")]
+        string Method13(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "esÅeoplÀÁð")]
+        string Method14(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
+        string Method15(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "123456789012345")]
+        string Method16(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "u")]
+        string Method17(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "ÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅ")]
+        string Method18(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "a_b - c - d_g()")]
+        string Method19(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "\\//\\/////////// /")]
+        string Method20(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "*")]
+        string Method21(string s);
+    }
+    #endregion
+}

--- a/src/CoreWCF.Http/tests/FaultContractNameTests.cs
+++ b/src/CoreWCF.Http/tests/FaultContractNameTests.cs
@@ -1,0 +1,372 @@
+﻿using System;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Http.Tests
+{
+    public class FaultContractNameTests
+    {
+        private ITestOutputHelper _output;
+
+        public FaultContractNameTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void FaultOnDiffString()
+        {
+            var host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                var httpBinding = ClientHelper.GetBufferedModeBinding();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestFaultContractName>(httpBinding, new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/TestFaultContractNameService.svc")));
+                var channel = factory.CreateChannel();
+
+                //test variations count
+                int count = 21;
+                string faultToThrow = "Test fault thrown from a service";
+
+                //variation method1
+                try
+                {
+                    string s = channel.Method1("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method2
+                try
+                {
+                    string s = channel.Method2("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method3
+                try
+                {
+                    string s = channel.Method3("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method4
+                try
+                {
+                    string s = channel.Method4("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method5
+                try
+                {
+                    string s = channel.Method5("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method6
+                try
+                {
+                    string s = channel.Method6("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method7
+                try
+                {
+                    string s = channel.Method7("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method8
+                try
+                {
+                    string s = channel.Method8("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method9
+                try
+                {
+                    string s = channel.Method9("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method10
+                try
+                {
+                    string s = channel.Method10("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method11
+                try
+                {
+                    string s = channel.Method11("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method12
+                try
+                {
+                    string s = channel.Method12("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method13
+                try
+                {
+                    string s = channel.Method13("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method14
+                try
+                {
+                    string s = channel.Method14("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method15
+                try
+                {
+                    string s = channel.Method15("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method16
+                try
+                {
+                    string s = channel.Method16("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method17
+                try
+                {
+                    string s = channel.Method17("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method18
+                try
+                {
+                    string s = channel.Method18("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method19
+                try
+                {
+                    string s = channel.Method19("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method20
+                try
+                {
+                    string s = channel.Method20("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+
+                //variation method21
+                try
+                {
+                    string s = channel.Method21("");
+                }
+                catch (Exception e)
+                {
+                    count--;
+                    Assert.NotNull(e);
+
+                    Assert.IsType<System.ServiceModel.FaultException<string>>(e);
+                    var ex = (System.ServiceModel.FaultException<string>)e;
+                    Assert.Equal(faultToThrow, ex.Detail.ToString());
+                }
+                Assert.Equal(0, count);
+            }
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.TestFaultContractNameService>();
+                    builder.AddServiceEndpoint<Services.TestFaultContractNameService, ServiceContract.ITestFaultContractName>(new CoreWCF.BasicHttpBinding(), "/BasicWcfService/TestFaultContractNameService.svc");
+                });
+            }
+        }
+
+    }
+}

--- a/src/CoreWCF.Http/tests/ServiceContract/ITestFaultContractName.cs
+++ b/src/CoreWCF.Http/tests/ServiceContract/ITestFaultContractName.cs
@@ -1,0 +1,96 @@
+﻿using System.IO;
+using CoreWCF;
+using CoreWCF.Channels;
+
+namespace ServiceContract
+{
+    #region Contract w/ FaultContract on Operations (ITestFaultContractName)
+    [ServiceContract]
+    public interface ITestFaultContractName
+    {
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "Method1")]
+        string Method1(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "Method2")]
+        string Method2(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "ITestFaultContractAction.Method3")]
+        string Method3(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "<hello>\"\'")]
+        string Method4(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "t t n")]
+        string Method5(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "&lt;&gt;&gt;")]
+        string Method6(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "http://y.c/5")]
+        string Method7(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "İüğmeIiiçeI")]
+        string Method8(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "esÅeoplÀÁð")]
+        string Method9(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "http://hello/\0")]
+        string Method10(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "http://www.yahoo.com")]
+        string Method11(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "null")]
+        string Method12(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "<hello>\"\'\0")]
+        string Method13(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "esÅeoplÀÁð")]
+        string Method14(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
+        string Method15(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "123456789012345")]
+        string Method16(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "u")]
+        string Method17(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "ÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅÅ")]
+        string Method18(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "a_b - c - d_g()")]
+        string Method19(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "\\//\\/////////// /")]
+        string Method20(string s);
+
+        [OperationContract]
+        [FaultContract(typeof(string), Name = "*")]
+        string Method21(string s);
+    }
+    #endregion
+}

--- a/src/CoreWCF.Http/tests/Services/TestFaultContractNameService.cs
+++ b/src/CoreWCF.Http/tests/Services/TestFaultContractNameService.cs
@@ -1,0 +1,242 @@
+﻿using CoreWCF;
+
+namespace Services
+{
+    public class TestFaultContractNameService : ServiceContract.ITestFaultContractName
+    {
+     
+        #region TwoWay_Methods
+        public string Method1(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method2(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method3(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method4(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method5(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method6(string s)
+        {
+                if (s.Length == 0)
+                {
+                    string faultToThrow = "Test fault thrown from a service";
+                    throw new FaultException<string>(faultToThrow);
+                }
+
+                return s;
+            }
+
+        public string Method7(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method8(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method9(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method10(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method11(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method12(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method13(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method14(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method15(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method16(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method17(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method18(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method19(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method20(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+
+        public string Method21(string s)
+        {
+            if (s.Length == 0)
+            {
+                string faultToThrow = "Test fault thrown from a service";
+                throw new FaultException<string>(faultToThrow);
+            }
+
+            return s;
+        }
+        #endregion
+    }
+}
+


### PR DESCRIPTION
Abstract: Use [FaultContract(typeof(T))] on a variety of contracts and operation types and set the Name property