### PR TITLE
Add BasicScenarios Test with OperationContract Action and ReplyAction

### DIFF
--- a/src/CoreWCF.Http/tests/BasicScenariosTest.cs
+++ b/src/CoreWCF.Http/tests/BasicScenariosTest.cs
@@ -1,0 +1,95 @@
+﻿using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.ServiceModel.Channels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Http.Tests
+{
+    public class BasicScenariosTest
+    {
+        private ITestOutputHelper _output;
+
+        public BasicScenariosTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void BasicScenariosAndOps()
+        {
+            var host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                var httpBinding = ClientHelper.GetBufferedModeBinding();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestBasicScenarios>(httpBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/ITestBasicScenariosService.svc")));
+                var channel = factory.CreateChannel();
+
+                var factory2 = new System.ServiceModel.ChannelFactory<ClientContract.ITestBasicScenariosClientService>(httpBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/ITestBasicScenariosService.svc")));
+                var channel2 = factory2.CreateChannel();
+
+                //Variation string TestMethodDefaults
+                    int ID = 1;
+                    string name = "Defaults";
+                    string result = channel.TestMethodDefaults(ID, name);
+                    Assert.NotNull(result);
+                    Assert.Equal(result, name);
+
+                //Variation_void TestMethodSetAction
+                    ID = 1;
+                    name = "Action";
+                    channel.TestMethodSetAction(ID, name);
+
+                //Variation_int TestMethodSetReplyAction               
+                    ID = 1;
+                    name = "ReplyAction";
+                    int resultInt = channel.TestMethodSetReplyAction(ID, name);                    
+                    Assert.Equal(resultInt, ID);
+                
+                //Variation_void TestMethodUntypedAction                
+                    Message clientMessage = Message.CreateMessage(MessageVersion.Soap11, "myUntypedAction");
+                    channel.TestMethodUntypedAction(clientMessage);
+
+                //Variation_Message TestMethodUntypedreplyAction                
+                    Message msg = channel.TestMethodUntypedReplyAction();
+                    Assert.NotNull(msg);                
+
+                //Variation_void TestMethodSetUntypedAction                                  
+                    Message clientUntypedActionMessage = Message.CreateMessage(MessageVersion.Soap11, "mySetUntypedAction");
+                    channel.TestMethodSetUntypedAction(clientUntypedActionMessage);                
+
+                //Variation_sting TestMethodasync                
+                    ID = 1;
+                    name = "Async";
+                    result = channel2.TestMethodAsync(ID, name).GetAwaiter().GetResult();
+                    Assert.NotNull(result);
+                    Assert.Equal(result, name);              
+            }            
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.TestBasicScenariosService>();
+                    builder.AddServiceEndpoint<Services.TestBasicScenariosService, ServiceContract.ITestBasicScenarios>(new BasicHttpBinding(), "/BasicWcfService/ITestBasicScenariosService.svc");
+                });
+            }
+        }
+    }
+
+   }

--- a/src/CoreWCF.Http/tests/BasicScenariosTest.cs
+++ b/src/CoreWCF.Http/tests/BasicScenariosTest.cs
@@ -36,42 +36,42 @@ namespace CoreWCF.Http.Tests
                 var channel2 = factory2.CreateChannel();
 
                 //Variation string TestMethodDefaults
-                    int ID = 1;
-                    string name = "Defaults";
-                    string result = channel.TestMethodDefaults(ID, name);
-                    Assert.NotNull(result);
-                    Assert.Equal(result, name);
+                int ID = 1;
+                string name = "Defaults";
+                string result = channel.TestMethodDefaults(ID, name);
+                Assert.NotNull(result);
+                Assert.Equal(result, name);
 
                 //Variation_void TestMethodSetAction
-                    ID = 1;
-                    name = "Action";
-                    channel.TestMethodSetAction(ID, name);
+                ID = 1;
+                name = "Action";
+                channel.TestMethodSetAction(ID, name);
 
                 //Variation_int TestMethodSetReplyAction               
