### PR TITLE
nit: IServiceBuilder chaining

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/IServiceBuilder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/IServiceBuilder.cs
@@ -9,16 +9,17 @@ namespace CoreWCF.Configuration
     {
         ICollection<Type> Services { get; }
         ICollection<Uri> BaseAddresses { get; }
-        void AddService<TService>() where TService : class;
-        void AddService(Type service);
-        void AddServiceEndpoint<TService, TContract>(Binding binding, string address);
-        void AddServiceEndpoint<TService, TContract>(Binding binding, Uri address);
-        void AddServiceEndpoint<TService, TContract>(Binding binding, string address, Uri listenUri);
-        void AddServiceEndpoint<TService, TContract>(Binding binding, Uri address, Uri listenUri);
-        void AddServiceEndpoint<TService>(Type implementedContract, Binding binding, string address);
-        void AddServiceEndpoint<TService>(Type implementedContract, Binding binding, Uri address);
-        void AddServiceEndpoint<TService>(Type implementedContract, Binding binding, string address, Uri listenUri);
-        void AddServiceEndpoint<TService>(Type implementedContract, Binding binding, Uri address, Uri listenUri);
-        void AddServiceEndpoint(Type service, Type implementedContract, Binding binding, Uri address, Uri listenUri);
+
+        IServiceBuilder AddService<TService>() where TService : class;
+        IServiceBuilder AddService(Type service);
+        IServiceBuilder AddServiceEndpoint<TService, TContract>(Binding binding, string address);
+        IServiceBuilder AddServiceEndpoint<TService, TContract>(Binding binding, Uri address);
+        IServiceBuilder AddServiceEndpoint<TService, TContract>(Binding binding, string address, Uri listenUri);
+        IServiceBuilder AddServiceEndpoint<TService, TContract>(Binding binding, Uri address, Uri listenUri);
+        IServiceBuilder AddServiceEndpoint<TService>(Type implementedContract, Binding binding, string address);
+        IServiceBuilder AddServiceEndpoint<TService>(Type implementedContract, Binding binding, Uri address);
+        IServiceBuilder AddServiceEndpoint<TService>(Type implementedContract, Binding binding, string address, Uri listenUri);
+        IServiceBuilder AddServiceEndpoint<TService>(Type implementedContract, Binding binding, Uri address, Uri listenUri);
+        IServiceBuilder AddServiceEndpoint(Type service, Type implementedContract, Binding binding, Uri address, Uri listenUri);
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilder.cs
@@ -23,12 +23,12 @@ namespace CoreWCF.Configuration
 
         public IServiceProvider ServiceProvider => _serviceProvider;
 
-        public void AddService<TService>() where TService : class
+        public IServiceBuilder AddService<TService>() where TService : class
         {
-            AddService(typeof(TService));
+            return AddService(typeof(TService));
         }
 
-        public void AddService(Type service)
+        public IServiceBuilder AddService(Type service)
         {
             if (service is null)
             {
@@ -37,54 +37,55 @@ namespace CoreWCF.Configuration
             var serviceConfig = (IServiceConfiguration)_serviceProvider.GetRequiredService(
                 typeof(IServiceConfiguration<>).MakeGenericType(service));
             _services[serviceConfig.ServiceType] = serviceConfig;
+            return this;
         }
 
-        public void AddServiceEndpoint<TService, TContract>(Binding binding, string address)
+        public IServiceBuilder AddServiceEndpoint<TService, TContract>(Binding binding, string address)
         {
-            AddServiceEndpoint<TService>(typeof(TContract), binding, address);
+            return AddServiceEndpoint<TService>(typeof(TContract), binding, address);
         }
 
-        public void AddServiceEndpoint<TService, TContract>(Binding binding, Uri address)
+        public IServiceBuilder AddServiceEndpoint<TService, TContract>(Binding binding, Uri address)
         {
-            AddServiceEndpoint<TService>(typeof(TContract), binding, address);
+            return AddServiceEndpoint<TService>(typeof(TContract), binding, address);
         }
 
-        public void AddServiceEndpoint<TService, TContract>(Binding binding, string address, Uri listenUri)
+        public IServiceBuilder AddServiceEndpoint<TService, TContract>(Binding binding, string address, Uri listenUri)
         {
-            AddServiceEndpoint<TService>(typeof(TContract), binding, address, listenUri);
+            return AddServiceEndpoint<TService>(typeof(TContract), binding, address, listenUri);
         }
 
-        public void AddServiceEndpoint<TService, TContract>(Binding binding, Uri address, Uri listenUri)
+        public IServiceBuilder AddServiceEndpoint<TService, TContract>(Binding binding, Uri address, Uri listenUri)
         {
-            AddServiceEndpoint<TService>(typeof(TContract), binding, address, listenUri);
+            return AddServiceEndpoint<TService>(typeof(TContract), binding, address, listenUri);
         }
 
-        public void AddServiceEndpoint<TService>(Type implementedContract, Binding binding, string address)
+        public IServiceBuilder AddServiceEndpoint<TService>(Type implementedContract, Binding binding, string address)
         {
-            AddServiceEndpoint<TService>(implementedContract, binding, address, (Uri)null);
+            return AddServiceEndpoint<TService>(implementedContract, binding, address, (Uri)null);
         }
 
-        public void AddServiceEndpoint<TService>(Type implementedContract, Binding binding, Uri address)
+        public IServiceBuilder AddServiceEndpoint<TService>(Type implementedContract, Binding binding, Uri address)
         {
-            AddServiceEndpoint<TService>(implementedContract, binding, address, (Uri)null);
+            return AddServiceEndpoint<TService>(implementedContract, binding, address, (Uri)null);
         }
 
-        public void AddServiceEndpoint<TService>(Type implementedContract, Binding binding, string address, Uri listenUri)
+        public IServiceBuilder AddServiceEndpoint<TService>(Type implementedContract, Binding binding, string address, Uri listenUri)
         {
             if (address is null)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentNullException(nameof(address)));
             }
 
-            AddServiceEndpoint<TService>(implementedContract, binding, new Uri(address, UriKind.RelativeOrAbsolute), listenUri);
+            return AddServiceEndpoint<TService>(implementedContract, binding, new Uri(address, UriKind.RelativeOrAbsolute), listenUri);
         }
 
