### PR TITLE
Fix charset parsing when there are quotes used

### DIFF
--- a/src/CoreWCF.Http/tests/RegressionFixes.cs
+++ b/src/CoreWCF.Http/tests/RegressionFixes.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Http.Tests
+{
+    // This class is for tests to validate we don't regress on targetted fixes to behavior
+    public class RegressionFixes
+    {
+        private readonly ITestOutputHelper _output;
+
+        public RegressionFixes(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void HandleQuotesInContentTypeCharSet()
+        {
+            string testString = new string('a', 3000);
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<StartupCharSetQuotes>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                System.ServiceModel.BasicHttpBinding httpBinding = ClientHelper.GetBufferedModeBinding();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IEchoService>(httpBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/ITestBasicScenariosService.svc")));
+                ClientContract.IEchoService channel = factory.CreateChannel();
+                var result = channel.EchoString(testString);
+                Assert.Equal(testString, result);
+            }
+        }
+
+        internal class StartupCharSetQuotes : StartupBase
+        {
+            public override void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.Use(async (context, next) =>
+                {
+                    var typedHeaders = context.Request.GetTypedHeaders();
+                    var contentType = typedHeaders.ContentType;
+                    contentType.Charset = '"' + contentType.Charset.ToString() + '"';
+                    typedHeaders.ContentType = contentType;
+                    await next.Invoke();
+                });
+                base.Configure(app, env);
+            }
+        }
+
+        internal abstract class StartupBase
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public virtual void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.EchoService>();
+                    builder.AddServiceEndpoint<Services.EchoService, ServiceContract.IEchoService>(new BasicHttpBinding(), "/BasicWcfService/ITestBasicScenariosService.svc");
+                });
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/TextMessageEncoderFactory.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/TextMessageEncoderFactory.cs
@@ -343,7 +343,20 @@ namespace CoreWCF.Channels
 
             internal override bool IsCharSetSupported(string charSet)
             {
-                return TextEncoderDefaults.TryGetEncoding(charSet, out Encoding tmp);
+                Encoding tmp;
+                if (!TextEncoderDefaults.TryGetEncoding(charSet, out tmp))
+                {
+                    // GetEncodingFromContentType supports charset with quotes (by simply stripping them) so we do the same here
+                    // This also gives us parity with Desktop WCF behavior
+                    if (charSet.Length > 2 && charSet[0] == '"' && charSet[charSet.Length - 1] == '"')
+                    {
+                        charSet = charSet.Substring(1, charSet.Length - 2);
+                        return TextEncoderDefaults.TryGetEncoding(charSet, out tmp);
+                    }
+                    return false;
+                }
+
+                return true;
             }
 
             public override bool IsContentTypeSupported(string contentType)


### PR DESCRIPTION
When the content type has quotes around the charset, e.g. `text/xml; charset="UTF-8"`, the TextMessageEncoder can't parse the charset because of the quotes. This fix is copied from the fix for the same issue in the WCF core client so skipping CR as it was CR'd there.