### PR TITLE
Updated Platform Details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Please start a discussion on the [core repo issue tracker](https://github.com/Co
 
 ## Platform
 
-Core WCF is built on top of .NET Core 2.2.
+Core WCF is built targeting .NET Standard 2.0
 
 ## Building
 


### PR DESCRIPTION
Original wording said Core WCF was built on top of .NET Core 2.2. This is not accurate. Core WCF targets .NET Standard 2.0.