-                    ID = 1;
-                    name = "ReplyAction";
-                    int resultInt = channel.TestMethodSetReplyAction(ID, name);                    
-                    Assert.Equal(resultInt, ID);
-                
+                ID = 1;
+                name = "ReplyAction";
+                int resultInt = channel.TestMethodSetReplyAction(ID, name);
+                Assert.Equal(resultInt, ID);
+
                 //Variation_void TestMethodUntypedAction                
-                    Message clientMessage = Message.CreateMessage(MessageVersion.Soap11, "myUntypedAction");
-                    channel.TestMethodUntypedAction(clientMessage);
+                Message clientMessage = Message.CreateMessage(MessageVersion.Soap11, "myUntypedAction");
+                channel.TestMethodUntypedAction(clientMessage);
 
                 //Variation_Message TestMethodUntypedreplyAction                
-                    Message msg = channel.TestMethodUntypedReplyAction();
-                    Assert.NotNull(msg);                
+                Message msg = channel.TestMethodUntypedReplyAction();
+                Assert.NotNull(msg);
 
                 //Variation_void TestMethodSetUntypedAction                                  
-                    Message clientUntypedActionMessage = Message.CreateMessage(MessageVersion.Soap11, "mySetUntypedAction");
-                    channel.TestMethodSetUntypedAction(clientUntypedActionMessage);                
+                Message clientUntypedActionMessage = Message.CreateMessage(MessageVersion.Soap11, "mySetUntypedAction");
+                channel.TestMethodSetUntypedAction(clientUntypedActionMessage);
 
                 //Variation_sting TestMethodasync                
-                    ID = 1;
-                    name = "Async";
-                    result = channel2.TestMethodAsync(ID, name).GetAwaiter().GetResult();
-                    Assert.NotNull(result);
-                    Assert.Equal(result, name);              
-            }            
+                ID = 1;
+                name = "Async";
+                result = channel2.TestMethodAsync(ID, name).GetAwaiter().GetResult();
+                Assert.NotNull(result);
+                Assert.Equal(result, name);
+            }
         }
 
         internal class Startup
@@ -92,4 +92,4 @@ namespace CoreWCF.Http.Tests
         }
     }
 
-   }
+}

--- a/src/CoreWCF.Http/tests/ClientContract/ITestBasicScenarios.cs
+++ b/src/CoreWCF.Http/tests/ClientContract/ITestBasicScenarios.cs
@@ -1,0 +1,34 @@
+﻿using System.ServiceModel.Channels;
+using System.ServiceModel;
+
+namespace ClientContract
+{    
+    [ServiceContract]
+    public interface ITestBasicScenarios
+    {
+        [OperationContract]
+        string TestMethodDefaults(int ID, string name);
+
+        [OperationContract(Action = "myAction")]
+        void TestMethodSetAction(int ID, string name);
+
+        [OperationContract(ReplyAction = "myReplyAction")]
+        int TestMethodSetReplyAction(int ID, string name);
+
+        [OperationContract(Action = "myUntypedAction")]
+        void TestMethodUntypedAction(Message m);
+
+        [OperationContract(ReplyAction = "myUntypedReplyAction")]
+        Message TestMethodUntypedReplyAction();
+
+        [OperationContract(Action = "*")]
+        void TestMethodSetUntypedAction(Message m);
+    }
+
+    [ServiceContract(Name = "ITestBasicScenarios")]
+    public interface ITestBasicScenariosClientService
+    {
+        [OperationContract(Action = "myAsyncAction", ReplyAction = "myAsyncReplyAction")]        
+        System.Threading.Tasks.Task<string> TestMethodAsync(int ID, string name);
+    }
+}

--- a/src/CoreWCF.Http/tests/ServiceContract/ITestBasicScenarios.cs
+++ b/src/CoreWCF.Http/tests/ServiceContract/ITestBasicScenarios.cs
@@ -24,8 +24,7 @@ namespace ServiceContract
         [OperationContract(Action = "mySetUntypedAction")]
         void TestMethodSetUntypedAction(Message m);
 
