### PR TITLE
Fix CompressionFormat for BinaryMessageEncoder

### DIFF
--- a/src/Common/src/CoreWCF/Runtime/IOThreadScheduler.cs
+++ b/src/Common/src/CoreWCF/Runtime/IOThreadScheduler.cs
@@ -641,7 +641,11 @@ namespace CoreWCF.Runtime
                 {
                     throw Fx.AssertAndThrowFatal("Cleanup called on an overlapped that is in-flight.");
                 }
-                Overlapped.Free(_nativeOverlapped);
+
+                if (s_isWindows)
+                {
+                    Overlapped.Free(_nativeOverlapped);
+                }
             }
         }
     }

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/HttpRequestContext.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/HttpRequestContext.cs
@@ -228,7 +228,6 @@ namespace CoreWCF.Channels
             try
             {
                 bool closeOutputAfterReply = PrepareReply(ref responseMessage);
-                httpOutput = GetHttpOutput(message);
                 await httpOutput.SendAsync(token);
 
                 if (closeOutputAfterReply)

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/HttpTransportBindingElement.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/HttpTransportBindingElement.cs
@@ -201,10 +201,13 @@ namespace CoreWCF.Channels
 
             //    return (T)(object)_anonymousUriPrefixMatcher;
             //}
-            //else if (typeof(T) == typeof(ITransportCompressionSupport))
-            //{
-            //    return (T)(object)new TransportCompressionSupportHelper();
-            //}
+            else if (typeof(T).FullName.Equals("CoreWCF.Channels.ITransportCompressionSupport"))
+            {
+                var app = context.BindingParameters.Find<IApplicationBuilder>();
+                if (app == null) return base.GetProperty<T>(context);
+                var tcs = app.ApplicationServices.GetService(typeof(T).Assembly.GetType("CoreWCF.Channels.TransportCompressionSupportHelper"));
+                return (T)tcs;
+            }
             else
             {
                 if (context.BindingParameters.Find<MessageEncodingBindingElement>() == null)

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/ServiceModelHttpMiddleware.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/ServiceModelHttpMiddleware.cs
@@ -52,7 +52,11 @@ namespace CoreWCF.Channels
                         continue;
                     }
 
-                    var binding = new CustomBinding(dispatcher.Binding);
+                    var binding = dispatcher.Binding as CustomBinding;
+                    if (binding == null)
+                    {
+                        binding = new CustomBinding(dispatcher.Binding);
+                    }
                     if (binding.Elements.Find<HttpTransportBindingElement>() == null)
                     {
                         _logger.LogDebug($"Binding for address {dispatcher.BaseAddress} is not an HTTP[S] binding ao skipping");

--- a/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
@@ -101,6 +101,30 @@ namespace Helpers
             .UseUrls("http://localhost:8080")
             .UseStartup<TStartup>();
 
+        public static IWebHostBuilder CreateWebHostBuilder(ITestOutputHelper outputHelper, Type startupType) =>
+            WebHost.CreateDefaultBuilder(new string[0])
+#if DEBUG
+            .ConfigureLogging((ILoggingBuilder logging) =>
+            {
+                logging.AddProvider(new XunitLoggerProvider(outputHelper));
+                logging.AddFilter("Default", LogLevel.Debug);
+                logging.AddFilter("Microsoft", LogLevel.Debug);
+                logging.SetMinimumLevel(LogLevel.Debug);
+            })
+#endif // DEBUG
+            .UseKestrel(options =>
+            {
+                options.Listen(IPAddress.Loopback, 8080, listenOptions =>
+                {
+                    if (Debugger.IsAttached)
+                    {
+                        listenOptions.UseConnectionLogging();
+                    }
+                });
+            })
+            .UseUrls("http://localhost:8080")
+            .UseStartup(startupType);
+
         public static IWebHostBuilder CreateHttpsWebHostBuilder<TStartup>(ITestOutputHelper outputHelper) where TStartup : class =>
             WebHost.CreateDefaultBuilder(new string[0])
 #if DEBUG

--- a/src/CoreWCF.Http/tests/MessageEncoderTests.cs
+++ b/src/CoreWCF.Http/tests/MessageEncoderTests.cs
@@ -1,0 +1,94 @@
+﻿using CoreWCF.Channels;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Http.Tests
+{
+    public class MessageEncoderTests
+    {
+        private ITestOutputHelper _output;
+
+        public MessageEncoderTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestVariations))]
+        public void BinaryMessageEncoderCompressionFormat_EchoString(Type startupType, System.ServiceModel.Channels.Binding clientBinding)
+        {
+            string testString = new string('a', 3000);
+            var host = ServiceHelper.CreateWebHostBuilder(_output, startupType).Build();
+            using (host)
+            {
+                host.Start();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IEchoService>(clientBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/basichttp.svc")));
+                var channel = factory.CreateChannel();
+                var result = channel.EchoString(testString);
+                Assert.Equal(testString, result);
+            }
+        }
+
+        public static IEnumerable<object[]> GetTestVariations()
+        {
+            yield return new object[] { typeof(BinaryEncoderWithGzipStartup), BinaryEncoderWithGzipStartup.GetClientBinding() };
+            yield return new object[] { typeof(BinaryEncoderWithDeflateStartup), BinaryEncoderWithDeflateStartup.GetClientBinding() };
+            yield return new object[] { typeof(BinaryEncoderNoCompressionStartup), BinaryEncoderNoCompressionStartup.GetClientBinding() };
+        }
+
+        internal class BinaryEncoderWithGzipStartup : Startup
+        {
+            protected override CompressionFormat CompressionFormat => CompressionFormat.GZip;
+            public static System.ServiceModel.Channels.Binding GetClientBinding() => GetClientBinding(System.ServiceModel.Channels.CompressionFormat.GZip);
+        }
+
+        internal class BinaryEncoderWithDeflateStartup : Startup
+        {
+            protected override CompressionFormat CompressionFormat => CompressionFormat.Deflate;
+            public static System.ServiceModel.Channels.Binding GetClientBinding() => GetClientBinding(System.ServiceModel.Channels.CompressionFormat.Deflate);
+        }
+
+        internal class BinaryEncoderNoCompressionStartup : Startup
+        {
+            protected override CompressionFormat CompressionFormat => CompressionFormat.None;
+            public static System.ServiceModel.Channels.Binding GetClientBinding() => GetClientBinding(System.ServiceModel.Channels.CompressionFormat.None);
+        }
+
+        internal abstract class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.EchoService>();
+                    var binding = new CustomBinding();
+                    binding.Elements.Add(new BinaryMessageEncodingBindingElement { CompressionFormat = CompressionFormat });
+                    binding.Elements.Add(new HttpTransportBindingElement { MaxReceivedMessageSize = 200065536 });
+                    builder.AddServiceEndpoint<Services.EchoService, ServiceContract.IEchoService>(binding, "/BasicWcfService/basichttp.svc");
+                });
+            }
+
+            protected static System.ServiceModel.Channels.Binding GetClientBinding(System.ServiceModel.Channels.CompressionFormat compressionFormat)
+            {
+                var binding = new System.ServiceModel.Channels.CustomBinding();
+                binding.Elements.Add(new System.ServiceModel.Channels.BinaryMessageEncodingBindingElement { CompressionFormat = compressionFormat });
+                binding.Elements.Add(new System.ServiceModel.Channels.HttpTransportBindingElement { MaxReceivedMessageSize = 200065536 });
+                return binding;
+            }
+
+            protected abstract CompressionFormat CompressionFormat { get; }
+        }
+    }
+}

