### PR TITLE
Fixes HTTP buffered mode chunked request and ServiceHostBase.Credentials

### DIFF
--- a/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs
@@ -1837,17 +1837,17 @@ namespace CoreWCF.Channels
 
     internal class PreReadStream : DelegatingStream
     {
-        private byte[] preReadBuffer;
+        private byte[] _preReadBuffer;
 
         public PreReadStream(Stream stream, byte[] preReadBuffer)
             : base(stream)
         {
-            this.preReadBuffer = preReadBuffer;
+            _preReadBuffer = preReadBuffer;
         }
 
         private bool ReadFromBuffer(byte[] buffer, int offset, int count, out int bytesRead)
         {
-            if (this.preReadBuffer != null)
+            if (_preReadBuffer != null)
             {
                 if (buffer == null)
                 {
@@ -1872,8 +1872,8 @@ namespace CoreWCF.Channels
                 }
                 else
                 {
-                    buffer[offset] = this.preReadBuffer[0];
-                    this.preReadBuffer = null;
+                    buffer[offset] = _preReadBuffer[0];
+                    _preReadBuffer = null;
                     bytesRead = 1;
                 }
 
@@ -1882,6 +1882,17 @@ namespace CoreWCF.Channels
 
             bytesRead = -1;
             return false;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            int bytesRead;
+            if (ReadFromBuffer(buffer, offset, count, out bytesRead))
+            {
+                return Task.FromResult(bytesRead);
+            }
+
+            return base.ReadAsync(buffer, offset, count, cancellationToken);
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -1897,15 +1908,15 @@ namespace CoreWCF.Channels
 
         public override int ReadByte()
         {
-            if (this.preReadBuffer != null)
+            if (_preReadBuffer != null)
             {
                 byte[] tempBuffer = new byte[1];
-                int bytesRead;
-                if (ReadFromBuffer(tempBuffer, 0, 1, out bytesRead))
+                if (ReadFromBuffer(tempBuffer, 0, 1, out _))
                 {
                     return tempBuffer[0];
                 }
             }
+
             return base.ReadByte();
         }
     }

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/HttpTransportBindingElement.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/HttpTransportBindingElement.cs
@@ -19,7 +19,7 @@ namespace CoreWCF.Channels
         public HttpTransportBindingElement()
         {
             AuthenticationScheme = HttpTransportDefaults.AuthenticationScheme;
-            MaxBufferSize = TransportDefaults.MaxBufferSize;
+            _maxBufferSize = TransportDefaults.MaxBufferSize;
             KeepAliveEnabled = HttpTransportDefaults.KeepAliveEnabled;
             TransferMode = HttpTransportDefaults.TransferMode;
             WebSocketSettings = HttpTransportDefaults.GetDefaultWebSocketTransportSettings();
@@ -28,7 +28,8 @@ namespace CoreWCF.Channels
         protected HttpTransportBindingElement(HttpTransportBindingElement elementToBeCloned) : base(elementToBeCloned)
         {
             AuthenticationScheme = elementToBeCloned.AuthenticationScheme;
-            MaxBufferSize = elementToBeCloned.MaxBufferSize;
+            _maxBufferSize = elementToBeCloned._maxBufferSize;
+            _maxBufferSizeInitialized = elementToBeCloned._maxBufferSizeInitialized;
             KeepAliveEnabled = elementToBeCloned.KeepAliveEnabled;
             TransferMode = elementToBeCloned.TransferMode;
             WebSocketSettings = elementToBeCloned.WebSocketSettings.Clone();

--- a/src/CoreWCF.Http/tests/LargeRequestTests.cs
+++ b/src/CoreWCF.Http/tests/LargeRequestTests.cs
@@ -1,0 +1,106 @@
+﻿using CoreWCF.Channels;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Http.Tests
+{
+    public class LargeRequestTests
+    {
+        private ITestOutputHelper _output;
+
+        public LargeRequestTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestVariations))]
+        public void EchoRoundtrip(Type startupType, System.ServiceModel.TransferMode clientTransferMode, int requestSize)
+        {
+            string testString = new string('a', requestSize);
+            var host = ServiceHelper.CreateWebHostBuilder(_output, startupType).Build();
+            using (host)
+            {
+                host.Start();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IEchoService>(Startup.GetClientBinding(clientTransferMode),
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/basichttp.svc")));
+                var channel = factory.CreateChannel();
+                var result = channel.EchoString(testString);
+                Assert.Equal(testString, result);
+                ((System.ServiceModel.Channels.IChannel)channel).Close();
+                factory.Close();
+            }
+        }
+
+        public static IEnumerable<object[]> GetTestVariations()
+        {
+            foreach (var requestSize in new int[] { 1024, 1024 * 1024, 10 * 1024 * 1024 })
+            {
+                foreach (var transferMode in new TransferMode[] { TransferMode.Buffered, TransferMode.Streamed })
+                {
+                    foreach (var clientTransferMode in new System.ServiceModel.TransferMode[] { System.ServiceModel.TransferMode.Buffered, System.ServiceModel.TransferMode.Streamed })
+                    {
+                        switch (transferMode)
+                        {
+                            case TransferMode.Buffered:
+                                yield return new object[] { typeof(BufferedModeStartup), clientTransferMode, requestSize };
+                                break;
+                            case TransferMode.Streamed:
+                                yield return new object[] { typeof(StreamedModeStartup), clientTransferMode, requestSize };
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        internal abstract class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.EchoService>();
+                    var binding = new CustomBinding();
+                    binding.Elements.Add(new TextMessageEncodingBindingElement { ReaderQuotas = XmlDictionaryReaderQuotas.Max });
+                    binding.Elements.Add(new HttpTransportBindingElement { MaxReceivedMessageSize = int.MaxValue, TransferMode = TransferMode });
+                    builder.AddServiceEndpoint<Services.EchoService, ServiceContract.IEchoService>(binding, "/BasicWcfService/basichttp.svc");
+                });
+            }
+
+            public static System.ServiceModel.Channels.Binding GetClientBinding(System.ServiceModel.TransferMode transferMode)
+            {
+                var binding = new System.ServiceModel.Channels.CustomBinding();
+                binding.Elements.Add(new System.ServiceModel.Channels.TextMessageEncodingBindingElement { ReaderQuotas = XmlDictionaryReaderQuotas.Max });
+                binding.Elements.Add(new System.ServiceModel.Channels.HttpTransportBindingElement { MaxReceivedMessageSize = int.MaxValue, TransferMode = transferMode });
+                return binding;
+            }
+
+            protected abstract TransferMode TransferMode { get; }
+        }
+
+        internal class StreamedModeStartup : Startup
+        {
+            protected override TransferMode TransferMode => TransferMode.Streamed;
+        }
+
+        internal class BufferedModeStartup : Startup
+        {
+            protected override TransferMode TransferMode => TransferMode.Buffered;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/ServiceHostBase.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/ServiceHostBase.cs
@@ -126,20 +126,18 @@ namespace CoreWCF
         {
             get
             {
-                // TODO: Decide if Credentials should be populated?
-                return null;
-                //if (this.Description == null)
-                //{
-                //    return null;
-                //}
-                //else if (this.State == CommunicationState.Created || this.State == CommunicationState.Opening)
-                //{
-                //    return EnsureCredentials(this.Description);
-                //}
-                //else
-                //{
-                //    return this.readOnlyCredentials;
-                //}
+                if (Description == null)
+                {
+                    return null;
+                }
+                else if (State == CommunicationState.Created || State == CommunicationState.Opening)
+                {
+                    return EnsureCredentials(Description);
+                }
+                else
+                {
+                    return readOnlyCredentials;
+                }
             }
         }
 
@@ -262,7 +260,7 @@ namespace CoreWCF
 
         internal virtual void BindInstance(InstanceContext instance)
         {
-            this.instances.Add(instance);
+            instances.Add(instance);
             //if (null != this.servicePerformanceCounters)
             //{
             //    lock (this.ThisLock)
@@ -313,6 +311,20 @@ namespace CoreWCF
         //    }
         //    return a;
         //}
+
+        ServiceCredentials EnsureCredentials(ServiceDescription description)
+        {
+            Fx.Assert(State == CommunicationState.Created || State == CommunicationState.Opening, "");
+            ServiceCredentials c = description.Behaviors.Find<ServiceCredentials>();
+
+            if (c == null)
+            {
+                c = new ServiceCredentials();
+                description.Behaviors.Add(c);
+            }
+
+            return c;
+        }
 
         public int IncrementManualFlowControlLimit(int incrementBy)
         {
@@ -368,7 +380,7 @@ namespace CoreWCF
 
         internal virtual void UnbindInstance(InstanceContext instance)
         {
-            this.instances.Remove(instance);
+            instances.Remove(instance);
             //if (null != this.servicePerformanceCounters)
             //{
             //    lock (this.ThisLock)

--- a/src/CoreWCF.Primitives/tests/ServiceHostBaseTests.cs
+++ b/src/CoreWCF.Primitives/tests/ServiceHostBaseTests.cs
@@ -1,0 +1,136 @@
+﻿using CoreWCF.Description;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CoreWCF.Primitives.Tests
+{
+    public static class ServiceHostBaseTests
+    {
+        [Fact]
+        public static void CredentialsNotNull()
+        {
+            var host = new TestServiceHost();
+            var creds = host.Credentials;
+            Assert.NotNull(creds);
+            Assert.IsType<ServiceCredentials>(creds);
+            // Make sure same instance is returned each time
+            Assert.Same(creds, host.Credentials);
+        }
+
+        [Fact]
+        public static void CustomCredentials()
+        {
+            var host = new TestServiceHost();
+            var testCreds = new TestServiceCredentials();
+            Assert.NotNull(host.Description);
+            Assert.NotNull(host.Description.Behaviors);
+            host.Description.Behaviors.Add(testCreds);
+            var creds = host.Credentials;
+            Assert.NotNull(creds);
+            Assert.IsType<TestServiceCredentials>(creds);
+            // Make sure same instance is returned each time
+            Assert.Same(testCreds, host.Credentials);
+        }
+
+        [Fact]
+        public static async Task ServiceHostBaseOpenCloseAbort()
+        {
+            var host = new TestServiceHost();
+            Assert.Equal(CommunicationState.Created, host.State);
+            await host.OpenAsync();
+            Assert.Equal(CommunicationState.Opened, host.State);
+            Assert.True(host.OnOpenAsynCalled);
+            await host.CloseAsync();
+            Assert.Equal(CommunicationState.Closed, host.State);
+            Assert.True(host.OnCloseAsynCalled);
+            host.Abort();
+            Assert.False(host.OnAbortCalled);
+            host = new TestServiceHost();
+            await host.OpenAsync();
+            Assert.Equal(CommunicationState.Opened, host.State);
+            host.Abort();
+            Assert.True(host.OnAbortCalled);
+            Assert.Equal(CommunicationState.Closed, host.State);
+        }
+
+        public class TestServiceHost : ServiceHostBase
+        {
+            private SimpleService _serviceInstance = new SimpleService();
+            public bool OnOpenAsynCalled { get; set; }
+            public bool OnCloseAsynCalled { get; set; }
+            public bool OnAbortCalled { get; set; }
+
+            public TestServiceHost()
+            {
+                InitializeDescription(new UriSchemeKeyedCollection());
+            }
+
+            protected override ServiceDescription CreateDescription(out IDictionary<string, ContractDescription> implementedContracts)
+            {
+                var description = ServiceDescription.GetService(_serviceInstance);
+                var cd = ContractDescription.GetContract<SimpleService>(typeof(ISimpleService));
+                implementedContracts = new Dictionary<string, ContractDescription>();
+                implementedContracts[cd.ConfigurationName] = cd;
+                return description;
+            }
+
+            protected override void OnAbort()
+            {
+                Assert.Equal(CommunicationState.Closing, State);
+                OnAbortCalled = true;
+            }
+
+            protected override void OnClosing()
+            {
+                Assert.Equal(CommunicationState.Closing, State);
+                base.OnClosing();
+                Assert.Equal(CommunicationState.Closing, State);
+            }
+
+            protected override Task OnCloseAsync(CancellationToken token)
+            {
+                Assert.Equal(CommunicationState.Closing, State);
+                OnCloseAsynCalled = true;
+                return Task.CompletedTask;
+            }
+
+            protected override void OnClosed()
+            {
+                Assert.Equal(CommunicationState.Closing, State);
+                base.OnClosed();
+                Assert.Equal(CommunicationState.Closed, State);
+            }
+
+            protected override void OnOpening()
+            {
+                Assert.Equal(CommunicationState.Opening, State);
+                base.OnOpening();
+                Assert.Equal(CommunicationState.Opening, State);
+            }
+
+            protected override Task OnOpenAsync(CancellationToken token)
+            {
+                Assert.Equal(CommunicationState.Opening, State);
+                OnOpenAsynCalled = true;
+                return Task.CompletedTask;
+            }
+
+            protected override void OnOpened()
+            {
+                Assert.Equal(CommunicationState.Opening, State);
+                base.OnOpened();
+                Assert.Equal(CommunicationState.Opened, State);
+            }
+
+            protected override void ApplyConfiguration()
+            {
+            }
+        }
+
+        public class TestServiceCredentials : ServiceCredentials { }
+    }
+}


### PR DESCRIPTION
3 different bugs were breaking HTTP buffered mode with chunked encoding:  
* PreReadStream wasn't reading from pre-read buffer when calling the async ReadAsync
* HttpTransportBindingElement constructor was setting the default MaxBufferSize using the property instead of the underlying field
* HttpTransportBindingElement copy constructor was setting the copied MaxBufferSize using the property instead of the underlying field

ServiceHostBase.Credentials issue was due to missing code from the original port.
