### PR TITLE
Add in-memory integration test harness and example test

### DIFF
--- a/src/CoreWCF.Http/src/CoreWCF/Channels/HttpRequestContext.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/HttpRequestContext.cs
@@ -471,8 +471,12 @@ namespace CoreWCF.Channels
 
                     var remoteIPAddress = request.HttpContext.Connection.RemoteIpAddress;
                     var remotePort = request.HttpContext.Connection.RemotePort;
-                    RemoteEndpointMessageProperty remoteEndpointProperty = new RemoteEndpointMessageProperty(new IPEndPoint(remoteIPAddress, remotePort));
-                    message.Properties.Add(RemoteEndpointMessageProperty.Name, remoteEndpointProperty);
+
+                    if (remoteIPAddress != null)
+                    {
+                        RemoteEndpointMessageProperty remoteEndpointProperty = new RemoteEndpointMessageProperty(new IPEndPoint(remoteIPAddress, remotePort));
+                        message.Properties.Add(RemoteEndpointMessageProperty.Name, remoteEndpointProperty);
+                    }
                 }
 
                 protected override Stream GetInputStream()

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -6,18 +6,24 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+
+    <!-- Required for multi-framework support for in-memory integration testing-->
+    <OutputType>Exe</OutputType>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
@@ -26,4 +32,15 @@
     <ProjectReference Include="..\..\CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />
     <ProjectReference Include="..\src\CoreWCF.Http.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing">
+      <Version>3.1.7</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing">
+      <Version>2.2.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/CoreWCF.Http/tests/Helpers/IntegrationTest.cs
+++ b/src/CoreWCF.Http/tests/Helpers/IntegrationTest.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using Helpers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+
+namespace CoreWCF.Http.Tests.Helpers
+{
+    /// <summary>
+    /// Enables in-memory integration testing for CoreWCF (outside-in testing via <see cref="HttpClient"/>).
+    ///
+    /// Use these tests to exercise the entire HTTP stack, rather than create in-process ServiceModel channels.
+    /// 
+    /// <see href="https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-3.1"/>
+    /// <seealso href="https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-2.1"/>
+    /// </summary>
+    /// <typeparam name="TStartup"></typeparam>
+    public class IntegrationTest<TStartup> : WebApplicationFactory<TStartup> where TStartup : class
+    {
+        protected override TestServer CreateServer(IWebHostBuilder builder)
+        {       
+            var addresses = new ServerAddressesFeature();
+            var features = new FeatureCollection();
+            features.Set<IServerAddressesFeature>(addresses); 
+
+            var server = new TestServer(builder, features);
+#if NETCOREAPP3_1
+            server.AllowSynchronousIO = true;
+#endif
+            return server;
+        }
+
+        protected override IWebHostBuilder CreateWebHostBuilder()
+        {
+            SetSelfHostedContentRoot();
+
+            return ServiceHelper.CreateWebHostBuilder<TStartup>();
+        }
+
+        private static void SetSelfHostedContentRoot()
+        {
+            var contentRoot = Directory.GetCurrentDirectory();
+            var assemblyName = typeof(IntegrationTest<TStartup>).Assembly.GetName().Name;
+            var settingSuffix = assemblyName.ToUpperInvariant().Replace(".", "_");
+            var settingName = $"ASPNETCORE_TEST_CONTENTROOT_{settingSuffix}";
+            Environment.SetEnvironmentVariable(settingName, contentRoot);
+        }
+    }
+}

--- a/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
@@ -77,19 +77,21 @@ namespace Helpers
         //    };
         //}
 
