### PR TITLE
Fix HTTP binding to use all async IO in BufferedMode scenario

### DIFF
--- a/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
@@ -97,8 +97,7 @@ namespace CoreWCF.Channels
 
             var requestContext = HttpRequestContext.CreateContext(_httpSettings, context);
             var httpInput = requestContext.GetHttpInput(true);
-            Exception requestException;
-            Message requestMessage = httpInput.ParseIncomingMessage(out requestException);
+            (Message requestMessage, Exception requestException) = await httpInput.ParseIncomingMessageAsync();
             requestMessage.Properties.Add("Microsoft.AspNetCore.Http.HttpContext", context);
             if ((requestMessage == null) && (requestException == null))
             {

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/WebSocketTransportDuplexSessionChannel.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/WebSocketTransportDuplexSessionChannel.cs
@@ -515,7 +515,7 @@ namespace CoreWCF.Channels
                         buffer = bufferManager.TakeBuffer(receivedByteCount);
                         Buffer.BlockCopy(internalBuffer, 0, buffer, 0, receivedByteCount);
                         Fx.Assert(result != null, "Result should not be null");
-                        pendingMessage = PrepareMessage(result, buffer, receivedByteCount);
+                        pendingMessage = await PrepareMessageAsync(result, buffer, receivedByteCount);
                         success = true;
                     }
                     finally
@@ -647,7 +647,7 @@ namespace CoreWCF.Channels
 
                                     WebSocketReceiveResult result = receiveTask.Result;
                                     CheckCloseStatus(result);
-                                    pendingMessage = PrepareMessage(result, buffer, result.Count);
+                                    pendingMessage = await PrepareMessageAsync(result, buffer, result.Count);
 
                                     //if (TD.WebSocketAsyncReadStopIsEnabled())
                                     //{
@@ -726,7 +726,7 @@ namespace CoreWCF.Channels
                 return null;
             }
 
