### PR TITLE
Added S.SM.ServiceKnownType compat on contract load

### DIFF
--- a/src/CoreWCF.Http/tests/ClientContract/IServiceKnownTypeTest.cs
+++ b/src/CoreWCF.Http/tests/ClientContract/IServiceKnownTypeTest.cs
@@ -1,0 +1,35 @@
+﻿using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Text;
+
+namespace ClientContract
+{
+    [ServiceContract]
+    [ServiceKnownType(typeof(HelloReply))]
+    interface IServiceKnownTypeTest
+    {
+        [OperationContract]
+        BaseHelloReply SayHello(HelloRequest request);
+    }
+
+    [DataContract(Namespace = "http://schemas.datacontract.org/2004/07/ServiceContract")]
+    public class HelloRequest
+    {
+        [DataMember]
+        public string Name { get; set; }
+    }
+
+    [DataContract(Namespace = "http://schemas.datacontract.org/2004/07/ServiceContract")]
+    public class HelloReply : BaseHelloReply
+    {
+        [DataMember]
+        public string Message { get; set; }
+    }
+
+    [DataContract(Namespace = "http://schemas.datacontract.org/2004/07/ServiceContract")]
+    public class BaseHelloReply
+    {
+        [DataMember]
+        public string Name { get; set; }
+    }
+}

--- a/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
@@ -101,6 +101,30 @@ namespace Helpers
             .UseUrls("http://localhost:8080")
             .UseStartup<TStartup>();
 
+        public static IWebHostBuilder CreateWebHostBuilder(Type startupType, ITestOutputHelper outputHelper) =>
+            WebHost.CreateDefaultBuilder(new string[0])
+#if DEBUG
+            .ConfigureLogging((ILoggingBuilder logging) =>
+            {
+                logging.AddProvider(new XunitLoggerProvider(outputHelper));
+                logging.AddFilter("Default", LogLevel.Debug);
+                logging.AddFilter("Microsoft", LogLevel.Debug);
+                logging.SetMinimumLevel(LogLevel.Debug);
+            })
+#endif // DEBUG
+            .UseKestrel(options =>
+                {
+                    options.Listen(IPAddress.Loopback, 8080, listenOptions =>
+                    {
+                        if (Debugger.IsAttached)
+                        {
+                            listenOptions.UseConnectionLogging();
+                        }
+                    });
+                })
+            .UseUrls("http://localhost:8080")
+            .UseStartup(startupType);
+
         public static IWebHostBuilder CreateHttpsWebHostBuilder<TStartup>(ITestOutputHelper outputHelper) where TStartup : class =>
             WebHost.CreateDefaultBuilder(new string[0])
 #if DEBUG