--- a/src/CoreWCF.Http/tests/RequestReplyTests.cs
+++ b/src/CoreWCF.Http/tests/RequestReplyTests.cs
@@ -36,12 +36,12 @@ namespace CoreWCF.Http.Tests
             using (host)
             {
                 host.Start();
-                System.ServiceModel.ChannelFactory<ClientContract.IStream> channelFactory =null;
+                System.ServiceModel.ChannelFactory<ClientContract.IStream> channelFactory = null;
                 switch (binding)
                 {
                     case "Http1Binding":
-                         channelFactory = new System.ServiceModel.ChannelFactory<ClientContract.IStream>(ClientHelper.GetBufferedModHttp1Binding(),
-                       new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService1/RequestReplyTests.svc")));
+                        channelFactory = new System.ServiceModel.ChannelFactory<ClientContract.IStream>(ClientHelper.GetBufferedModHttp1Binding(),
+                      new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService1/RequestReplyTests.svc")));
                         break;
                     //case "Http2Binding":
                     //    channelFactory = new System.ServiceModel.ChannelFactory<ClientContract.IStream>(ClientHelper.GetBufferedModHttp2Binding(),
@@ -70,26 +70,24 @@ namespace CoreWCF.Http.Tests
                 Assert.Equal(num2, (long)num3);
             }
         }
-    }
 
-
-    internal class Startup
-    {
-        public static string binding;
-        public void ConfigureServices(IServiceCollection services)
+        internal class Startup
         {
-            services.AddServiceModelServices();
-        }
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-        {
-            app.UseServiceModel(builder =>
+            public static string binding;
+            public void ConfigureServices(IServiceCollection services)
             {
-                builder.AddService<ReqRepService>();
-                switch (binding)
+                services.AddServiceModelServices();
+            }
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
                 {
-                    case "Http1Binding":
-                        builder.AddServiceEndpoint<ReqRepService, ServiceContract.IStream>(ServiceHelper.GetBufferedModHttp1Binding(), "/BasicWcfService1/RequestReplyTests.svc");
-                        break;
+                    builder.AddService<ReqRepService>();
+                    switch (binding)
+                    {
+                        case "Http1Binding":
+                            builder.AddServiceEndpoint<ReqRepService, ServiceContract.IStream>(ServiceHelper.GetBufferedModHttp1Binding(), "/BasicWcfService1/RequestReplyTests.svc");
+                            break;
                     //case "Http2Binding":
                     //    builder.AddServiceEndpoint<ReqRepService, ServiceContract.IStream>(ServiceHelper.GetBufferedModHttp2Binding(), "/BasicWcfService2/RequestReplyTests.svc");
                     //    break;
@@ -97,10 +95,11 @@ namespace CoreWCF.Http.Tests
                     //    builder.AddServiceEndpoint<ReqRepService, ServiceContract.IStream>(ServiceHelper.GetBufferedModHttp3Binding(), "/BasicWcfService3/RequestReplyTests.svc");
                     //    break;
                     default:
-                        throw new Exception("Unknown binding");
+                            throw new Exception("Unknown binding");
 
-                }
-            });
+                    }
+                });
+            }
         }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/Binding.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/Binding.cs
