### PR TITLE
Update sdk version

### DIFF
--- a/templates/BuildStage.yml
+++ b/templates/BuildStage.yml
@@ -20,7 +20,7 @@ stages:
         displayName: 'Use .NET Core sdk'
         inputs:
           packageType: sdk
-          version: 3.1.x
+          version: 5.0.x
           installationPath: $(Agent.ToolsDirectory)/dotnet
 
       # NGBV project at https://github.com/dotnet/Nerdbank.GitVersioning

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.3.0-alpha",
+  "version": "0.3.0-alpha.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
Using an older SDK version causes produced packages to not include the compiler flags in a reproducible way.
GitVersion was always producing the exact same package version with no build number suffix.