--- a/src/CoreWCF.Http/tests/ServiceContract/IServiceKnownTypeTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceContract/IServiceKnownTypeTest.cs
@@ -4,11 +4,27 @@ using System.Runtime.Serialization;
 namespace ServiceContract
 {
     [ServiceContract]
-    [ServiceKnownType(typeof(HelloReply))]
-    interface IServiceKnownTypeTest
+    public interface IServiceKnownTypeBase
     {
-        [OperationContract]
+        [OperationContract(Action = "http://tempuri.org/IServiceKnownTypeTest/SayHello",
+                           ReplyAction = "http://tempuri.org/IServiceKnownTypeTest/SayHelloResponse")]
         BaseHelloReply SayHello(HelloRequest request);
+    }
+
+    // Helper interface to avoid having lots of interfaces declared on the service itself
+    public interface IServiceKnownTypeTest : IServiceKnownTypeWithType, IServiceKnownTypeWithDeclaredTypeAndMethodName
+    { }
+
+    [ServiceContract]
+    [ServiceKnownType(typeof(HelloReply))]
+    public interface IServiceKnownTypeWithType : IServiceKnownTypeBase
+    {
+    }
+
+    [ServiceContract]
+    [ServiceKnownType("GetKnownTypes", typeof(Services.ServiceKnownTypeServiceHelper))]
+    public interface IServiceKnownTypeWithDeclaredTypeAndMethodName : IServiceKnownTypeBase
+    {
     }
 
     [DataContract]

--- a/src/CoreWCF.Http/tests/ServiceContract/IServiceKnownTypeTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceContract/IServiceKnownTypeTest.cs
@@ -1,0 +1,34 @@
+﻿using CoreWCF;
+using System.Runtime.Serialization;
+
+namespace ServiceContract
+{
+    [ServiceContract]
+    [ServiceKnownType(typeof(HelloReply))]
+    interface IServiceKnownTypeTest
+    {
+        [OperationContract]
+        BaseHelloReply SayHello(HelloRequest request);
+    }
+
+    [DataContract]
+    public class HelloRequest
+    {
+        [DataMember]
+        public string Name { get; set; }
+    }
+
+    [DataContract]
+    public class HelloReply : BaseHelloReply
+    {
+        [DataMember]
+        public string Message { get; set; }
+    }
+
+    [DataContract]
+    public class BaseHelloReply
+    {
+        [DataMember]
+        public string Name { get; set; }
+    }
+}

--- a/src/CoreWCF.Http/tests/ServiceKnownTypeTests.cs
+++ b/src/CoreWCF.Http/tests/ServiceKnownTypeTests.cs
@@ -1,0 +1,85 @@
+﻿using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Http.Tests
+{
+    public class ServiceKnownTypeTests
+    {
+        private ITestOutputHelper _output;
+
+        public ServiceKnownTypeTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void ServiceKnownTypeSerializes()
+        {
+            var host = ServiceHelper.CreateWebHostBuilder<Startup<ServiceContract.IServiceKnownTypeTest>>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                System.ServiceModel.ChannelFactory<ClientContract.IServiceKnownTypeTest> channelFactory = null;
+                channelFactory = new System.ServiceModel.ChannelFactory<ClientContract.IServiceKnownTypeTest>(ClientHelper.GetBufferedModHttp1Binding(),
+                      new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/ServiceKnownType/HttpEndpoint.svc")));
+                var channel = channelFactory.CreateChannel();
+                var request = new ClientContract.HelloRequest { Name = "Bill Gates" };
+                var responseBase = channel.SayHello(request);
+                Assert.NotNull(responseBase);
+                Assert.IsType<ClientContract.HelloReply>(responseBase);
+                var response = responseBase as ClientContract.HelloReply;
+                Assert.Equal("Hello " + request.Name, response.Message);
+                ((System.ServiceModel.IClientChannel)channel).Close();
+                channelFactory.Close();
+            }
+        }
+
+        [Fact]
+        public void ServiceKnownTypeCompatibilitySerializes()
+        {
+            // This variant uses the System.ServiceModel namespaced attributes on the service side
+            var host = ServiceHelper.CreateWebHostBuilder<Startup<ClientContract.IServiceKnownTypeTest>>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                System.ServiceModel.ChannelFactory<ClientContract.IServiceKnownTypeTest> channelFactory = null;
+                channelFactory = new System.ServiceModel.ChannelFactory<ClientContract.IServiceKnownTypeTest>(ClientHelper.GetBufferedModHttp1Binding(),
+                      new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/ServiceKnownType/HttpEndpoint.svc")));
+                var channel = channelFactory.CreateChannel();
+                var request = new ClientContract.HelloRequest { Name = "Bill Gates" };
+                var responseBase = channel.SayHello(request);
+                Assert.NotNull(responseBase);
+                Assert.IsType<ClientContract.HelloReply>(responseBase);
+                var response = responseBase as ClientContract.HelloReply;
+                Assert.Equal("Hello " + request.Name, response.Message);
+                ((System.ServiceModel.IClientChannel)channel).Close();
+                channelFactory.Close();
+            }
+        }
+
+        internal class Startup<TContract>
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.ServiceKnownTypeService>();
+                    builder.AddServiceEndpoint<Services.ServiceKnownTypeService, TContract>(ServiceHelper.GetBufferedModHttp1Binding(), "/ServiceKnownType/HttpEndpoint.svc");
+                });
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Http/tests/Services/ServiceKnownTypeService.cs
+++ b/src/CoreWCF.Http/tests/Services/ServiceKnownTypeService.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using CoreWCF;
+using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
 
 namespace Services
@@ -22,6 +24,23 @@ namespace Services
                 Name = request.Name,
                 Message = "Hello " + request.Name
             };