@@ -193,7 +193,9 @@ where TChannel : class, IChannel
             where TChannel : class, IChannel
         {
             EnsureInvariants();
-            BindingContext context = new BindingContext(new CustomBinding(this), parameters, listenUriBaseAddress, listenUriRelativeAddress);
+            var binding = this as CustomBinding;
+            if (binding == null) binding = new CustomBinding(this);
+            BindingContext context = new BindingContext(binding, parameters, listenUriBaseAddress, listenUriRelativeAddress);
             IServiceDispatcher serviceDispatcher = context.BuildNextServiceDispatcher<TChannel>(dispatcher);
             context.ValidateBindingElementsConsumed();
 

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/ITransportCompressionSupport.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/ITransportCompressionSupport.cs
@@ -1,0 +1,7 @@
+﻿namespace CoreWCF.Channels
+{
+    internal interface ITransportCompressionSupport
+    {
+        bool IsCompressionFormatSupported(CompressionFormat compressionFormat);
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/TransportCompressionSupportHelper.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/TransportCompressionSupportHelper.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CoreWCF.Channels
+{
+    internal class TransportCompressionSupportHelper : ITransportCompressionSupport
+    {
+        public bool IsCompressionFormatSupported(CompressionFormat compressionFormat)
+        {
+            return true;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceModelServiceCollectionExtensions.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceModelServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ namespace CoreWCF.Configuration
             services.AddScoped<InputChannelBinder>();
             services.AddScoped<ServiceChannel.SessionIdleManager>();
             services.AddSingleton(typeof(ServiceHostObjectModel<>));
-
+            services.AddSingleton(typeof(TransportCompressionSupportHelper));
             return services;
         }
     }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/DispatcherBuilder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/DispatcherBuilder.cs
@@ -139,7 +139,7 @@ namespace CoreWCF.Description
             return new ListenUriInfo(listenUri, endpoint.ListenUriMode);
         }
 
-        internal static void InitializeServiceHost(ServiceHostBase serviceHost)
+        internal static void InitializeServiceHost(ServiceHostBase serviceHost, IServiceProvider services)
         {
             var description = serviceHost.Description;
             if (serviceHost.ImplementedContracts != null && serviceHost.ImplementedContracts.Count > 0)
@@ -163,6 +163,7 @@ namespace CoreWCF.Description
                     stuffPerListenUriInfo.Add(listenUriInfo, new StuffPerListenUriInfo());
                 }
                 stuffPerListenUriInfo[listenUriInfo].Endpoints.Add(endpoint);
+                stuffPerListenUriInfo[listenUriInfo].Parameters.Add(services);
             }
 
             foreach (KeyValuePair<ListenUriInfo, StuffPerListenUriInfo> stuff in stuffPerListenUriInfo)
@@ -690,7 +691,7 @@ namespace CoreWCF.Description
                 serviceHost.Description.Endpoints.Add(serviceEndpoint);
             }
 
-            InitializeServiceHost(serviceHost);
+            InitializeServiceHost(serviceHost, services);
             ServiceConfigurationDelegateHolder<TService> configDelegate = services.GetService<ServiceConfigurationDelegateHolder<TService>>();
             configDelegate?.Configure(serviceHost);
 


### PR DESCRIPTION
A few fixes here. The most important is to enable copying the MaxMessageSize property from the transport to the BinaryMessageEncoder. This required stopping the binding from being cloned on a critical code path as the copying of the value would happen on the clone and the eventual encoder is created on one of the earlier copies.
There was also a bug where the HttpOutput object would be created twice resulting in a duplicate message property when using compression.
Fixes #220