### PR TITLE
Fix race condition where connection reuse would happen before ReadAsync completed

### DIFF
--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/ServerFramingDuplexSessionMiddleware.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/ServerFramingDuplexSessionMiddleware.cs
@@ -149,7 +149,7 @@ namespace CoreWCF.Channels.Framing
 
         public static async Task UpgradeConnectionAsync(FramingConnection connection)
         {
-            connection.RawStream = new RawStream(connection.Input, connection.Output);
+            connection.RawStream = new RawStream(connection);
             var upgradeAcceptor = connection.StreamUpgradeAcceptor;
             var stream = await upgradeAcceptor.AcceptUpgradeAsync(connection.RawStream);
             CreatePipelineFromStream(connection, stream);

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/ServerFramingSingletonMiddleware.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/ServerFramingSingletonMiddleware.cs
@@ -240,7 +240,7 @@ namespace CoreWCF.Channels.Framing
 
         public static async Task UpgradeConnectionAsync(FramingConnection connection)
         {
-            connection.RawStream = new RawStream(connection.Input, connection.Output);
+            connection.RawStream = new RawStream(connection);
             var upgradeAcceptor = connection.StreamUpgradeAcceptor;
             var stream = await upgradeAcceptor.AcceptUpgradeAsync(connection.RawStream);
             CreatePipelineFromStream(connection, stream);

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/StreamedFramingRequestContext.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/StreamedFramingRequestContext.cs
@@ -70,7 +70,7 @@ namespace CoreWCF.Channels.Framing
                 {
                     if (_connection.RawStream != null)
                     {
-                        _connection.RawStream.FinishUnwrapRead();
+                        await _connection.RawStream.FinishUnwrapReadAsync();
                         _connection.RawStream = null;
                         _connection.Output.Complete();
                         _connection.Input.Complete();

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/ServerFramingDuplexSessionChannel.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/ServerFramingDuplexSessionChannel.cs
@@ -317,7 +317,7 @@ namespace CoreWCF.Channels
             {
                 if (Connection.RawStream != null)
                 {
-                    Connection.RawStream.FinishUnwrapRead();
+                    await Connection.RawStream.FinishUnwrapReadAsync();
                     Connection.RawStream = null;
                     Connection.Output.Complete();
                     Connection.Input.Complete();


### PR DESCRIPTION
On channel close, a pending read by NegotiateStream/SslStream is being delayed until the send part of the channel close has completed. What wasn't happening and needed to happen was to wait for that pending read to complete before preparing the socket for connection reuse. There was an incredibly difficult to hit race condition which would cause a connection failure due to two concurrent reads.