+        }
+    }
+
+    [ServiceKnownType("GetKnownTypes")]
+    public class ServiceKnownTypeWithAttribute : ServiceKnownTypeService
+    {
+        public static IEnumerable<Type> GetKnownTypes(ICustomAttributeProvider provider)
+        {
+            return new List<Type> { typeof(ServiceContract.HelloReply) };
+        }
+    }
+
+    public static class ServiceKnownTypeServiceHelper
+    {
+        public static IEnumerable<Type> GetKnownTypes(ICustomAttributeProvider provider)
+        {
+            return new List<Type> { typeof(ServiceContract.HelloReply) };
         }
     }
 }

--- a/src/CoreWCF.Http/tests/Services/ServiceKnownTypeService.cs
+++ b/src/CoreWCF.Http/tests/Services/ServiceKnownTypeService.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Services
+{
+    public class ServiceKnownTypeService : ServiceContract.IServiceKnownTypeTest, ClientContract.IServiceKnownTypeTest
+    {
+        public ServiceContract.BaseHelloReply SayHello(ServiceContract.HelloRequest request)
+        {
+            return new ServiceContract.HelloReply
+            {
+                Name = request.Name,
+                Message = "Hello " + request.Name
+            };
+        }
+
+        public ClientContract.BaseHelloReply SayHello(ClientContract.HelloRequest request)
+        {
+            return new ClientContract.HelloReply
+            {
+                Name = request.Name,
+                Message = "Hello " + request.Name
+            };
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/CustomAttributeProvider.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/CustomAttributeProvider.cs
@@ -123,7 +123,7 @@ namespace CoreWCF.Description
                         result[i] = ConvertFromServiceModelMessageBodyMemberAttribute(result[i]);
                     }
                 }
-                else if (attributeType == typeof(MessageBodyMemberAttribute))
+                else if (attributeType == typeof(MessagePropertyAttribute))
                 {
                     result = attributes.Where(attribute => attribute.GetType().FullName.Equals(ServiceReflector.SMMessagePropertyAttributeFullName)).ToArray();
                     for (int i = 0; i < result.Length; i++)
@@ -131,7 +131,16 @@ namespace CoreWCF.Description
                         result[i] = ConvertFromServiceModelMessagePropertyAttribute(result[i]);
                     }
                 }
+                else if (attributeType == typeof(ServiceKnownTypeAttribute))
+                {
+                    result = attributes.Where(attribute => attribute.GetType().FullName.Equals(ServiceReflector.SMServiceKnownTypeAttributeFullName)).ToArray();
+                    for (int i = 0; i < result.Length; i++)
+                    {
+                        result[i] = ConvertFromServiceModelServiceKnownTypeAttribute(result[i]);
+                    }
+                }
             }
+
             return result;
         }
 
@@ -238,6 +247,24 @@ namespace CoreWCF.Description
             return messageBody;
         }
 
+        private static ServiceKnownTypeAttribute ConvertFromServiceModelServiceKnownTypeAttribute(object attr)
+        {
+            //var messsageProperty = new ServiceKnownTypeAttribute();
+            Type type = GetProperty<Type>(attr, nameof(ServiceKnownTypeAttribute.Type));
+            string methodName = GetProperty<string>(attr, nameof(ServiceKnownTypeAttribute.MethodName));
+            Type declaringType = GetProperty<Type>(attr, nameof(ServiceKnownTypeAttribute.DeclaringType));
+
+            if (type != null)
+            {
+                return new ServiceKnownTypeAttribute(type);
+            }
+            else
+            {
+                // This also covers the constructor used with just a method name as declaring type will just be null
+                return new ServiceKnownTypeAttribute(methodName, declaringType);
+            }
+        }
+
         private static MessagePropertyAttribute ConvertFromServiceModelMessagePropertyAttribute(object attr)
         {
             var messsageProperty = new MessagePropertyAttribute();
@@ -249,6 +276,7 @@ namespace CoreWCF.Description
 
             return messsageProperty;
         }
