### PR TITLE
Fix Message.ToString() so it doesn't throw on invalid XML

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/Message.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/Message.cs
@@ -485,27 +485,19 @@ namespace CoreWCF.Channels
                 return base.ToString();
             }
 
-            XmlWriterSettings settings = new XmlWriterSettings();
-            settings.Indent = true;
-
-            using (StringWriter stringWriter = new StringWriter(CultureInfo.InvariantCulture))
+            StringWriter stringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            EncodingFallbackAwareXmlTextWriter textWriter = new EncodingFallbackAwareXmlTextWriter(stringWriter);
+            textWriter.Formatting = Formatting.Indented;
+            XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(textWriter);
+            try
             {
-                using (XmlWriter textWriter = XmlWriter.Create(stringWriter, settings))
-                {
-                    using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateDictionaryWriter(textWriter))
-                    {
-                        try
-                        {
-                            ToString(writer);
-                            writer.Flush();
-                            return stringWriter.ToString();
-                        }
-                        catch (XmlException e)
-                        {
-                            return SR.Format(SR.MessageBodyToStringError, e.GetType().ToString(), e.Message);
-                        }
-                    }
-                }
+                ToString(writer);
+                writer.Flush();
+                return stringWriter.ToString();
+            }
+            catch (XmlException e)
+            {
+                return SR.Format(SR.MessageBodyToStringError, e.GetType().ToString(), e.Message);
             }
         }
 

--- a/src/CoreWCF.Primitives/src/CoreWCF/Diagnostics/EncodingFallbackAwareXmlTextWriter.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Diagnostics/EncodingFallbackAwareXmlTextWriter.cs
@@ -1,0 +1,59 @@
+﻿using System.IO;
+using System.Text;
+using System.Xml;
+
+namespace CoreWCF.Diagnostics
+{
+    class EncodingFallbackAwareXmlTextWriter : XmlTextWriter
+    {
+        private readonly Encoding _encoding;
+
+        internal EncodingFallbackAwareXmlTextWriter(TextWriter writer) : base(writer)
+        {
+            _encoding = writer.Encoding;
+        }
+
+        public override void WriteString(string value)
+        {
+            if (!string.IsNullOrEmpty(value) &&
+                ContainsInvalidXmlChar(value))
+            {
+                byte[] blob = _encoding.GetBytes(value);
+                value = _encoding.GetString(blob);
+            }
+
+            base.WriteString(value);
+        }
+
+        bool ContainsInvalidXmlChar(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            int i = 0;
+            int len = value.Length;
+
+            while (i < len)
+            {
+                if (XmlConvert.IsXmlChar(value[i]))
+                {
+                    i++;
+                    continue;
+                }
+
+                if (i + 1 < len &&
+                    XmlConvert.IsXmlSurrogatePair(value[i + 1], value[i]))
+                {
+                    i += 2;
+                    continue;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/tests/MessageTests.cs
+++ b/src/CoreWCF.Primitives/tests/MessageTests.cs
@@ -1,0 +1,31 @@
+﻿using CoreWCF.Channels;
+using System;
+using System.Text;
+using Xunit;
+
+namespace CoreWCF.Primitives.Tests
+{
+    public static class MessageTests
+    {
+        [Fact]
+        public static void InvalidCharToString()
+        {
+            string invalidSoap11Message = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<soap:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:soap=""http://schemas.xmlsoap.org/soap/envelope/"">
+<soap:Body>
+<ServiceResponse xmlns=""http://tempuri.org/"">
+<ServiceResult>string" + (char)0x0f + @"</ServiceResult>
+</ServiceResponse>
+</soap:Body>
+</soap:Envelope>";
+            var textMessageEncodingBindingElement = new TextMessageEncodingBindingElement { MessageVersion = MessageVersion.Soap11 };
+            var factory = textMessageEncodingBindingElement.CreateMessageEncoderFactory();
+            var messageEncoder = factory.Encoder;
+            var messageBytes = Encoding.UTF8.GetBytes(invalidSoap11Message);
+            var message = messageEncoder.ReadMessage(new ArraySegment<byte>(messageBytes), BufferManager.CreateBufferManager(10, 10), "text/xml; charset=utf-8");
+            var messageStr = message.ToString();
+            Assert.NotNull(messageStr);
+            Assert.True(messageStr.Contains("The byte 0x0F is not valid at this location"));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #157 