### PR TITLE
Remove global.json and update GitVersionTask

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="!($(IsTestProject) OR $(IsSampleProject))">
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
+    <PackageReference Include="GitVersionTask" Version="5.3.7">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <!-- Include license file in packages -->

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "3.1.101",
-    "rollForward": "disable"
-  }
-}


### PR DESCRIPTION
The version of .NET Core was pinned using the global.json file because of a breaking change in the SDK which broke GitVersion. GitVersion has made changes to work around the breaking change so no need to pin older versions.