### PR TITLE
Add 2 BufferManagerTests testcases

### DIFF
--- a/src/CoreWCF.Primitives/tests/Helpers/BufferManagerTestsCommon.cs
+++ b/src/CoreWCF.Primitives/tests/Helpers/BufferManagerTestsCommon.cs
@@ -1,0 +1,43 @@
+﻿using CoreWCF.Channels;
+using System;
+using System.Reflection;
+
+namespace CoreWCF.Primitives.Tests.Helpers
+{
+    public class BufferManagerTestsCommon
+    {
+        private static string SynchronizedBufferPool = "synchronizedbufferpool";
+
+        private static string LargeBufferPool = "largebufferpool";
+
+        public static int TrainingCount = 64;
+
+        public static int LargeBufferLimit = 85000;
+
+        public static bool VerifyBufferPoolsCreated(BufferManager bufferManager)
+        {
+            bool flag = true;
+            PropertyInfo property = bufferManager.GetType().GetProperty("InternalBufferManager");
+            object value = property.GetValue(bufferManager, null);
+            object obj = value.GetType().InvokeMember("bufferPools", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.GetField, null, value, null);
+            Array array = obj as Array;
+            for (int i = 0; i < array.Length; i++)
+            {
+                object value2 = array.GetValue(i);
+                PropertyInfo property2 = value2.GetType().GetProperty("BufferSize");
+                int num = (int)property2.GetValue(value2, null);
+                string text = value2.GetType().ToString();
+                if (num < LargeBufferLimit)
+                {
+                    flag &= text.ToLower().Contains(SynchronizedBufferPool);
+                }
+                else
+                {
+                    flag &= text.ToLower().Contains(LargeBufferPool);
+                }
+            }
+
+            return flag;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/tests/Helpers/BufferManagerTestsCommon.cs
+++ b/src/CoreWCF.Primitives/tests/Helpers/BufferManagerTestsCommon.cs
@@ -7,11 +7,8 @@ namespace CoreWCF.Primitives.Tests.Helpers
     public class BufferManagerTestsCommon
     {
         private static string SynchronizedBufferPool = "synchronizedbufferpool";
-
         private static string LargeBufferPool = "largebufferpool";
-
         public static int TrainingCount = 64;
-
         public static int LargeBufferLimit = 85000;
 
         public static bool VerifyBufferPoolsCreated(BufferManager bufferManager)

--- a/src/CoreWCF.Primitives/tests/VerifyBufferPools.cs
+++ b/src/CoreWCF.Primitives/tests/VerifyBufferPools.cs
@@ -1,0 +1,36 @@
+﻿using CoreWCF.Channels;
+using CoreWCF.Primitives.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Primitives.Tests
+{
+    public class VerifyBufferPoolsCreated
+    {
+        private bool testPassed = true;
+        private ITestOutputHelper _output;
+
+        public VerifyBufferPoolsCreated(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void VerifyBufferPoolsCreatedtest()
+        {
+            for (int i = 80000; i <= 90000; i += 5000)
+            {
+                BufferManager bufferManager = BufferManager.CreateBufferManager(524288L, i);
+                bool flag = BufferManagerTestsCommon.VerifyBufferPoolsCreated(bufferManager);
+                testPassed &= flag;
+                _output.WriteLine("Correct BufferPools are created for maxbuffersize:{0} {1} ", new object[]
+                {
+                    i,
+                    flag
+                });
+
+                Assert.True(testPassed);
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/tests/VerifyBufferUsed.cs
+++ b/src/CoreWCF.Primitives/tests/VerifyBufferUsed.cs
@@ -1,0 +1,72 @@
+﻿using CoreWCF.Channels;
+using CoreWCF.Primitives.Tests.Helpers;
+using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Primitives.Tests
+{
+    public class VerifyBufferUsed
+    {
+        private bool testPassed = true;
+        private static byte[] buffer;
+        private ITestOutputHelper _output;
+
+        public VerifyBufferUsed(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void VerifyBufferUsedbyThreadsTest()
+        {
+            for (int i = 80000; i <= 90000; i += 5000)
+            {
+                _output.WriteLine("Training Buffer of size = " + i);
+                for (int j = 63; j <= BufferManagerTestsCommon.TrainingCount; j++)
+                {
+                    BufferPoolAffinitize(j, i);
+                }
+            }
+
+            Assert.True(testPassed);
+        }
+
+        private void BufferPoolAffinitize(int trainingCount, int bufferSize)
+        {
+            BufferManager bufferManager = BufferManager.CreateBufferManager(524288L, bufferSize);
+            buffer = null;
+            for (int i = 0; i < trainingCount; i++)
+            {
+                buffer = bufferManager.TakeBuffer(bufferSize);
+                bufferManager.ReturnBuffer(buffer);
+            }
+
+            _output.WriteLine("Same buffers returned for bufferSize={0} and  training Count={1} : ", new object[]
+            {
+                bufferSize,
+                trainingCount
+            });
+
+            Thread thread = new Thread(delegate ()
+            {
+                byte[] array = bufferManager.TakeBuffer(bufferSize);
+                bool flag = array == buffer;
+                if (bufferSize < BufferManagerTestsCommon.LargeBufferLimit && trainingCount == BufferManagerTestsCommon.TrainingCount)
+                {
+                    testPassed &= !flag;
+                }
+                else
+                {
+                    testPassed &= flag;
+                }
+
+                _output.WriteLine(flag.ToString());
+            });
+
+            thread.Start();
+            thread.Join();
+        }
+    }
+}
+


### PR DESCRIPTION
case1: VerifyBufferUsed( )
           <summary> Verify buffer object used by different threads before and after a thread gets trained
case2: VerifyBufferPools( )
            <summary> Verify BufferPools created for different buffer sizes

@ZhaodongTian