+
         private static OperationContractAttribute ConvertFromServiceModelOperationContractAttribute(object attr)
         {
             Fx.Assert(attr.GetType().FullName.Equals(ServiceReflector.SMOperationContractAttributeFullName), "Expected attribute of type S.SM.OperationContractAttribute");

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/CustomAttributeProviderExtentions.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/CustomAttributeProviderExtentions.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace CoreWCF.Description
 {
-    internal class CustomAttributeProvider
+    internal static class CustomAttributeProviderExtentions
     {
         private enum AttributeProviderType
         {
@@ -18,63 +18,9 @@ namespace CoreWCF.Description
             ParameterInfo,
         };
 
-        private CustomAttributeProvider(object attrProvider)
+        public static object[] GetCustomAttributesWithCompat(this ICustomAttributeProvider provider, Type attributeType, bool inherit)
         {
-            if (attrProvider is Type)
-            {
-                Type = (Type)attrProvider;
-                TypeInfo = Type.GetTypeInfo();
-                ProviderType = AttributeProviderType.Type;
-            }
-            else if (attrProvider is MethodInfo)
-            {
-                MethodInfo = (MethodInfo)attrProvider;
-                ProviderType = AttributeProviderType.MethodInfo;
-            }
-            else if (attrProvider is MemberInfo)
-            {
-                MemberInfo = (MemberInfo)attrProvider;
-                ProviderType = AttributeProviderType.MemberInfo;
-            }
-            else if (attrProvider is ParameterInfo)
-            {
-                ParameterInfo = (ParameterInfo)attrProvider;
-                ProviderType = AttributeProviderType.ParameterInfo;
-            }
-            else
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(nameof(attrProvider));
-            }
-        }
-
-        private AttributeProviderType ProviderType { get; set; }
-        internal Type Type { get; private set; }
-        internal TypeInfo TypeInfo { get; private set; }
-        internal MemberInfo MemberInfo { get; private set; }
-        internal MethodInfo MethodInfo { get; private set; }
-        internal ParameterInfo ParameterInfo { get; private set; }
-
-        public object[] GetCustomAttributes(bool inherit)
-        {
-            switch (ProviderType)
-            {
-                case AttributeProviderType.Type:
-                    return Type.GetTypeInfo().GetCustomAttributes(inherit).ToArray();
-                case AttributeProviderType.MethodInfo:
-                    return MethodInfo.GetCustomAttributes(inherit).ToArray();
-                case AttributeProviderType.MemberInfo:
-                    return MemberInfo.GetCustomAttributes(inherit).ToArray();
-                case AttributeProviderType.ParameterInfo:
-                    // ParameterInfo.GetCustomAttributes can return null instead of an empty enumerable
-                    return ParameterInfo.GetCustomAttributes(inherit)?.ToArray();
-            }
-            Contract.Assert(false, "This should never execute.");
-            throw new InvalidOperationException();
-        }
-
-        public object[] GetCustomAttributes(Type attributeType, bool inherit)
-        {
-            var attributes = GetCustomAttributes(inherit);
+            var attributes = provider.GetCustomAttributes(inherit);
             if (attributes == null || attributes.Length == 0)
                 return attributes;
 
@@ -328,43 +274,6 @@ namespace CoreWCF.Description
                 Fx.Assert(propInfo != null, $"Could not find property with name {propName} of type {typeof(TProp).FullName} on object of type {obj.GetType().FullName}");
                 return (TProp)propInfo.GetValue(obj);
             }
-        }
-
-        public bool IsDefined(Type attributeType, bool inherit)
-        {
-            switch (ProviderType)
-            {
-                case AttributeProviderType.Type:
-                    return Type.GetTypeInfo().IsDefined(attributeType, inherit);
-                case AttributeProviderType.MethodInfo:
-                    return MethodInfo.IsDefined(attributeType, inherit);
-                case AttributeProviderType.MemberInfo:
-                    return MemberInfo.IsDefined(attributeType, inherit);
-                case AttributeProviderType.ParameterInfo:
-                    return ParameterInfo.IsDefined(attributeType, inherit);
-            }
-            Contract.Assert(false, "This should never execute.");
-            throw new InvalidOperationException();
-        }
-
-        public static implicit operator CustomAttributeProvider(MemberInfo attrProvider)
-        {
-            return new CustomAttributeProvider(attrProvider);
-        }
-
-        public static implicit operator CustomAttributeProvider(MethodInfo attrProvider)
-        {
-            return new CustomAttributeProvider(attrProvider);
-        }
-
-        public static implicit operator CustomAttributeProvider(ParameterInfo attrProvider)
-        {
-            return new CustomAttributeProvider(attrProvider);
-        }
-
-        public static implicit operator CustomAttributeProvider(Type attrProvider)
-        {
-            return new CustomAttributeProvider(attrProvider);
         }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MessagePartDescription.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MessagePartDescription.cs
@@ -14,7 +14,7 @@ namespace CoreWCF.Description
         //bool hasProtectionLevel;
         MemberInfo memberInfo;
         // TODO: Was ICustomAttributeProvider
-        CustomAttributeProvider additionalAttributesProvider;
+        ICustomAttributeProvider additionalAttributesProvider;
 
         bool multiple;
         //string baseType;
@@ -99,7 +99,7 @@ namespace CoreWCF.Description
 
         internal bool HasProtectionLevel => false;
 
-        internal CustomAttributeProvider AdditionalAttributesProvider
+        internal ICustomAttributeProvider AdditionalAttributesProvider
         {
             get { return additionalAttributesProvider ?? memberInfo; }
             set { additionalAttributesProvider = value; }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceReflector.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceReflector.cs
@@ -357,6 +357,7 @@ namespace CoreWCF.Description
         internal const string SMMessageHeaderAttributeFullName = "System.ServiceModel.MessageHeaderAttribute";
         internal const string SMMessagePropertyAttributeFullName = "System.ServiceModel.MessagePropertyAttribute";
         internal const string SMMessageBodyMemberAttributeFullName = "System.ServiceModel.MessageBodyMemberAttribute";
+        internal const string SMServiceKnownTypeAttributeFullName = "System.ServiceModel.ServiceKnownTypeAttribute";
 
         internal static readonly string CWCFMesssageHeaderAttribute = "CoreWCF.MessageHeaderAttribute";
         internal static readonly string CWCFMesssageHeaderArrayAttribute = "CoreWCF.MessageHeaderArrayAttribute";

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceReflector.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceReflector.cs
@@ -478,16 +478,16 @@ namespace CoreWCF.Description
             return types;
         }
 
-        static internal object[] GetCustomAttributes(CustomAttributeProvider attrProvider, Type attrType)
+        static internal object[] GetCustomAttributes(ICustomAttributeProvider attrProvider, Type attrType)
         {
             return GetCustomAttributes(attrProvider, attrType, false);
         }
 
-        static internal object[] GetCustomAttributes(CustomAttributeProvider attrProvider, Type attrType, bool inherit)
+        static internal object[] GetCustomAttributes(ICustomAttributeProvider attrProvider, Type attrType, bool inherit)
         {
             try
             {
-                return attrProvider.GetCustomAttributes(attrType, inherit) ?? Array.Empty<object>();
+                return attrProvider.GetCustomAttributesWithCompat(attrType, inherit) ?? Array.Empty<object>();
             }
             catch (Exception e)
             {
@@ -507,14 +507,14 @@ namespace CoreWCF.Description
                     }
                 }
 
-                TypeInfo typeInfo = attrProvider.TypeInfo;
-                MethodInfo method = attrProvider.MethodInfo;
-                ParameterInfo param = attrProvider.ParameterInfo;
+                Type type = attrProvider as Type;
+                MethodInfo method = attrProvider as MethodInfo;
+                ParameterInfo param = attrProvider as ParameterInfo;
                 // there is no good way to know if this is a return type attribute
-                if (typeInfo != null)
+                if (type != null)
                 {
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
-                        SR.Format(SR.SFxErrorReflectingOnType2, attrType.Name, typeInfo.Name), e));
+                        SR.Format(SR.SFxErrorReflectingOnType2, attrType.Name, type.Name), e));
                 }
                 else if (method != null)
                 {
@@ -538,7 +538,7 @@ namespace CoreWCF.Description
             }
         }
 