-            private Message PrepareMessage(WebSocketReceiveResult result, byte[] buffer, int count)
+            private async Task<Message> PrepareMessageAsync(WebSocketReceiveResult result, byte[] buffer, int count)
             {
                 if (result.MessageType != WebSocketMessageType.Close)
                 {
@@ -734,7 +734,7 @@ namespace CoreWCF.Channels
                     if (useStreaming)
                     {
                         TimeoutHelper readTimeoutHelper = new TimeoutHelper(defaultTimeouts.ReceiveTimeout);
-                        message = encoder.ReadMessage(
+                        message = await encoder.ReadMessageAsync(
                             new MaxMessageSizeStream(
                                 new TimeoutStream(
                                     new WebSocketStream(

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/ServerSingletonConnectionReaderMiddleware.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/ServerSingletonConnectionReaderMiddleware.cs
@@ -125,8 +125,7 @@ namespace CoreWCF.Channels.Framing
                 Message message = null;
                 try
                 {
-                    // TODO: Make async
-                    message = connection.MessageEncoderFactory.Encoder.ReadMessage(
+                    message = await connection.MessageEncoderFactory.Encoder.ReadMessageAsync(
                         inputStream, connection.MaxBufferSize, connection.FramingDecoder.ContentType);
                 }
                 catch (XmlException xmlException)

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/StreamedFramingRequestContext.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/StreamedFramingRequestContext.cs
@@ -136,7 +136,7 @@ namespace CoreWCF.Channels.Framing
                     Stream connectionStream = new StreamingOutputConnectionStream(connection, settings);
                     // TODO: Determine if timeout stream is needed as StreamingOutputConnectionStream implements some timeout functionality
                     //Stream writeTimeoutStream = new TimeoutStream(connectionStream, ref timeoutHelper);
-                    messageEncoder.WriteMessage(message, connectionStream);
+                    messageEncoder.WriteMessageAsync(message, connectionStream);
                     await connection.Output.FlushAsync();
                 }
                 else

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/BinaryMessageEncoderFactory.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/BinaryMessageEncoderFactory.cs
@@ -5,6 +5,7 @@ using System.Text;
 using CoreWCF.Runtime;
 using System.Xml;
 using CoreWCF.Xml;
+using System.Threading.Tasks;
 
 namespace CoreWCF.Channels
 {
@@ -656,7 +657,7 @@ namespace CoreWCF.Channels
                 return message;
             }
 
-            public override Message ReadMessage(Stream stream, int maxSizeOfHeaders, string contentType)
+            public override Task<Message> ReadMessageAsync(Stream stream, int maxSizeOfHeaders, string contentType)
             {
                 if (stream == null)
                 {
@@ -675,7 +676,7 @@ namespace CoreWCF.Channels
                 Message message = Message.CreateMessage(reader, maxSizeOfHeaders, factory.messageVersion);
                 message.Properties.Encoder = this;
 
-                return message;
+                return Task.FromResult(message);
             }
 
             public override ArraySegment<byte> WriteMessage(Message message, int maxMessageSize, BufferManager bufferManager, int messageOffset)
@@ -754,7 +755,7 @@ namespace CoreWCF.Channels
                 return messageData;
             }
 
-            public override void WriteMessage(Message message, Stream stream)
+            public override async Task WriteMessageAsync(Message message, Stream stream)
             {
                 if (message == null)
                 {
@@ -774,10 +775,8 @@ namespace CoreWCF.Channels
                 ThrowIfMismatchedMessageVersion(message);
                 message.Properties.Encoder = this;
                 XmlDictionaryWriter xmlWriter = factory.TakeStreamedWriter(stream);
-                message.WriteMessage(xmlWriter);
+                await message.WriteMessageAsync(xmlWriter);
                 xmlWriter.Flush();
-
-
 
                 factory.ReturnStreamedWriter(xmlWriter);
                 if (compressionFormat != CompressionFormat.None)

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/TextMessageEncoderFactory.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/TextMessageEncoderFactory.cs
@@ -420,7 +420,7 @@ namespace CoreWCF.Channels
                 return message;
             }
 
-            public override Message ReadMessage(Stream stream, int maxSizeOfHeaders, string contentType)
+            public override Task<Message> ReadMessageAsync(Stream stream, int maxSizeOfHeaders, string contentType)
             {
                 if (stream == null)
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException(nameof(stream)));
@@ -429,7 +429,7 @@ namespace CoreWCF.Channels
                 Message message = Message.CreateMessage(reader, maxSizeOfHeaders, version);
                 message.Properties.Encoder = this;
 
-                return message;
+                return Task.FromResult(message);
             }
 
             public override ArraySegment<byte> WriteMessage(Message message, int maxMessageSize, BufferManager bufferManager, int messageOffset)
@@ -453,30 +453,6 @@ namespace CoreWCF.Channels
                 ReturnMessageWriter(messageWriter);
 
                 return messageData;
-            }
-
-            public override void WriteMessage(Message message, Stream stream)
-            {
-                if (message == null)
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException(nameof(message)));
-                if (stream == null)
-                    throw TraceUtility.ThrowHelperError(new ArgumentNullException(nameof(stream)), message);
-                ThrowIfMismatchedMessageVersion(message);
-
-                message.Properties.Encoder = this;
-                XmlDictionaryWriter xmlWriter = TakeStreamedWriter(stream);
-                if (optimizeWriteForUTF8)
-                {
-                    message.WriteMessage(xmlWriter);
-                }
-                else
-                {
-                    xmlWriter.WriteStartDocument();
-                    message.WriteMessage(xmlWriter);
-                    xmlWriter.WriteEndDocument();
-                }
-                xmlWriter.Flush();
-                ReturnStreamedWriter(xmlWriter);
             }
 
             public override async Task WriteMessageAsync(Message message, Stream stream)

--- a/src/CoreWCF.Primitives/tests/Helpers/TestRequestContext.cs
+++ b/src/CoreWCF.Primitives/tests/Helpers/TestRequestContext.cs
@@ -69,7 +69,7 @@ namespace Helpers
             var mef = mebe.CreateMessageEncoderFactory();
             var me = mef.Encoder;
             MemoryStream ms = new MemoryStream();
-            me.WriteMessage(ReplyMessage, ms);
+            me.WriteMessageAsync(ReplyMessage, ms);
             var messageBytes = ms.ToArray();
             _replyMessageString = Encoding.UTF8.GetString(messageBytes);
         }

--- a/src/CoreWCF.Primitives/tests/Helpers/XmlSerializerTestRequestContext.cs
+++ b/src/CoreWCF.Primitives/tests/Helpers/XmlSerializerTestRequestContext.cs
@@ -57,7 +57,7 @@ namespace Helpers
             var mef = mebe.CreateMessageEncoderFactory();
             var me = mef.Encoder;
             MemoryStream ms = new MemoryStream();
-            me.WriteMessage(ReplyMessage, ms);
+            me.WriteMessageAsync(ReplyMessage, ms);
             var messageBytes = ms.ToArray();
             _replyMessageString = Encoding.UTF8.GetString(messageBytes);
         }

--- a/src/CoreWCF.Primitives/tests/MessageEncoderTest.cs
+++ b/src/CoreWCF.Primitives/tests/MessageEncoderTest.cs
@@ -3,6 +3,7 @@ using Helpers;
 using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace CoreWCF.Primitives.Tests
@@ -10,7 +11,7 @@ namespace CoreWCF.Primitives.Tests
     public class MessageEncoderTest
     {
         [Fact]
-        public void BasicTextTest()
+        public async Task BasicTextTest()
         {
             int bad = 0;
             int good = 0;
@@ -24,11 +25,11 @@ namespace CoreWCF.Primitives.Tests
                 {
                     Message myMessage = (Message)ims.Current;
                     var s = new MemoryStream();
-                    f.WriteMessage(myMessage, s);
+                    await f.WriteMessageAsync(myMessage, s);
                     s.Seek(0, SeekOrigin.Begin);
                     _ = new StreamReader(s);
                     s.Seek(0, SeekOrigin.Begin);
-                    Message m2 = f.ReadMessage(s, int.MaxValue);
+                    Message m2 = await f.ReadMessageAsync(s, int.MaxValue);
 
                     // original got closed by sending, so recreate it:
                     myMessage = ims.CurrentParameters.CreateMessage();
@@ -47,7 +48,7 @@ namespace CoreWCF.Primitives.Tests
             catch(Exception ex)
             {
                 Assert.True(false, $"Exception caught: {ex.Message} More information: {bad} bad ones, {good} good ones.");
-            }           
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Embarrassingly I had left the HTTP transport to read from the incoming request stream synchronously. This fixes that faux pas. It still will sometimes use sync reads and writes in the streamed mode scenario as Xml[Dictionary]Reader/Xml[Dictionary]Writer aren't entirely async and neither are XmlSerializer or DataContractSerializer.