-        public static IWebHostBuilder CreateWebHostBuilder<TStartup>(ITestOutputHelper outputHelper) where TStartup : class =>
+        public static IWebHostBuilder CreateWebHostBuilder<TStartup>(ITestOutputHelper outputHelper = default) where TStartup : class =>
             WebHost.CreateDefaultBuilder(new string[0])
 #if DEBUG
             .ConfigureLogging((ILoggingBuilder logging) =>
             {
-                logging.AddProvider(new XunitLoggerProvider(outputHelper));
+                if(outputHelper != default)
+                    logging.AddProvider(new XunitLoggerProvider(outputHelper));
                 logging.AddFilter("Default", LogLevel.Debug);
                 logging.AddFilter("Microsoft", LogLevel.Debug);
                 logging.SetMinimumLevel(LogLevel.Debug);
             })
 #endif // DEBUG
             .UseKestrel(options =>
-                {
+            {
+                    options.AllowSynchronousIO = true;
                     options.Listen(IPAddress.Loopback, 8080, listenOptions =>
                     {
                         if (Debugger.IsAttached)
@@ -101,12 +103,13 @@ namespace Helpers
             .UseUrls("http://localhost:8080")
             .UseStartup<TStartup>();
 
-        public static IWebHostBuilder CreateHttpsWebHostBuilder<TStartup>(ITestOutputHelper outputHelper) where TStartup : class =>
+        public static IWebHostBuilder CreateHttpsWebHostBuilder<TStartup>(ITestOutputHelper outputHelper = default) where TStartup : class =>
             WebHost.CreateDefaultBuilder(new string[0])
 #if DEBUG
             .ConfigureLogging((ILoggingBuilder logging) =>
             {
-                logging.AddProvider(new XunitLoggerProvider(outputHelper));
+                if(outputHelper != default)
+                    logging.AddProvider(new XunitLoggerProvider(outputHelper));
                 logging.AddFilter("Default", LogLevel.Debug);
                 logging.AddFilter("Microsoft", LogLevel.Debug);
                 logging.SetMinimumLevel(LogLevel.Debug);

--- a/src/CoreWCF.Http/tests/HttpClientTests.cs
+++ b/src/CoreWCF.Http/tests/HttpClientTests.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Net.Http;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using CoreWCF.Configuration;
+using CoreWCF.Http.Tests.Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+
+namespace CoreWCF.Http.Tests
+{
+    public class HttpClientTests : IClassFixture<IntegrationTest<HttpClientTests.Startup>>
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly IntegrationTest<Startup> _factory;
+
+        public HttpClientTests(ITestOutputHelper output, IntegrationTest<Startup> factory)
+        {
+            _output = output;
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task EchoServiceRespondsSuccessfullyWhenRequestIsValid()
+        {
+            //
+            // FIXME:
+            // - Pre-read buffer breaks message parsing when Transfer-Encoding is set to chunked (removes first byte)
+            // - When a message is invalid, but no error is thrown, message reply crashes because a null message is passed to the Close channel
+            //
+
+            var client = _factory.CreateClient();
+            const string action = "http://tempuri.org/IEchoService/Echo";
+            
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri("http://localhost:8080/BasicWcfService/basichttp.svc", UriKind.Absolute));
+            request.Headers.TryAddWithoutValidation("SOAPAction", $"\"{action}\"");
+
+            const string requestBody = @"<s:Envelope xmlns:s=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:tem=""http://tempuri.org/"">
+   <s:Header/>
+   <s:Body>
+      <tem:Echo>
+         <tem:text>A</tem:text>
+      </tem:Echo>
+   </s:Body>
+</s:Envelope>";
+            
+            request.Content = new StringContent(requestBody, Encoding.UTF8, "text/xml");
+
+            // FIXME: Commenting out this line will induce a chunked response, which will break the pre-read message parser
+            request.Content.Headers.ContentLength = Encoding.UTF8.GetByteCount(requestBody);
+
+            var response = await client.SendAsync(request);
+            Assert.True(response.IsSuccessStatusCode);
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            _output.WriteLine(responseBody);
+
+            const string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+                                    "<s:Body>" +
+                                    "<EchoResponse xmlns=\"http://tempuri.org/\">" +
+                                    "<EchoResult>A</EchoResult>" +
+                                    "</EchoResponse>" +
+                                    "</s:Body>" +
+                                    "</s:Envelope>";
+
+            Assert.Equal(expected, responseBody);
+        }
+
+        #region Fixtures
+
+        public class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<EchoService>();
+                    builder.AddServiceEndpoint<EchoService, IEchoService>(new BasicHttpBinding(), "/BasicWcfService/basichttp.svc");
+                });
+            }
+        }
+
+        [ServiceContract]
+        public interface IEchoService
+        {
+            [OperationContract]
+            string Echo(string text);
+        }
+
+        [DataContract]
+        public class EchoMessage
+        {
+            [DataMember]
+            public string Text { get; set; }
+        }
+
+        public class EchoService : IEchoService
+        {
+            public string Echo(string text)
+            {
+                Console.WriteLine($"Received {text} from client!");
+                return text;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/CoreWCF.Http/tests/Program.cs
+++ b/src/CoreWCF.Http/tests/Program.cs
@@ -1,0 +1,9 @@
+﻿namespace CoreWCF.Http.Tests
+{
+    /// <summary>
+    /// Required because `<GenerateProgramFile />` is set to `false` to
+    /// accommodate differences in behavior between `netcoreapp2.1` and
+    /// `netcoreapp3.1`
+    /// </summary> 
+    internal static class Program { public static void Main(params string[] args) { } }
+}

--- a/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
+++ b/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
@@ -128,14 +128,25 @@ namespace CoreWCF.NetTcp.Tests
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
                         new System.ServiceModel.EndpointAddress(new Uri(WindowsAuthNetTcpServiceUri)));
                     channel = factory.CreateChannel();
+                    
+                    // ReSharper disable once SuspiciousTypeConversion.Global
                     ((IChannel)channel).Open();
+
                     var result = channel.EchoForPermission(sourceString);
                     Assert.Equal(sourceString, result);
-                    ((IChannel)channel).Close();
-                    factory.Close();
+
+                    //
+                    // These were explicitly removed because the ServiceHelper already cleans these up, and
+                    // in some cases not using proper disposal handling will result in:
+                    // 'System.IO.IOException : Received an unexpected EOF or 0 bytes from the transport stream.'
+                    // on the build server, causing false test failures.
+                    //
+                    // ((IChannel)channel).Close();
+                    // factory.Close();
                 }
                 finally
                 {
+                    // ReSharper disable once SuspiciousTypeConversion.Global
                     ServiceHelper.CloseServiceModelObjects((IChannel)channel, factory);
                 }
             }


### PR DESCRIPTION
This PR adds the ability to test using `HttpClient` against an in-memory service.

This is important for our testing process as we can now perform "left-to-right' comparison of request/response data between the native WCF service and CoreWCF.

An example test shows a basic request/reply. During the creation of the test we were able to find one bug which is fixed, and two bugs which we will investigate further, and for which reproduction unit tests are now possible.