### PR TITLE
Add ability to provide delegate to modify ServiceHostBase

### DIFF
--- a/src/CoreWCF.Http/tests/SimpleTest.cs
+++ b/src/CoreWCF.Http/tests/SimpleTest.cs
@@ -41,6 +41,24 @@ namespace BasicHttp
             }
         }
 
+        [Fact]
+        public void BasicHttpConfigureSericeHostBaseEchoString()
+        {
+            string testString = new string('a', 3000);
+            var host = ServiceHelper.CreateWebHostBuilder<StartupWithConfiguration>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                var httpBinding = ClientHelper.GetBufferedModeBinding();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IEchoService>(httpBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/basichttp.svc")));
+                var channel = factory.CreateChannel();
+                var result = channel.EchoString(testString);
+                Assert.Equal(testString, result);
+                Assert.True(StartupWithConfiguration.ConfigureServiceHostValid);
+            }
+        }
+
         internal class Startup
         {
             public void ConfigureServices(IServiceCollection services)
@@ -54,6 +72,28 @@ namespace BasicHttp
                 {
                     builder.AddService<Services.EchoService>();
                     builder.AddServiceEndpoint<Services.EchoService, ServiceContract.IEchoService>(new CoreWCF.BasicHttpBinding(), "/BasicWcfService/basichttp.svc");
+                });
+            }
+        }
+
+        internal class StartupWithConfiguration
+        {
+            public static bool ConfigureServiceHostValid { get; set; } = false;
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.EchoService>();
+                    builder.AddServiceEndpoint<Services.EchoService, ServiceContract.IEchoService>(new CoreWCF.BasicHttpBinding(), "/BasicWcfService/basichttp.svc");
+                    builder.ConfigureServiceHostBase<Services.EchoService>(serviceHost =>
+                    {
+                        ConfigureServiceHostValid = serviceHost.Description.ServiceType == typeof(Services.EchoService);
+                    });
                 });
             }
         }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilder.cs
@@ -22,6 +22,8 @@ namespace CoreWCF.Configuration
 
         ICollection<Type> IServiceBuilder.Services => _services.Keys;
 
+        public IServiceProvider ServiceProvider => _serviceProvider;
+
         public void AddService<TService>() where TService : class
         {
             var serviceConfig = _serviceProvider.GetRequiredService<IServiceConfiguration<TService>>();

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilderExtensions.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilderExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace CoreWCF.Configuration
+{
+    public static class ServiceBuilderExtensions
+    {
+        public static void ConfigureServiceHostBase<TService>(this IServiceBuilder builder, Action<ServiceHostBase> func) where TService : class
+        {
+            var serviceBuilder = builder as ServiceBuilder;
+            var holder = serviceBuilder.ServiceProvider
+                .GetRequiredService<ServiceConfigurationDelegateHolder<TService>>();
+            holder.AddConfigDelegate(func);
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceConfigurationDelegateHolder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceConfigurationDelegateHolder.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CoreWCF.Configuration
+{
+    internal class ServiceConfigurationDelegateHolder<TService> where TService : class
+    {
+        private List<Action<ServiceHostBase>> configDelegates = new List<Action<ServiceHostBase>>();
+
+        public void AddConfigDelegate(Action<ServiceHostBase> func)
+        {
+            configDelegates.Add(func);
+        }
+
+        public void Configure(ServiceHostBase host)
+        {
+            foreach (var del in configDelegates)
+            {
+                del(host);
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceModelServiceCollectionExtensions.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceModelServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ namespace CoreWCF.Configuration
             });
             services.TryAddSingleton(typeof(IServiceConfiguration<>), typeof(ServiceConfiguration<>));
             services.TryAddSingleton<IDispatcherBuilder, DispatcherBuilderImpl>();
+            services.AddSingleton(typeof(ServiceConfigurationDelegateHolder<>));
             services.AddScoped<ReplyChannelBinder>();
             services.AddScoped<DuplexChannelBinder>();
             services.AddScoped<InputChannelBinder>();

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/DispatcherBuilder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/DispatcherBuilder.cs
@@ -691,6 +691,8 @@ namespace CoreWCF.Description
             }
 
             InitializeServiceHost(serviceHost);
+            ServiceConfigurationDelegateHolder<TService> configDelegate = services.GetService<ServiceConfigurationDelegateHolder<TService>>();
+            configDelegate?.Configure(serviceHost);
 
             // TODO: Add error checking to make sure property chain is correctly populated with objects
             var dispatchers = new List<IServiceDispatcher>(serviceHost.ChannelDispatchers.Count);

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceDescription.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceDescription.cs
@@ -99,8 +99,7 @@ namespace CoreWCF.Description
             get { return _endpoints; }
         }
 
-        // TODO: I made this internal, evaluate making it public as it is on full framework
-        internal Type ServiceType
+        public Type ServiceType
         {
             get { return _serviceType; }
             set { _serviceType = value; }


### PR DESCRIPTION
This allows code similar to the following to make porting existing code over a bit easier:
```c#
                app.UseServiceModel(builder =>
                {
                    builder.AddService<Services.EchoService>();
                    builder.AddServiceEndpoint<Services.EchoService, ServiceContract.IEchoService>(new CoreWCF.BasicHttpBinding(), "/BasicWcfService/basichttp.svc");
                    builder.ConfigureServiceHostBase<Services.EchoService>(serviceHost =>
                    {
                        // Modify or examine the ServiceHostBase instance
                    });
                });
```