### PR TITLE
Fix dependency on ServerAddressFeatures

### DIFF
--- a/src/CoreWCF.Http/tests/ContractBehaviorTests.cs
+++ b/src/CoreWCF.Http/tests/ContractBehaviorTests.cs
@@ -72,8 +72,10 @@ namespace CoreWCF.Http.Tests
         public void TwoAttributesSameType_Test()
         {
             Startup._method = "TwoAttributesSameType";
-            var host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
-            Assert.Throws<ArgumentException>(()=> host.Start());
+            using (var host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build())
+            {
+                Assert.Throws<ArgumentException>(() => host.Start());
+            }
         }
 
         //Variation

--- a/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
@@ -98,7 +98,6 @@ namespace Helpers
                         }
                     });
                 })
-            .UseUrls("http://localhost:8080")
             .UseStartup<TStartup>();
 
         public static IWebHostBuilder CreateWebHostBuilder(ITestOutputHelper outputHelper, Type startupType) =>
@@ -122,7 +121,6 @@ namespace Helpers
                     }
                 });
             })
-            .UseUrls("http://localhost:8080")
             .UseStartup(startupType);
 
         public static IWebHostBuilder CreateHttpsWebHostBuilder<TStartup>(ITestOutputHelper outputHelper) where TStartup : class =>
@@ -159,7 +157,6 @@ namespace Helpers
                     }
                 });
             })