-        [OperationContract(AsyncPattern = true, Action = "myAsyncAction", ReplyAction = "myAsyncReplyAction")]
-        //IAsyncResult BeginTestMethodAsync(int ID, string name, AsyncCallback callback, object state);
+        [OperationContract(AsyncPattern = true, Action = "myAsyncAction", ReplyAction = "myAsyncReplyAction")]     
         System.Threading.Tasks.Task<string> TestMethodAsync(int ID, string name);      
     }
 }

--- a/src/CoreWCF.Http/tests/ServiceContract/ITestBasicScenarios.cs
+++ b/src/CoreWCF.Http/tests/ServiceContract/ITestBasicScenarios.cs
@@ -1,0 +1,31 @@
+﻿using CoreWCF;
+using CoreWCF.Channels;
+
+namespace ServiceContract
+{
+    [ServiceContract]
+    public interface ITestBasicScenarios
+    {
+        [OperationContract]
+        string TestMethodDefaults(int ID, string name);
+
+        [OperationContract(Action = "myAction")]
+        void TestMethodSetAction(int ID, string name);
+
+        [OperationContract(ReplyAction = "myReplyAction")]
+        int TestMethodSetReplyAction(int ID, string name);
+
+        [OperationContract(Action = "myUntypedAction")]
+        void TestMethodUntypedAction(Message m);
+
+        [OperationContract(ReplyAction = "myUntypedReplyAction")]
+        Message TestMethodUntypedReplyAction();
+
+        [OperationContract(Action = "mySetUntypedAction")]
+        void TestMethodSetUntypedAction(Message m);
+
+        [OperationContract(AsyncPattern = true, Action = "myAsyncAction", ReplyAction = "myAsyncReplyAction")]
+        //IAsyncResult BeginTestMethodAsync(int ID, string name, AsyncCallback callback, object state);
+        System.Threading.Tasks.Task<string> TestMethodAsync(int ID, string name);      
+    }
+}

--- a/src/CoreWCF.Http/tests/Services/TestBasicScenariosService.cs
+++ b/src/CoreWCF.Http/tests/Services/TestBasicScenariosService.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+using CoreWCF;
+
+namespace Services
+{
+    [ServiceBehavior]
+    public class TestBasicScenariosService : ServiceContract.ITestBasicScenarios
+    {
+        private delegate string myDelegate(int ID, string name);
+        public async Task<string> TestMethodAsync(int ID, string name)
+        {
+            myDelegate del = ProcessAsync;
+            var workTask = System.Threading.Tasks.Task.Run(() => del.Invoke(ID, name));
+            return await workTask;
+        }
+
+        public string ProcessAsync(int ID, string name)
+        {
+            return name;
+        }
+
+        public string TestMethodDefaults(int ID, string name)
+        {
+            return name;
+        }
+
+        public void TestMethodSetAction(int ID, string name)
+        {
+            Assert.NotNull(name);
+            Assert.Equal("Action", name);
+        }
+
+        public int TestMethodSetReplyAction(int ID, string name)
+        {
+            return ID;
+        }
+
+        public void TestMethodSetUntypedAction(CoreWCF.Channels.Message msg)
+        {
+            Assert.NotNull(msg);
+        }
+
+        public void TestMethodUntypedAction(CoreWCF.Channels.Message msg)
+        {
+            Assert.NotNull(msg);
+        }
+
+        public CoreWCF.Channels.Message TestMethodUntypedReplyAction()
+        {
+            CoreWCF.Channels.Message serviceMessage = CoreWCF.Channels.Message.CreateMessage(CoreWCF.Channels.MessageVersion.Soap11, "myUntypedReplyAction");
+            return serviceMessage;
+        }
+    }
+}
+


### PR DESCRIPTION
 Abstract: A special OperationContract is created for each variation. This test case if for all the basic scenarios where Action and Reply Action are used works.

@ZhaodongTian