### PR TITLE
Skip wrapping IServer when IIS hosted

### DIFF
--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.7.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\CoreWCF.NetTcp.csproj" />

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/IService.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/IService.cs
@@ -1,9 +1,0 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace CoreWCF.Configuration
-{
-    public interface IService
-    {
-    }
-}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceModelServiceCollectionExtensions.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceModelServiceCollectionExtensions.cs
@@ -14,6 +14,8 @@ namespace CoreWCF.Configuration
 {
     public static class ServiceModelServiceCollectionExtensions
     {
+        private const string IISHttpServerTypeName = "Microsoft.AspNetCore.Server.IIS.Core.IISHttpServer";
+
         public static IServiceCollection AddServiceModelServices(this IServiceCollection services)
         {
             if (services == null)
@@ -27,6 +29,12 @@ namespace CoreWCF.Configuration
                 {
                     if (services[i].ImplementationType != null)
                     {
+                        if (services[i].ImplementationType.FullName.Equals(IISHttpServerTypeName))
+                        {
+                            // Don't wrap IISHttpServer as there isn't a console app to discover any thrown exception at startup
+                            continue;
+                        }
+
                         Type implType = services[i].ImplementationType;
                         if (!services.Any(d => d.ServiceType == implType))
                         {

--- a/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
@@ -27,6 +27,9 @@ namespace CoreWCF.Primitives.Tests
             Assert.Equal(builder, builder.AddServiceEndpoint<SomeService>(typeof(IService), new NoBinding(), "http://localhost:8088/SomeService.svc"));
         }
 
+        [ServiceContract]
+        public interface IService { }
+
         public class SomeService : IService { }
 
         public class NoBinding : Binding


### PR DESCRIPTION
Also removed accidental dummy IServer interface from CoreWCF.Configuration

Fixes #313 