### PR TITLE
Connection header fix + X509 security classes exposed

### DIFF
--- a/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
@@ -99,6 +99,7 @@ namespace CoreWCF.Channels
             var httpInput = requestContext.GetHttpInput(true);
             Exception requestException;
             Message requestMessage = httpInput.ParseIncomingMessage(out requestException);
+            requestMessage.Properties.Add("Microsoft.AspNetCore.Http.HttpContext", context);
             if ((requestMessage == null) && (requestException == null))
             {
                 throw Fx.Exception.AsError(

--- a/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Selectors/X509SecurityTokenAuthenticator.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Selectors/X509SecurityTokenAuthenticator.cs
@@ -11,7 +11,7 @@ using System.Text;
 
 namespace CoreWCF.IdentityModel.Selectors
 {
-    internal class X509SecurityTokenAuthenticator : SecurityTokenAuthenticator
+    public class X509SecurityTokenAuthenticator : SecurityTokenAuthenticator
     {
         X509CertificateValidator validator;
         bool mapToWindows;

--- a/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Tokens/X509SecurityToken.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Tokens/X509SecurityToken.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace CoreWCF.IdentityModel.Tokens
 {
-    internal class X509SecurityToken : SecurityToken, IDisposable
+    public class X509SecurityToken : SecurityToken, IDisposable
     {
         string id;
         X509Certificate2 certificate;

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/SecurityMessageProperty.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/SecurityMessageProperty.cs
@@ -85,7 +85,7 @@ namespace CoreWCF.Security
         //    }
         //}
 
-        internal SecurityTokenSpecification TransportToken
+        public SecurityTokenSpecification TransportToken
         {
             get
             {

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/SecurityTokenSpecification.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/SecurityTokenSpecification.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace CoreWCF.Security
 {
-    internal class SecurityTokenSpecification
+    public class SecurityTokenSpecification
     {
         SecurityToken token;
         ReadOnlyCollection<IAuthorizationPolicy> tokenPolicies;

--- a/src/CoreWCF.Primitives/src/CoreWCF/ServiceSecurityContext.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/ServiceSecurityContext.cs
@@ -21,7 +21,7 @@ namespace CoreWCF
         WindowsIdentity windowsIdentity;
 
         // Perf: delay created authorizationContext using forward chain.
-        internal ServiceSecurityContext(ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies)
+        public ServiceSecurityContext(ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies)
         {
             if (authorizationPolicies == null)
             {
@@ -31,12 +31,12 @@ namespace CoreWCF
             this.authorizationPolicies = authorizationPolicies;
         }
 
-        internal ServiceSecurityContext(AuthorizationContext authorizationContext)
+        public ServiceSecurityContext(AuthorizationContext authorizationContext)
             : this(authorizationContext, EmptyReadOnlyCollection<IAuthorizationPolicy>.Instance)
         {
         }
 
-        internal ServiceSecurityContext(AuthorizationContext authorizationContext, ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies)
+        public ServiceSecurityContext(AuthorizationContext authorizationContext, ReadOnlyCollection<IAuthorizationPolicy> authorizationPolicies)
         {
             if (authorizationContext == null)
             {


### PR DESCRIPTION
Fixes a problem where adding a Connection header using HttpResponseMessageProperty.Headers wouldn't remove the existing Connection header based on HttpTransportBindingElement.KeepAliveEnabled. This resulted in a header which could look like this: `Connection: keep-alive, close".
Also tidied up the header adding code to using StringValues.Concat instead of concatenating using `+ ',' + newvalue`.
Exposed some classes needed as the basis for setting OperationContext.ServiceSecurityContext when using X509 certificates.
This allows manually providing a ServiceAuthorizationManager which does this. Automatic support for this will be coming in the future.