-        public void AddServiceEndpoint<TService>(Type implementedContract, Binding binding, Uri address, Uri listenUri)
+        public IServiceBuilder AddServiceEndpoint<TService>(Type implementedContract, Binding binding, Uri address, Uri listenUri)
         {
-            AddServiceEndpoint(typeof(TService), implementedContract, binding, address, listenUri);
+            return AddServiceEndpoint(typeof(TService), implementedContract, binding, address, listenUri);
         }
 
-        public void AddServiceEndpoint(Type service, Type implementedContract, Binding binding, Uri address, Uri listenUri)
+        public IServiceBuilder AddServiceEndpoint(Type service, Type implementedContract, Binding binding, Uri address, Uri listenUri)
         {
             if (service is null)
             {
@@ -116,6 +117,8 @@ namespace CoreWCF.Configuration
                 // TODO: Either find an existing SR to use or create a new one.
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentException(nameof(service)));
             }
+
+            return this;
         }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/InternalsVisibleTo.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/InternalsVisibleTo.cs
@@ -1,0 +1,9 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("CoreWCF.Primitives.Tests")]
+
+namespace CoreWCF
+{
+    // ReSharper disable once UnusedMember.Global
+    internal sealed class InternalsVisibleTo { }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/InternalsVisibleTo.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/InternalsVisibleTo.cs
@@ -1,9 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly:InternalsVisibleTo("CoreWCF.Primitives.Tests")]
-
-namespace CoreWCF
-{
-    // ReSharper disable once UnusedMember.Global
-    internal sealed class InternalsVisibleTo { }
-}

--- a/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
@@ -12,6 +12,7 @@ namespace CoreWCF.Primitives.Tests
         public void ServiceBuilderCanChain()
         {
             var services = new ServiceCollection();
+            services.AddServiceModelServices();
             var serviceProvider = services.BuildServiceProvider();
             var builder = new ServiceBuilder(serviceProvider);
             

--- a/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
@@ -14,7 +14,7 @@ namespace CoreWCF.Primitives.Tests
             var services = new ServiceCollection();
             services.AddServiceModelServices();
             var serviceProvider = services.BuildServiceProvider();
-            var builder = new ServiceBuilder(serviceProvider);
+            var builder = serviceProvider.GetRequiredService<IServiceBuilder>();
             
             Assert.Equal(builder, builder.AddService<SomeService>());
             Assert.Equal(builder, builder.AddService(typeof(SomeService)));

--- a/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using CoreWCF.Channels;
+using CoreWCF.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace CoreWCF.Primitives.Tests
+{
+    public class ServiceBuilderTests
+    {
+        [Fact]
+        public void ServiceBuilderCanChain()
+        {
+            var services = new ServiceCollection();
+            var serviceProvider = services.BuildServiceProvider();
+            var builder = new ServiceBuilder(serviceProvider);
+            
+            Assert.Equal(builder, builder.AddService<SomeService>());
+            Assert.Equal(builder, builder.AddService(typeof(SomeService)));
+            Assert.Equal(builder, builder.AddServiceEndpoint<SomeService, IService>(new NoBinding(), new Uri("http://localhost:8088/SomeService.svc")));
+            Assert.Equal(builder, builder.AddServiceEndpoint<SomeService, IService>(new NoBinding(), "http://localhost:8088/SomeService.svc"));
+            Assert.Equal(builder, builder.AddServiceEndpoint<SomeService>(typeof(IService), new NoBinding(), new Uri("http://localhost:8088/SomeService.svc")));
+            Assert.Equal(builder, builder.AddServiceEndpoint<SomeService>(typeof(IService), new NoBinding(), "http://localhost:8088/SomeService.svc"));
+        }
+
+        public class SomeService : IService { }
+
+        public class NoBinding : Binding
+        {
+            public override string Scheme => "none";
+            public override BindingElementCollection CreateBindingElements()
+            {
+                return new BindingElementCollection();
+            }
+        }
+    }
+}

--- a/src/Samples/NetCoreServer/Startup.cs
+++ b/src/Samples/NetCoreServer/Startup.cs
@@ -12,14 +12,15 @@ namespace NetCoreServer
         {
             services.AddServiceModelServices();
         }
-
+        
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseServiceModel(builder =>
             {
-                builder.AddService<EchoService>();
-                builder.AddServiceEndpoint<EchoService, Contract.IEchoService>(new BasicHttpBinding(), "/basichttp");
-                builder.AddServiceEndpoint<EchoService, Contract.IEchoService>(new NetTcpBinding(), "/nettcp");
+                builder
+                    .AddService<EchoService>()
+                    .AddServiceEndpoint<EchoService, Contract.IEchoService>(new BasicHttpBinding(), "/basichttp")
+                    .AddServiceEndpoint<EchoService, Contract.IEchoService>(new NetTcpBinding(), "/nettcp");
             });
         }
     }


### PR DESCRIPTION
nit: Change `IServiceBuilder` interface to match other official .NET Core APIs that use the builder to "chain" method calls configuring the same scope of services.