### PR TITLE
Fix HttpSys and IIS hosting, added HttpSys tests

### DIFF
--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -28,6 +28,7 @@
       <Version Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'net472'">2.2.0</Version>
       <Version Condition="!('$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'net472')">3.1.7</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />

--- a/src/CoreWCF.Http/tests/Helpers/IntegrationTest.cs
+++ b/src/CoreWCF.Http/tests/Helpers/IntegrationTest.cs
@@ -22,8 +22,9 @@ namespace CoreWCF.Http.Tests.Helpers
     public class IntegrationTest<TStartup> : WebApplicationFactory<TStartup> where TStartup : class
     {
         protected override TestServer CreateServer(IWebHostBuilder builder)
-        {       
+        {
             var addresses = new ServerAddressesFeature();
+            addresses.Addresses.Add("http://localhost/");
             var features = new FeatureCollection();
             features.Set<IServerAddressesFeature>(addresses); 
 

--- a/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
@@ -80,6 +80,28 @@ namespace Helpers
         //    };
         //}
 
+        public static IWebHostBuilder CreateHttpSysBuilder<TStartup>(ITestOutputHelper outputHelper = default) where TStartup : class =>
+            WebHost.CreateDefaultBuilder(Array.Empty<string>())
+#if DEBUG
+            .ConfigureLogging((ILoggingBuilder logging) =>
+            {
+                if (outputHelper != default)
+                    logging.AddProvider(new XunitLoggerProvider(outputHelper));
+                logging.AddFilter("Default", LogLevel.Debug);
+                logging.AddFilter("Microsoft", LogLevel.Debug);
+                logging.SetMinimumLevel(LogLevel.Debug);
+            })
+#endif // DEBUG
+            .UseHttpSys(options =>
+            {
+                options.Authentication.Schemes = Microsoft.AspNetCore.Server.HttpSys.AuthenticationSchemes.None;
+                options.Authentication.AllowAnonymous = true;
+                options.AllowSynchronousIO = true;
+                options.UrlPrefixes.Add("http://+:80/Temporary_Listen_Addresses/CoreWCFTestServices");
+                options.UrlPrefixes.Add("http://+:80/Temporary_Listen_Addresses/CoreWCFTestServices/MorePath");
+            })
+            .UseStartup<TStartup>();
+
         public static IWebHostBuilder CreateWebHostBuilder<TStartup>(ITestOutputHelper outputHelper = default) where TStartup : class =>
             WebHost.CreateDefaultBuilder(Array.Empty<string>())
 #if DEBUG

--- a/src/CoreWCF.Http/tests/HttpSysTests.cs
+++ b/src/CoreWCF.Http/tests/HttpSysTests.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Http.Tests
+{
+    public class HttpSysTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public HttpSysTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        [Trait("Category", "WindowsOnly")]
+        public void BasicHttpRequestReplyEchoString()
+        {
+            string testString = new string('a', 3000);
+            IWebHost host = ServiceHelper.CreateHttpSysBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                System.ServiceModel.BasicHttpBinding httpBinding = ClientHelper.GetBufferedModeBinding();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IEchoService>(httpBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost/Temporary_Listen_Addresses/CoreWCFTestServices/BasicWcfService/basichttp.svc")));
+                ClientContract.IEchoService channel = factory.CreateChannel();
+                string result = channel.EchoString(testString);
+                Assert.Equal(testString, result);
+                // Work around HttpSys host bug where it doesn't cancel a callback timer
+                // and causes the host to write to the ILogger after the test has ended
+                // which causes xunit to abort the test run. See dotnet/aspnetcore#30828
+                var cts = new CancellationTokenSource();
+                host.StopAsync(cts.Token).GetAwaiter().GetResult();
+                cts.Cancel();
+                cts.Dispose();
+            }
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.EchoService>();
+                    builder.AddServiceEndpoint<Services.EchoService, ServiceContract.IEchoService>(new CoreWCF.BasicHttpBinding(), "/BasicWcfService/basichttp.svc");
+                });
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
@@ -7,6 +7,7 @@
     <RootNamespace />
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/DispatcherBuilder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/DispatcherBuilder.cs
@@ -11,6 +11,7 @@ using CoreWCF.Configuration;
 using CoreWCF.Dispatcher;
 using CoreWCF.Runtime;
 using CoreWCF.Security;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CoreWCF.Description
@@ -681,7 +682,6 @@ namespace CoreWCF.Description
                 }
 
                 ContractDescription contract = serviceHost.ReflectedContracts[endpointConfig.Contract];
-
                 Uri uri = serviceHost.MakeAbsoluteUri(endpointConfig.Address, endpointConfig.Binding);
                 var serviceEndpoint = new ServiceEndpoint(
                     contract,

--- a/src/CoreWCF.Primitives/tests/DispatchBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/DispatchBuilderTests.cs
@@ -6,9 +6,13 @@ using System.Threading;
 using CoreWCF.Channels;
 using CoreWCF.Configuration;
 using Helpers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace DispatchBuilder
@@ -24,6 +28,8 @@ namespace DispatchBuilder
             services.AddServiceModelServices();
             IServer server = new MockServer();
             services.AddSingleton(server);
+            services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+            services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             IServiceBuilder serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
             serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
@@ -55,6 +61,8 @@ namespace DispatchBuilder
             services.AddServiceModelServices();
             IServer server = new MockServer();
             services.AddSingleton(server);
+            services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+            services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             IServiceBuilder serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
             serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
@@ -87,6 +95,8 @@ namespace DispatchBuilder
             IServer server = new MockServer();
             services.AddSingleton(server);
             services.AddSingleton(new SimpleSingletonService());
+            services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+            services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             IServiceBuilder serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
             serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
@@ -120,6 +130,8 @@ namespace DispatchBuilder
 
             IServer server = new MockServer();
             services.AddSingleton(server);
+            services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+            services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
 
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             IServiceBuilder serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();

--- a/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherHelper.cs
+++ b/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherHelper.cs
@@ -4,8 +4,12 @@
 using System;
 using System.ServiceModel;
 using CoreWCF.Description;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DispatcherClient
 {
@@ -21,6 +25,8 @@ namespace DispatcherClient
                 IServerAddressesFeature serverAddressesFeature = new ServerAddressesFeature();
                 serverAddressesFeature.Addresses.Add(new Uri(s_endpointAddress).GetLeftPart(UriPartial.Authority) + "/");
                 services.AddSingleton(serverAddressesFeature);
+                services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+                services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
             }, configureServiceHostBase);
             return new ChannelFactory<TContract>(binding, new EndpointAddress(s_endpointAddress));
         }

--- a/src/CoreWCF.Primitives/tests/Helpers/MockServer.cs
+++ b/src/CoreWCF.Primitives/tests/Helpers/MockServer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http.Features;
 
 namespace Helpers
@@ -12,6 +13,13 @@ namespace Helpers
 
     internal class MockServer : IServer
     {
+        public MockServer()
+        {
+            var addresses = new ServerAddressesFeature();
+            addresses.Addresses.Add("http://localhost/");
+            Features.Set<IServerAddressesFeature>(addresses);
+        }
+
         public IFeatureCollection Features { get; } = new FeatureCollection();
 
         public void Dispose()

--- a/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
@@ -4,7 +4,11 @@
 using System;
 using CoreWCF.Channels;
 using CoreWCF.Configuration;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace CoreWCF.Primitives.Tests
@@ -16,6 +20,8 @@ namespace CoreWCF.Primitives.Tests
         {
             var services = new ServiceCollection();
             services.AddServiceModelServices();
+            services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+            services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             IServiceBuilder builder = serviceProvider.GetRequiredService<IServiceBuilder>();
 


### PR DESCRIPTION
IIS Host adds non-http bindings to IServerAddresses, this skip's those.
HttpSys has a base path which broke address mapping, this fixes that.
HttpSys can use + or * wildcards in server address, this fixes that.