### PR TITLE
Fix test which is flakey on NetFx

### DIFF
--- a/src/CoreWCF.Http/tests/Async767311Tests.cs
+++ b/src/CoreWCF.Http/tests/Async767311Tests.cs
@@ -86,7 +86,7 @@ namespace CoreWCF.Http.Tests
             }
         }
 
-        public void CallbackResults(IAsyncResult asyncResult)
+        internal void CallbackResults(IAsyncResult asyncResult)
         {
             _output.WriteLine("Callback received, signalling");
             autoEvent.Set();

--- a/src/CoreWCF.Http/tests/TaskCollectionsTests.cs
+++ b/src/CoreWCF.Http/tests/TaskCollectionsTests.cs
@@ -21,6 +21,8 @@ namespace CoreWCF.Http.Tests
 
         public TaskCollectionsTests(ITestOutputHelper output)
         {
+            // No-op on .NET Core but necessary to complete concurrect requests on NetFx
+            System.Net.ServicePointManager.DefaultConnectionLimit = 50;
             _output = output;
         }
 


### PR DESCRIPTION
TaskCollectionsTest issues multiple requests simultaneously. On NetFx the default is 2 concurrent
HTTP requests per endpoint. This causes the calls to be made serially and times out the test.
This change tells NetFx that it can make up to 50 concurrent HTTP calls which should be more than
enough for any sane unit test scenario.
Also changed a callback from public -> internal as Xunit code analysis says it should be a Theory
due to being public.