-            .UseUrls("http://localhost:8080", "https://localhost:8443")
             .UseStartup<TStartup>();
 
         public static void CloseServiceModelObjects(params System.ServiceModel.ICommunicationObject[] objects)

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/IServiceBuilder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/IServiceBuilder.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace CoreWCF.Configuration
 {
-    public interface IServiceBuilder
+    public interface IServiceBuilder : ICommunicationObject
     {
         ICollection<Type> Services { get; }
         ICollection<Uri> BaseAddresses { get; }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/WrappingIServer.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/WrappingIServer.cs
@@ -1,0 +1,52 @@
+﻿using CoreWCF.Runtime;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http.Features;
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreWCF.Configuration
+{
+    internal class WrappingIServer : IServer
+    {
+        private readonly ServiceBuilder _serviceBuilder;
+
+        public WrappingIServer(ServiceBuilder serviceBuilder)
+        {
+            _serviceBuilder = serviceBuilder;
+        }
+
+        public IFeatureCollection Features => InnerServer.Features;
+
+        public IServer InnerServer { get; internal set; }
+
+        public void Dispose()
+        {
+            InnerServer.Dispose();
+        }
+
+        public async Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken)
+        {
+            await InnerServer.StartAsync(application, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await _serviceBuilder.OpenAsync(cancellationToken);
+            }
+            catch(CallbackException e)
+            {
+                if (e.InnerException != null)
+                {
+                    ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                }
+
+                throw;
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return InnerServer.StopAsync(cancellationToken);
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/tests/DispatchBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/DispatchBuilderTests.cs
@@ -19,17 +19,16 @@ namespace DispatchBuilder
             var services = new ServiceCollection();
             services.AddLogging();
             services.AddServiceModelServices();
-            var serverAddressesFeature = new ServerAddressesFeature();
-            serverAddressesFeature.Addresses.Add(serviceAddress);
             IServer server = new MockServer();
-            server.Features.Set<IServerAddressesFeature>(serverAddressesFeature);
             services.AddSingleton(server);
             var serviceProvider = services.BuildServiceProvider();
             var serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
+            serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
             serviceBuilder.AddService<SimpleService>();
             var binding = new CustomBinding("BindingName", "BindingNS");
             binding.Elements.Add(new MockTransportBindingElement());
             serviceBuilder.AddServiceEndpoint<SimpleService, ISimpleService>(binding, serviceAddress);
+            serviceBuilder.OpenAsync().GetAwaiter().GetResult();
             var dispatcherBuilder = serviceProvider.GetRequiredService<IDispatcherBuilder>();
             var dispatchers = dispatcherBuilder.BuildDispatchers(typeof(SimpleService));
             Assert.Single(dispatchers);
@@ -51,17 +50,16 @@ namespace DispatchBuilder
             var services = new ServiceCollection();
             services.AddLogging();
             services.AddServiceModelServices();
-            var serverAddressesFeature = new ServerAddressesFeature();
-            serverAddressesFeature.Addresses.Add(serviceAddress);
             IServer server = new MockServer();
-            server.Features.Set<IServerAddressesFeature>(serverAddressesFeature);
             services.AddSingleton(server);
             var serviceProvider = services.BuildServiceProvider();
             var serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
+            serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
             serviceBuilder.AddService<SimpleSingletonService>();
             var binding = new CustomBinding("BindingName", "BindingNS");
             binding.Elements.Add(new MockTransportBindingElement());
             serviceBuilder.AddServiceEndpoint<SimpleSingletonService, ISimpleService>(binding, serviceAddress);
+            serviceBuilder.OpenAsync().GetAwaiter().GetResult();
             var dispatcherBuilder = serviceProvider.GetRequiredService<IDispatcherBuilder>();
             var dispatchers = dispatcherBuilder.BuildDispatchers(typeof(SimpleSingletonService));
             Assert.Single(dispatchers);
@@ -83,18 +81,17 @@ namespace DispatchBuilder
             var services = new ServiceCollection();
             services.AddLogging();
             services.AddServiceModelServices();
-            var serverAddressesFeature = new ServerAddressesFeature();
-            serverAddressesFeature.Addresses.Add(serviceAddress);
             IServer server = new MockServer();
-            server.Features.Set<IServerAddressesFeature>(serverAddressesFeature);
             services.AddSingleton(server);
             services.AddSingleton(new SimpleSingletonService());
             var serviceProvider = services.BuildServiceProvider();
             var serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
+            serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
             serviceBuilder.AddService<SimpleSingletonService>();
             var binding = new CustomBinding("BindingName", "BindingNS");
             binding.Elements.Add(new MockTransportBindingElement());
             serviceBuilder.AddServiceEndpoint<SimpleSingletonService, ISimpleService>(binding, serviceAddress);
+            serviceBuilder.OpenAsync().GetAwaiter().GetResult();
             var dispatcherBuilder = serviceProvider.GetRequiredService<IDispatcherBuilder>();
             var dispatchers = dispatcherBuilder.BuildDispatchers(typeof(SimpleSingletonService));
             Assert.Single(dispatchers);
@@ -118,20 +115,18 @@ namespace DispatchBuilder
             services.AddLogging();
             services.AddServiceModelServices();
 
-            var serverAddressesFeature = new ServerAddressesFeature();
-            serverAddressesFeature.Addresses.Add(serviceAddress);
-
             IServer server = new MockServer();
-            server.Features.Set<IServerAddressesFeature>(serverAddressesFeature);
             services.AddSingleton(server);
 
             var serviceProvider = services.BuildServiceProvider();
             var serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
+            serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
             serviceBuilder.AddService<SimpleXmlSerializerService>();
 
             var binding = new CustomBinding("BindingName", "BindingNS");
             binding.Elements.Add(new MockTransportBindingElement());
             serviceBuilder.AddServiceEndpoint<SimpleXmlSerializerService, ISimpleXmlSerializerService>(binding, serviceAddress);
+            serviceBuilder.OpenAsync().GetAwaiter().GetResult();
 
             var dispatcherBuilder = serviceProvider.GetRequiredService<IDispatcherBuilder>();
             var dispatchers = dispatcherBuilder.BuildDispatchers(typeof(SimpleXmlSerializerService));

--- a/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherChannelFactory.cs
+++ b/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherChannelFactory.cs
@@ -97,6 +97,7 @@ namespace DispatcherClient
             var binding = new CoreWCF.Channels.CustomBinding("BindingName", "BindingNS");
             binding.Elements.Add(new Helpers.MockTransportBindingElement());
             serviceBuilder.AddServiceEndpoint<TService, TContract>(binding, channel.Via);
+            await serviceBuilder.OpenAsync();
             var dispatcherBuilder = _serviceProvider.GetRequiredService<IDispatcherBuilder>();
             var dispatchers = dispatcherBuilder.BuildDispatchers(typeof(TService));
             var serviceDispatcher = dispatchers[0];

--- a/src/CoreWCF.sln
+++ b/src/CoreWCF.sln
@@ -18,20 +18,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreWCF.NetTcp.Tests", "Cor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreWCF.Primitives.Tests", "CoreWCF.Primitives\tests\CoreWCF.Primitives.Tests.csproj", "{0BAAF301-23F3-49AC-B167-B8A88565F95B}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{083F2ED2-5D26-4EEB-A410-29ADCC0C4B42}"
-	ProjectSection(SolutionItems) = preProject
-		Samples\CoreWCF Postman Samples Collection.json = Samples\CoreWCF Postman Samples Collection.json
-		README.MD = README.MD
-	EndProjectSection
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCoreServer", "Samples\NetCoreServer\NetCoreServer.csproj", "{3FB095F3-767E-470D-918D-A8BE546C8217}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCoreClient", "Samples\NetCoreClient\NetCoreClient.csproj", "{F270C4F1-6F1D-44B1-B29F-97C8D810C209}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DesktopClient", "Samples\DesktopClient\DesktopClient.csproj", "{AC474D52-EC86-43CC-AE48-579D9465DE2D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DesktopServer", "Samples\DesktopServer\DesktopServer.csproj", "{53D7DDAB-757E-42DF-A064-62E97C7AD813}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DAAE6286-93E2-4F2B-81D2-A32A9F024595}"
 	ProjectSection(SolutionItems) = preProject
 		..\azure-pipelines.yml = ..\azure-pipelines.yml
@@ -125,54 +111,6 @@ Global
 		{0BAAF301-23F3-49AC-B167-B8A88565F95B}.Release|x64.Build.0 = Release|Any CPU
 		{0BAAF301-23F3-49AC-B167-B8A88565F95B}.Release|x86.ActiveCfg = Release|Any CPU
 		{0BAAF301-23F3-49AC-B167-B8A88565F95B}.Release|x86.Build.0 = Release|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Debug|x64.Build.0 = Debug|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Debug|x86.Build.0 = Debug|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Release|x64.ActiveCfg = Release|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Release|x64.Build.0 = Release|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Release|x86.ActiveCfg = Release|Any CPU
-		{3FB095F3-767E-470D-918D-A8BE546C8217}.Release|x86.Build.0 = Release|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Debug|x64.Build.0 = Debug|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Debug|x86.Build.0 = Debug|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Release|x64.ActiveCfg = Release|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Release|x64.Build.0 = Release|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Release|x86.ActiveCfg = Release|Any CPU
-		{F270C4F1-6F1D-44B1-B29F-97C8D810C209}.Release|x86.Build.0 = Release|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Debug|x64.Build.0 = Debug|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Debug|x86.Build.0 = Debug|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Release|x64.ActiveCfg = Release|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Release|x64.Build.0 = Release|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Release|x86.ActiveCfg = Release|Any CPU
-		{AC474D52-EC86-43CC-AE48-579D9465DE2D}.Release|x86.Build.0 = Release|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Debug|x64.Build.0 = Debug|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Debug|x86.Build.0 = Debug|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Release|Any CPU.Build.0 = Release|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Release|x64.ActiveCfg = Release|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Release|x64.Build.0 = Release|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Release|x86.ActiveCfg = Release|Any CPU
-		{53D7DDAB-757E-42DF-A064-62E97C7AD813}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Samples/NetCoreServer/Program.cs
+++ b/src/Samples/NetCoreServer/Program.cs
@@ -16,7 +16,6 @@ namespace NetCoreServer
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
             .UseKestrel(options => { options.ListenLocalhost(8080); })
-            .UseUrls("http://localhost:8080")
             .UseNetTcp(8808)
             .UseStartup<Startup>();
     }


### PR DESCRIPTION
Fixes #226 
This change removes the need for UseUrl and fixes an early change which ended up requiring an HTTP endpoint. It replaces using ServerAddressFeature to obtain the BaseAddresses url's with a mechanism so that the transports can register a BaseAddress more directly.