### PR TITLE
Use AsyncManualResetEvent in ChannelHandler, remove ResettableAsyncWaitable

### DIFF
--- a/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
+++ b/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -475,52 +475,6 @@ namespace CoreWCF.Runtime
         internal static void PostCallback(object state)
         {
             ((Action)state)();
-        }
-    }
-
-    internal class ResettableAsyncWaitable
-    {
-        private TaskCompletionSource<object> _tcs = null;
-
-        public bool IsSet => _tcs?.Task.IsCompleted ?? false;
-
-        public void Reset()
-        {
-            if (!(_tcs?.Task.IsCompleted ?? true))
-            {
-                Fx.Exception.AsError(new InvalidOperationException(nameof(Reset)));
-            }
-
-            Interlocked.Exchange(ref _tcs, null);
-        }
-
-        public void Set()
-        {
-            TaskCompletionSource<object> tcs = _tcs;
-            if (tcs == null)
-            {
-                TaskCompletionSource<object> temp = CreateTcs();
-                tcs = Interlocked.CompareExchange(ref _tcs, temp, null) ?? temp;
-            }
-
-            tcs.TrySetResult(null);
-        }
-
-        public TaskAwaiter<object> GetAwaiter()
-        {
-            TaskCompletionSource<object> tcs = _tcs;
-            if (tcs == null)
-            {
-                TaskCompletionSource<object> temp = CreateTcs();
-                tcs = Interlocked.CompareExchange(ref _tcs, temp, null) ?? temp;
-            }
-
-            return tcs.Task.GetAwaiter();
-        }
-
-        private TaskCompletionSource<object> CreateTcs()
-        {
-            return new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
         }
     }
 

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ChannelHandler.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ChannelHandler.cs
@@ -39,7 +39,7 @@ namespace CoreWCF.Dispatcher
         private bool _shouldRejectMessageWithOnOpenActionHeader;
         private RequestContext _replied;
         private readonly bool _incrementedActivityCountInConstructor;
-        private readonly ResettableAsyncWaitable _resettableAsyncWaitable;
+        private readonly AsyncManualResetEvent _asyncManualResetEvent;
         private bool _openCalled;
 
         internal ChannelHandler(MessageVersion messageVersion, IChannelBinder binder, ServiceThrottle throttle,
@@ -83,7 +83,7 @@ namespace CoreWCF.Dispatcher
             _serviceDispatcher.ChannelDispatcher.Channels.IncrementActivityCount();
             _incrementedActivityCountInConstructor = true;
             //}
-            _resettableAsyncWaitable = new ResettableAsyncWaitable();
+            _asyncManualResetEvent = new AsyncManualResetEvent();
         }
 
         internal IServiceChannelDispatcher GetDispatcher()
@@ -209,7 +209,7 @@ namespace CoreWCF.Dispatcher
 
         public void EnsureReceive()
         {
-            _resettableAsyncWaitable.Set();
+            _asyncManualResetEvent.Set();
         }
 
         public Task DispatchAsync(Message message)
@@ -1007,7 +1007,7 @@ namespace CoreWCF.Dispatcher
         {
             if (_isConcurrent)
             {
-                _resettableAsyncWaitable.Set();
+                _asyncManualResetEvent.Set();
             }
         }
 
@@ -1015,8 +1015,8 @@ namespace CoreWCF.Dispatcher
         {
             if (_isConcurrent)
             {
-                await _resettableAsyncWaitable;
-                _resettableAsyncWaitable.Reset();
+                await _asyncManualResetEvent.WaitAsync();
+                _asyncManualResetEvent.Reset();
             }
         }
 


### PR DESCRIPTION
In doing some load testing for a migration, I found that a very small percentage of requests timed out. Catching it in a debugger, the long request was stuck on the await on https://github.com/CoreWCF/CoreWCF/compare/main...BradBarnich:deadlock?expand=1#diff-b59ad09365ce977d3b5d54beb9f8c4396253e434b320f7bcb7805e58f755f1c6L1018

I think something is not quite correct in the CompareExchange code of ResettableAsyncWaitable. Luckily there is another implementation of an async reset event in CoreWCF, https://github.com/CoreWCF/CoreWCF/blob/main/src/CoreWCF.Primitives/src/CoreWCF/Runtime/AsyncManualResetEvent.cs 

The issue when away when I switched to that.

