### PR TITLE
Fix race condition when new request is waiting for the instance just as it's being released

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ConcurrencyBehavior.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ConcurrencyBehavior.cs
@@ -88,7 +88,7 @@ namespace CoreWCF.Dispatcher
             if (concurrencyMode != ConcurrencyMode.Multiple)
             {
                 ConcurrencyInstanceContextFacet resource = rpc.InstanceContext.Concurrency;
-                bool needToWait = false;
+                Task waiter = null;
                 lock (rpc.InstanceContext.ThisLock)
                 {
                     if (!resource.Locked)
@@ -97,13 +97,13 @@ namespace CoreWCF.Dispatcher
                     }
                     else
                     {
-                        needToWait = true;
+                        waiter = resource.EnqueueNewMessage();
                     }
                 }
 
-                if (needToWait)
+                if (waiter != null)
                 {
-                    await resource.EnqueueNewMessage();
+                    await waiter;
                 }
 
                 // TODO: Throw this on setup


### PR DESCRIPTION
Basically the queue isn't being created under the lock so when the instance context is being released under lock, it checks and sees the queue either doesn't exist yet or doesn't have an item in the queue. This fix updates the queue under lock and only await's the returned task outside the lock.