### PR TITLE
Empty HTTP requests to active endpoints should respond per WCF

### DIFF
--- a/src/Common/tests/Helpers/XunitLogger.cs
+++ b/src/Common/tests/Helpers/XunitLogger.cs
@@ -23,9 +23,9 @@ namespace Helpers
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            _testOutputHelper.WriteLine($"{_categoryName} [{eventId}] {formatter(state, exception)}");
+            _testOutputHelper?.WriteLine($"{_categoryName} [{eventId}] {formatter(state, exception)}");
             if (exception != null)
-                _testOutputHelper.WriteLine(exception.ToString());
+                _testOutputHelper?.WriteLine(exception.ToString());
         }
 
         private class NoopDisposable : IDisposable

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
@@ -99,7 +99,8 @@ namespace CoreWCF.Channels
             var requestContext = HttpRequestContext.CreateContext(_httpSettings, context);
             var httpInput = requestContext.GetHttpInput(true);
 
-            if(httpInput.ContentLength == -1)
+            // FIXME: this is equivalent to !httpInput.HasContent, which is protected, but could be public?
+            if(httpInput.ContentLength == -1 && !httpInput.IsStreamed)
             {
                 await requestContext.SendResponseAndCloseAsync(HttpStatusCode.BadRequest);
                 return;

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -97,6 +98,13 @@ namespace CoreWCF.Channels
 
             var requestContext = HttpRequestContext.CreateContext(_httpSettings, context);
             var httpInput = requestContext.GetHttpInput(true);
+
+            if(httpInput.ContentLength == -1)
+            {
+                await requestContext.SendResponseAndCloseAsync(HttpStatusCode.BadRequest);
+                return;
+            }
+
             (Message requestMessage, Exception requestException) = await httpInput.ParseIncomingMessageAsync();
             if ((requestMessage == null) && (requestException == null))
             {

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs
@@ -38,6 +38,8 @@ namespace CoreWCF.Channels
         private bool enableChannelBinding;
         private bool errorGettingInputStream;
 
+        internal bool IsStreamed => streamed;
+
         protected HttpInput(IHttpTransportFactorySettings settings, bool isRequest, bool enableChannelBinding)
         {
             this.settings = settings;

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -8,17 +8,18 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
   </ItemGroup>

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -1,11 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">
@@ -26,5 +29,15 @@
   <ItemGroup>
     <ProjectReference Include="..\..\CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />
     <ProjectReference Include="..\src\CoreWCF.Http.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing">
+      <Version>2.2.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing">
+      <Version>3.1.7</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
@@ -77,7 +77,7 @@ namespace Helpers
         //    };
         //}
 
-        public static IWebHostBuilder CreateWebHostBuilder<TStartup>(ITestOutputHelper outputHelper) where TStartup : class =>
+        public static IWebHostBuilder CreateWebHostBuilder<TStartup>(ITestOutputHelper outputHelper = default) where TStartup : class =>
             WebHost.CreateDefaultBuilder(new string[0])
 #if DEBUG
             .ConfigureLogging((ILoggingBuilder logging) =>
@@ -89,15 +89,16 @@ namespace Helpers
             })
 #endif // DEBUG
             .UseKestrel(options =>
+            {
+                options.AllowSynchronousIO = true;
+                options.Listen(IPAddress.Loopback, 8080, listenOptions =>
                 {
-                    options.Listen(IPAddress.Loopback, 8080, listenOptions =>
+                    if (Debugger.IsAttached)
                     {
-                        if (Debugger.IsAttached)
-                        {
-                            listenOptions.UseConnectionLogging();
-                        }
-                    });
-                })
+                        listenOptions.UseConnectionLogging();
+                    }
+                });
+            })
             .UseUrls("http://localhost:8080")
             .UseStartup<TStartup>();
 

