### PR TITLE
Fix #218: Add port auto-assignment feature for `net.tcp` and use it for unit tests

### DIFF
--- a/src/CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj
+++ b/src/CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.7" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
   </ItemGroup>

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Configuration/ServiceModelWebHostBuilderExtensions.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Configuration/ServiceModelWebHostBuilderExtensions.cs
@@ -1,16 +1,16 @@
 ﻿using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using CoreWCF.Channels.Framing;
 using System;
 using System.Collections.Generic;
 using System.Net;
-using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.Extensions.Logging;
 
 namespace CoreWCF.Configuration
 {

--- a/src/CoreWCF.NetTcp/tests/ConnectionHandlerBufferedModeTests.cs
+++ b/src/CoreWCF.NetTcp/tests/ConnectionHandlerBufferedModeTests.cs
@@ -15,9 +15,6 @@ namespace ConnectionHandler
 {
     public class ConnectionHandlerBufferedModeTests
     {
-        private const string NetTcpServiceBaseUri = "net.tcp://localhost:8808";
-        private const string WindowsAuthNetTcpServiceUri = NetTcpServiceBaseUri + Startup.WindowsAuthRelativePath;
-        private const string NoAuthNetTcpServiceUri = NetTcpServiceBaseUri + Startup.NoSecurityRelativePath;
         private ITestOutputHelper _output;
 
         public ConnectionHandlerBufferedModeTests(ITestOutputHelper output)
@@ -40,7 +37,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetBufferedModeBinding(System.ServiceModel.SecurityMode.Transport);
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(WindowsAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.WindowsAuthRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var result = channel.EchoString(testString);
@@ -69,7 +66,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetBufferedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(NoAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.NoSecurityRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var result = channel.EchoString(testString);
@@ -98,7 +95,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetBufferedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(NoAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.NoSecurityRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var result = channel.EchoString(testString);
@@ -131,7 +128,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetBufferedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(NoAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.NoSecurityRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var resultTask = channel.WaitForSecondRequestAsync();
@@ -162,7 +159,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetBufferedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(NoAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.NoSecurityRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var clientIpEndpoint = channel.GetClientIpEndpoint();
@@ -197,7 +194,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetBufferedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(NoAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.NoSecurityRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var message = new ClientContract.TestMessage()

--- a/src/CoreWCF.NetTcp/tests/ConnectionHandlerStreamedModeTests.cs
+++ b/src/CoreWCF.NetTcp/tests/ConnectionHandlerStreamedModeTests.cs
@@ -12,10 +12,6 @@ namespace ConnectionHandler
 {
     public class ConnectionHandlerStreamedModeTests
     {
-        private const string NetTcpServiceBaseUri = "net.tcp://localhost:8808";
-        private const string WindowsAuthNetTcpServiceUri = NetTcpServiceBaseUri + Startup.WindowsAuthRelativePath;
-        private const string NoAuthNetTcpServiceUri = NetTcpServiceBaseUri + Startup.NoSecurityRelativePath;
-
         private ITestOutputHelper _output;
 
         public ConnectionHandlerStreamedModeTests(ITestOutputHelper output)
@@ -38,7 +34,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetStreamedModeBinding(System.ServiceModel.SecurityMode.Transport);
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(WindowsAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.WindowsAuthRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var result = channel.EchoString(testString);
@@ -67,7 +63,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetStreamedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(NoAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.NoSecurityRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var result = channel.EchoString(testString);
@@ -96,7 +92,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetStreamedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(NoAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.NoSecurityRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var result = channel.EchoString(testString);
@@ -130,7 +126,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetStreamedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(NoAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.NoSecurityRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var result = channel.EchoString(testString);
@@ -160,7 +156,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetStreamedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(NoAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.NoSecurityRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var clientIpEndpoint = channel.GetClientIpEndpoint();
@@ -195,7 +191,7 @@ namespace ConnectionHandler
                 {
                     var binding = ClientHelper.GetStreamedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(NoAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.NoSecurityRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var clientIpEndpoint = channel.GetClientIpEndpoint();

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />

--- a/src/CoreWCF.NetTcp/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.NetTcp/tests/Helpers/ServiceHelper.cs
@@ -3,6 +3,10 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Helpers
@@ -20,8 +24,15 @@ namespace Helpers
                 logging.SetMinimumLevel(LogLevel.Debug);
             })
 #endif // DEBUG
-            .UseNetTcp(8808)
+            .UseNetTcp(0)
             .UseStartup<TStartup>();
+
+        public static string GetNetTcpAddressInUse(this IWebHost host)
+        {
+            var addresses = host.ServerFeatures.Get<IServerAddressesFeature>().Addresses;
+            var addressInUse = new Uri(addresses.First(), UriKind.Absolute);
+            return $"net.tcp://localhost:{addressInUse.Port}";
+        }
 
         public static void CloseServiceModelObjects(params System.ServiceModel.ICommunicationObject[] objects)
         {

--- a/src/CoreWCF.NetTcp/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.NetTcp/tests/Helpers/ServiceHelper.cs
@@ -29,9 +29,14 @@ namespace Helpers
 
         public static string GetNetTcpAddressInUse(this IWebHost host)
         {
+            return $"net.tcp://localhost:{host.GetNetTcpPortInUse()}";
+        }
+
+        public static int GetNetTcpPortInUse(this IWebHost host)
+        {
             var addresses = host.ServerFeatures.Get<IServerAddressesFeature>().Addresses;
             var addressInUse = new Uri(addresses.First(), UriKind.Absolute);
-            return $"net.tcp://localhost:{addressInUse.Port}";
+            return addressInUse.Port;
         }
 
         public static void CloseServiceModelObjects(params System.ServiceModel.ICommunicationObject[] objects)

--- a/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
+++ b/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
@@ -9,10 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.ServiceModel.Channels;
-using System.Text;
-using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,8 +17,6 @@ namespace CoreWCF.NetTcp.Tests
 {
    public class ServiceAuthBehaviorTest
     {
-        private const string NetTcpServiceBaseUri = "net.tcp://localhost:8808";
-        private const string WindowsAuthNetTcpServiceUri = NetTcpServiceBaseUri + Startup.WindowsAuthRelativePath;
         private ITestOutputHelper _output;
 
         public ServiceAuthBehaviorTest(ITestOutputHelper output)
@@ -44,7 +39,7 @@ namespace CoreWCF.NetTcp.Tests
                 {
                     var binding = ClientHelper.GetBufferedModeBinding(System.ServiceModel.SecurityMode.Transport);
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(WindowsAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.WindowsAuthRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var result = channel.EchoString(testString);
@@ -100,7 +95,7 @@ namespace CoreWCF.NetTcp.Tests
                 {
                     var binding = ClientHelper.GetBufferedModeBinding(System.ServiceModel.SecurityMode.Transport);
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(WindowsAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.WindowsAuthRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var result = channel.EchoForImpersonation(sourceString);
@@ -126,7 +121,7 @@ namespace CoreWCF.NetTcp.Tests
                 {
                     var binding = ClientHelper.GetBufferedModeBinding(System.ServiceModel.SecurityMode.Transport);
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri(WindowsAuthNetTcpServiceUri)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.WindowsAuthRelativePath));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     var result = channel.EchoForPermission(sourceString);

--- a/src/CoreWCF.NetTcp/tests/TaskBasedOperationTests.cs
+++ b/src/CoreWCF.NetTcp/tests/TaskBasedOperationTests.cs
@@ -4,8 +4,10 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Linq;
 using System.ServiceModel.Channels;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -34,7 +36,7 @@ namespace AsyncServices
                 {
                     var binding = ClientHelper.GetBufferedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<Contract.ITaskService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri("net.tcp://localhost:8808" + Startup.BufferedRelatveAddress)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.BufferedRelatveAddress));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     await channel.SynchronousCompletion();
@@ -62,7 +64,7 @@ namespace AsyncServices
                 {
                     var binding = ClientHelper.GetBufferedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<Contract.ITaskService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri("net.tcp://localhost:8808" + Startup.BufferedRelatveAddress)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.BufferedRelatveAddress));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     await channel.AsynchronousCompletion();
@@ -86,11 +88,12 @@ namespace AsyncServices
                 System.ServiceModel.ChannelFactory<Contract.ITaskService> factory = null;
                 Contract.ITaskService channel = null;
                 host.Start();
+
                 try
                 {
                     var binding = ClientHelper.GetStreamedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<Contract.ITaskService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri("net.tcp://localhost:8808" + Startup.StreamedRelatveAddress)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.StreamedRelatveAddress));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     await channel.SynchronousCompletion();
@@ -118,7 +121,7 @@ namespace AsyncServices
                 {
                     var binding = ClientHelper.GetStreamedModeBinding();
                     factory = new System.ServiceModel.ChannelFactory<Contract.ITaskService>(binding,
-                        new System.ServiceModel.EndpointAddress(new Uri("net.tcp://localhost:8808" + Startup.StreamedRelatveAddress)));
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.StreamedRelatveAddress));
                     channel = factory.CreateChannel();
                     ((IChannel)channel).Open();
                     await channel.AsynchronousCompletion();

--- a/src/CoreWCF.NetTcp/tests/TaskBasedOperationTests.cs
+++ b/src/CoreWCF.NetTcp/tests/TaskBasedOperationTests.cs
@@ -88,7 +88,6 @@ namespace AsyncServices
                 System.ServiceModel.ChannelFactory<Contract.ITaskService> factory = null;
                 Contract.ITaskService channel = null;
                 host.Start();
-
                 try
                 {
                     var binding = ClientHelper.GetStreamedModeBinding();

--- a/src/CoreWCF.NetTcp/tests/TransportFrameworkTests.cs
+++ b/src/CoreWCF.NetTcp/tests/TransportFrameworkTests.cs
@@ -43,7 +43,7 @@ namespace CoreWCF.NetTcp.Tests
 
                 string clientIP = results[1];
                 CheckIP(clientIP);
-                ThreadPool.QueueUserWorkItem(NetstatResults, results[2]);
+                NetstatResults(results[2], host.GetNetTcpPortInUse().ToString());
             }
         }
 
@@ -64,7 +64,7 @@ namespace CoreWCF.NetTcp.Tests
             }
         }
 
-        private void NetstatResults(object state)
+        private void NetstatResults(string clientPort, string endpointPort)
         {
             Process netstatProcess = new Process();
             netstatProcess.StartInfo.FileName = "netstat";
@@ -74,8 +74,6 @@ namespace CoreWCF.NetTcp.Tests
 
             // get the netstat results while the connection is open
             netstatProcess.Start();
-            string clientPort = (string)state;
-            string endpointPort = "8808";
             CheckPort(clientPort, endpointPort, netstatProcess);
         }
 

--- a/src/CoreWCF.NetTcp/tests/TransportFrameworkTests.cs
+++ b/src/CoreWCF.NetTcp/tests/TransportFrameworkTests.cs
@@ -31,7 +31,7 @@ namespace CoreWCF.NetTcp.Tests
                 host.Start();
                 var nettcpBinding = ClientHelper.GetBufferedModeBinding();
                 var factory = new System.ServiceModel.ChannelFactory<ClientContract.IRemoteEndpointMessageProperty>(nettcpBinding,
-                    new System.ServiceModel.EndpointAddress(new Uri("net.tcp://localhost:8808/RemoteEndpointMessagePropertyService.svc")));
+                    new System.ServiceModel.EndpointAddress(new Uri(host.GetNetTcpAddressInUse() + "/RemoteEndpointMessagePropertyService.svc")));
                 var channel = factory.CreateChannel();
 
                 Message request = Message.CreateMessage(nettcpBinding.MessageVersion, "echo", "PASS");

--- a/src/CoreWCF.Primitives/tests/DispatchBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/DispatchBuilderTests.cs
@@ -17,6 +17,7 @@ namespace DispatchBuilder
         {
             string serviceAddress = "http://localhost/dummy";
             var services = new ServiceCollection();
+            services.AddLogging();
             services.AddServiceModelServices();
             var serverAddressesFeature = new ServerAddressesFeature();
             serverAddressesFeature.Addresses.Add(serviceAddress);
@@ -48,6 +49,7 @@ namespace DispatchBuilder
         {
             string serviceAddress = "http://localhost/dummy";
             var services = new ServiceCollection();
+            services.AddLogging();
             services.AddServiceModelServices();
             var serverAddressesFeature = new ServerAddressesFeature();
             serverAddressesFeature.Addresses.Add(serviceAddress);
@@ -79,6 +81,7 @@ namespace DispatchBuilder
         {
             string serviceAddress = "http://localhost/dummy";
             var services = new ServiceCollection();
+            services.AddLogging();
             services.AddServiceModelServices();
             var serverAddressesFeature = new ServerAddressesFeature();
             serverAddressesFeature.Addresses.Add(serviceAddress);
@@ -112,6 +115,7 @@ namespace DispatchBuilder
             var serviceAddress = "http://localhost/dummy";
 
             var services = new ServiceCollection();
+            services.AddLogging();
             services.AddServiceModelServices();
 
             var serverAddressesFeature = new ServerAddressesFeature();

--- a/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherChannelFactory.cs
+++ b/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherChannelFactory.cs
@@ -38,6 +38,7 @@ namespace DispatcherClient
             services.AddSingleton<DispatcherChannelFactory>(this);
             services.AddScoped<DispatcherReplyChannel>();
             services.AddServiceModelServices();
+            services.AddLogging();
             IServer server = new Helpers.MockServer();
             services.AddSingleton(server);
             services.AddSingleton(GetType(), this);


### PR DESCRIPTION
This PR adds a feature to pass `0` to `UseNetTcp` which will properly handle a deferred/auto-assigned port, rather always require an explicit port. The port is assigned "implicitly" via the TCP stack, there is no "hunt and peck" required.

The feature is then used to convert `net.tcp` tests to use auto-assigned ports, to fix issue #218, where the build server will intermittently fail on `AddressInUseException`.