### PR TITLE
Fix builder errors caused by `Microsoft.Test.Sdk` version `16.4.0` in VS 2019

### DIFF
--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -8,11 +8,11 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -8,11 +8,11 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
+++ b/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
@@ -128,14 +128,25 @@ namespace CoreWCF.NetTcp.Tests
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
                         new System.ServiceModel.EndpointAddress(new Uri(WindowsAuthNetTcpServiceUri)));
                     channel = factory.CreateChannel();
+                    
+                    // ReSharper disable once SuspiciousTypeConversion.Global
                     ((IChannel)channel).Open();
+
                     var result = channel.EchoForPermission(sourceString);
                     Assert.Equal(sourceString, result);
-                    ((IChannel)channel).Close();
-                    factory.Close();
+
+                    //
+                    // These were explicitly removed because the ServiceHelper already cleans these up, and
+                    // in some cases not using proper disposal handling will result in:
+                    // 'System.IO.IOException : Received an unexpected EOF or 0 bytes from the transport stream.'
+                    // on the build server, causing false test failures.
+                    //
+                    // ((IChannel)channel).Close();
+                    // factory.Close();
                 }
                 finally
                 {
+                    // ReSharper disable once SuspiciousTypeConversion.Global
                     ServiceHelper.CloseServiceModelObjects((IChannel)channel, factory);
                 }
             }

--- a/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
+++ b/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
@@ -128,25 +128,14 @@ namespace CoreWCF.NetTcp.Tests
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
                         new System.ServiceModel.EndpointAddress(new Uri(WindowsAuthNetTcpServiceUri)));
                     channel = factory.CreateChannel();
-                    
-                    // ReSharper disable once SuspiciousTypeConversion.Global
                     ((IChannel)channel).Open();
-
                     var result = channel.EchoForPermission(sourceString);
                     Assert.Equal(sourceString, result);
-
-                    //
-                    // These were explicitly removed because the ServiceHelper already cleans these up, and
-                    // in some cases not using proper disposal handling will result in:
-                    // 'System.IO.IOException : Received an unexpected EOF or 0 bytes from the transport stream.'
-                    // on the build server, causing false test failures.
-                    //
-                    // ((IChannel)channel).Close();
-                    // factory.Close();
+                    ((IChannel)channel).Close();
+                    factory.Close();
                 }
                 finally
                 {
-                    // ReSharper disable once SuspiciousTypeConversion.Global
                     ServiceHelper.CloseServiceModelObjects((IChannel)channel, factory);
                 }
             }

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
   </ItemGroup>

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -8,11 +8,11 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- In this SDK, MSBuild parameter `GenerateProgramFile` is not test to `true` by default, but recent builds of VS2019 expect it
- End result is `Program does not contain a static 'Main' method suitable for an entry point`
- updating the SDK results in no other changes required to fix the build in recent updates of VS2019