### PR TITLE
Fix intermittent failing test

### DIFF
--- a/src/CoreWCF.Http/tests/Services/RequestReplyService.cs
+++ b/src/CoreWCF.Http/tests/Services/RequestReplyService.cs
@@ -77,7 +77,9 @@ namespace Services
             log.Add("DownloadStream");
             localStream = new FlowControlledStream();
             localStream.ReadThrottle = TimeSpan.FromMilliseconds(500);
-            localStream.StreamDuration = TimeSpan.FromSeconds(1);
+            // Setting to 900ms instead of 1 second because sometimes 3 reads occur and the read buffer grows with
+            // each read by a factor of 16 up to 64KB and this is causing the client to exceed it's MaxReceivedMessageSize
+            localStream.StreamDuration = TimeSpan.FromMilliseconds(900);
 
             return localStream;
         }


### PR DESCRIPTION
One test was sometimes having an extra read from the server side stream due to sometimes a wait completing just a little bit too quickly and failing the test to complete the stream. This caused the client side to exceed the MaxReceivedMessageSize property on the binding and throw an exception failing the test.
I've modified the stream completion time to be a little shorter to prevent this edge case. Rather than rely on timing. If this continues to be an issue, rather than rely on timing the test should be modified to have a fixed count of reads before completing.