--- a/src/CoreWCF.Http/tests/IntegrationTests/HttpClientTests.cs
+++ b/src/CoreWCF.Http/tests/IntegrationTests/HttpClientTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CoreWCF.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using ServiceContract;
+using Services;
+using Xunit;
+using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+
+namespace CoreWCF.Http.Tests.IntegrationTests
+{
+    public class HttpClientTests : IClassFixture<IntegrationTest<HttpClientTests.Startup>>
+    {
+        private readonly IntegrationTest<Startup> _factory;
+
+        public HttpClientTests(IntegrationTest<Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task BasicHttpClientBadRequestWhenBodyIsEmpty()
+        {
+            var client = _factory.CreateClient();
+            var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost:8080/BasicWcfService/basichttp.svc", UriKind.Absolute));
+            var response = await client.SendAsync(request);
+            Assert.True(response.StatusCode == HttpStatusCode.BadRequest);
+        }
+
+        public class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<EchoService>();
+                    builder.AddServiceEndpoint<EchoService, IEchoService>(new BasicHttpBinding(), "/BasicWcfService/basichttp.svc");
+                });
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Http/tests/IntegrationTests/IntegrationTest.cs
+++ b/src/CoreWCF.Http/tests/IntegrationTests/IntegrationTest.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+using Helpers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+
+namespace CoreWCF.Http.Tests.IntegrationTests
+{
+    public class IntegrationTest<TStartup> : WebApplicationFactory<TStartup> where TStartup : class
+    {
+        protected override TestServer CreateServer(IWebHostBuilder builder)
+        {       
+            var addresses = new ServerAddressesFeature();
+            var features = new FeatureCollection();
+            features.Set<IServerAddressesFeature>(addresses); 
+
+            var server = new TestServer(builder, features);
+#if NETCOREAPP3_1
+            server.AllowSynchronousIO = true;
+#endif
+            return server;
+        }
+
+        protected override IWebHostBuilder CreateWebHostBuilder()
+        {
+            var contentRoot = Directory.GetCurrentDirectory();
+
+            var assemblyName = typeof(IntegrationTest<TStartup>).Assembly.GetName().Name;
+            var settingSuffix = assemblyName.ToUpperInvariant().Replace(".", "_");
+            var settingName = $"ASPNETCORE_TEST_CONTENTROOT_{settingSuffix}";
+            Environment.SetEnvironmentVariable(settingName, contentRoot);
+
+            return ServiceHelper.CreateWebHostBuilder<TStartup>();
+        }
+    }
+}

--- a/src/CoreWCF.Http/tests/Program.cs
+++ b/src/CoreWCF.Http/tests/Program.cs
@@ -1,0 +1,5 @@
+﻿namespace CoreWCF.Http.Tests
+{
+    // Required because <GenerateProgramFile> is set to false to accommodate multiple test SDK versions
+    public class Program { public static void Main(params string[] args) { } }
+}

--- a/src/CoreWCF.Http/tests/SimpleTest.cs
+++ b/src/CoreWCF.Http/tests/SimpleTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using CoreWCF.Configuration;
 using Helpers;
@@ -57,6 +59,15 @@ namespace BasicHttp
                 Assert.Equal(testString, result);
                 Assert.True(StartupWithConfiguration.ConfigureServiceHostValid);
             }
+        }
+
+        [Fact]
+        public async Task BasicHttpClientBadRequestWhenBodyIsEmpty()
+        {
+            var client = new HttpClient();
+            var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost:8080/BasicWcfService/basichttp.svc", UriKind.Absolute));
+            var response = await client.SendAsync(request);
+            Assert.True(response.StatusCode == HttpStatusCode.BadRequest);
         }
 
         internal class Startup

--- a/src/CoreWCF.Http/tests/SimpleTest.cs
+++ b/src/CoreWCF.Http/tests/SimpleTest.cs
@@ -61,15 +61,6 @@ namespace BasicHttp
             }
         }
 
-        [Fact]
-        public async Task BasicHttpClientBadRequestWhenBodyIsEmpty()
-        {
-            var client = new HttpClient();
-            var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost:8080/BasicWcfService/basichttp.svc", UriKind.Absolute));
-            var response = await client.SendAsync(request);
-            Assert.True(response.StatusCode == HttpStatusCode.BadRequest);
-        }
-
         internal class Startup
         {
             public void ConfigureServices(IServiceCollection services)

--- a/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
+++ b/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
@@ -128,14 +128,25 @@ namespace CoreWCF.NetTcp.Tests
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
                         new System.ServiceModel.EndpointAddress(new Uri(WindowsAuthNetTcpServiceUri)));
                     channel = factory.CreateChannel();
+                    
+                    // ReSharper disable once SuspiciousTypeConversion.Global
                     ((IChannel)channel).Open();
+
                     var result = channel.EchoForPermission(sourceString);
                     Assert.Equal(sourceString, result);
-                    ((IChannel)channel).Close();
-                    factory.Close();
+
+                    //
+                    // These were explicitly removed because the ServiceHelper already cleans these up, and
+                    // in some cases not using proper disposal handling will result in:
+                    // 'System.IO.IOException : Received an unexpected EOF or 0 bytes from the transport stream.'
+                    // on the build server, causing false test failures.
+                    //
+                    // ((IChannel)channel).Close();
+                    // factory.Close();
                 }
                 finally
                 {
+                    // ReSharper disable once SuspiciousTypeConversion.Global
                     ServiceHelper.CloseServiceModelObjects((IChannel)channel, factory);
                 }
             }


### PR DESCRIPTION
This PR adds `HttpClient` based integration testing capability, and uses it to verify a patch to make CoreWCF respond the same way as WCF when an HTTP request to an active service endpoint is empty. It currently attempts to parse a SOAP message and crashes, rather than send a terminal `400 Bad Request`, as per WCF.