-        static internal T GetFirstAttribute<T>(CustomAttributeProvider attrProvider)
+        static internal T GetFirstAttribute<T>(ICustomAttributeProvider attrProvider)
             where T : class
         {
             Type attrType = typeof(T);
@@ -553,7 +553,7 @@ namespace CoreWCF.Description
             }
         }
 
-        static internal T GetSingleAttribute<T>(CustomAttributeProvider attrProvider) where T : class
+        static internal T GetSingleAttribute<T>(ICustomAttributeProvider attrProvider) where T : class
         {
             Type attrType = typeof(T);
             object[] attrs = GetCustomAttributes(attrProvider, attrType);
@@ -608,7 +608,7 @@ namespace CoreWCF.Description
         //    }
         //}
 
-        static internal T GetRequiredSingleAttribute<T>(CustomAttributeProvider attrProvider)
+        static internal T GetRequiredSingleAttribute<T>(ICustomAttributeProvider attrProvider)
             where T : class
         {
             T result = GetSingleAttribute<T>(attrProvider);
@@ -619,7 +619,7 @@ namespace CoreWCF.Description
             return result;
         }
 
-        static internal T GetSingleAttribute<T>(CustomAttributeProvider attrProvider, Type[] attrTypeGroup)
+        static internal T GetSingleAttribute<T>(ICustomAttributeProvider attrProvider, Type[] attrTypeGroup)
             where T : class
         {
             T result = GetSingleAttribute<T>(attrProvider);
@@ -642,7 +642,7 @@ namespace CoreWCF.Description
             return result;
         }
 
-        static internal T GetRequiredSingleAttribute<T>(CustomAttributeProvider attrProvider, Type[] attrTypeGroup)
+        static internal T GetRequiredSingleAttribute<T>(ICustomAttributeProvider attrProvider, Type[] attrTypeGroup)
             where T : class
         {
             T result = GetSingleAttribute<T>(attrProvider, attrTypeGroup);

--- a/src/CoreWCF.Primitives/src/CoreWCF/ServiceKnownTypeAttribute.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/ServiceKnownTypeAttribute.cs
@@ -5,10 +5,6 @@ namespace CoreWCF
     [AttributeUsage(CoreWCFAttributeTargets.ServiceContract | CoreWCFAttributeTargets.OperationContract, Inherited = true, AllowMultiple = true)]
     public sealed class ServiceKnownTypeAttribute : Attribute
     {
-        //Type _declaringType;
-        //string _methodName;
-        readonly Type _type;
-
         private ServiceKnownTypeAttribute()
         {
             // Disallow default constructor
@@ -16,25 +12,24 @@ namespace CoreWCF
 
         public ServiceKnownTypeAttribute(Type type)
         {
-            _type = type;
+            Type = type;
         }
 
-        // The named method must take a parameter of ICustomAttributeProvider which isn't available so this overload can't be used
-        //public ServiceKnownTypeAttribute(string methodName)
-        //{
-        //    _methodName = methodName;
-        //}
+        public ServiceKnownTypeAttribute(string methodName)
+        {
+            MethodName = methodName;
+        }
 
-        //public ServiceKnownTypeAttribute(string methodName, Type declaringType)
-        //{
-        //    _methodName = methodName;
-        //    _declaringType = declaringType;
-        //}
+        public ServiceKnownTypeAttribute(string methodName, Type declaringType)
+        {
+            MethodName = methodName;
+            DeclaringType = declaringType;
+        }
 
-        //public Type DeclaringType => _declaringType;
+        public Type DeclaringType { get; }
 
-        //public string MethodName => _methodName;
+        public string MethodName { get; }
 
-        public Type Type => _type;
+        public Type Type { get; }
     }
 }


### PR DESCRIPTION
Allows using System.ServiceModel.ServiceKnownType attribute on a service side contract to support reusing the same contract on client and server.