### PR TITLE
Test fix.

### DIFF
--- a/src/CoreWCF.Primitives/tests/BasicFaultTest.cs
+++ b/src/CoreWCF.Primitives/tests/BasicFaultTest.cs
@@ -1,8 +1,8 @@
 ﻿using CoreWCF.Channels;
+using Helpers;
 using System;
 using System.Collections.Generic;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace CoreWCF.Primitives.Tests
 {
@@ -23,7 +23,7 @@ namespace CoreWCF.Primitives.Tests
                 translations.Add(new FaultReasonText("Raison: auto-generat error pour examiner.", "fr"));
 
                 var reason = new FaultReason(translations);
-                Object detail = "Sample fault detail content.";
+                object detail = "Sample fault detail content.";
 
                 MessageFault fault = MessageFault.CreateFault(new FaultCode("Sender"), reason, detail, new System.Runtime.Serialization.DataContractSerializer(typeof(string)), "", "");
                 Message message = Message.CreateMessage(MessageVersion.Soap12WSAddressing10, fault, "http://www.w3.org/2005/08/addressing/fault");
@@ -63,27 +63,6 @@ namespace CoreWCF.Primitives.Tests
                     throw new ApplicationException("Message Fault Detail are not equal");
                 }
             }
-        }
-    }
-
-    internal class MessageTestUtilities
-    {
-        public static Message SendAndReceiveMessage(Message toSend)
-        {
-            MessageEncoder encoder = null;
-            if (toSend.Version.Envelope == EnvelopeVersion.Soap11)
-            {
-                encoder = new TextMessageEncodingBindingElement(toSend.Version, System.Text.Encoding.UTF8).CreateMessageEncoderFactory().Encoder;
-            }
-            else
-            {
-                encoder = new BinaryMessageEncodingBindingElement().CreateMessageEncoderFactory().Encoder;
-            }
-            BufferManager bufferManager = BufferManager.CreateBufferManager(int.MaxValue, int.MaxValue);
-            ArraySegment<byte> encodedMessage = encoder.WriteMessage(toSend, int.MaxValue, bufferManager);
-
-            Message r = encoder.ReadMessage(encodedMessage, bufferManager);
-            return r;
         }
     }
 }

--- a/src/CoreWCF.Primitives/tests/MessageEncoderTest.cs
+++ b/src/CoreWCF.Primitives/tests/MessageEncoderTest.cs
@@ -33,7 +33,7 @@ namespace CoreWCF.Primitives.Tests
 
                     // original got closed by sending, so recreate it:
                     myMessage = ims.CurrentParameters.CreateMessage();
-                    if (Helpers.MessageTestUtilities.AreMessagesEqual(myMessage, m2))
+                    if (MessageTestUtilities.AreMessagesEqual(myMessage, m2))
                     {
                         good++;
                     }
@@ -59,8 +59,8 @@ namespace CoreWCF.Primitives.Tests
             Message m1p = Message.CreateMessage(MessageVersion.Soap12WSAddressing10, action, new CustomGeneratedBodyWriter(2, 1024));
 
             // Note, m1 is closed by this, which is we compare m2 with m1p
-            Message m2 = Helpers.MessageTestUtilities.SendAndReceiveMessage(m1);
-            Assert.True(Helpers.MessageTestUtilities.AreBodiesEqual(m1p, m2, true, true));
+            Message m2 = MessageTestUtilities.SendAndReceiveMessage(m1);
+            Assert.True(MessageTestUtilities.AreBodiesEqual(m1p, m2, true, true));
         }
     }
 }


### PR DESCRIPTION
@mconnew 

Build break fix: SendAndReceiveMessage already defined in Helpers.MessageTestUtilities class.