### PR TITLE
Minor patch to make happy path of duplex channel working

### DIFF
--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.8.1" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.8.1" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>

--- a/src/CoreWCF.NetTcp/tests/DuplexServiceTests.cs
+++ b/src/CoreWCF.NetTcp/tests/DuplexServiceTests.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ServiceModel.Channels;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.NetTcp.Tests
+{
+    public class DuplexServiceTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public DuplexServiceTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void DuplexEcho()
+        {
+            string testString = new string('a', 3000);
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                System.ServiceModel.ChannelFactory<ServiceContract.IDuplexTestService> factory = null;
+                ServiceContract.IDuplexTestService channel = null;
+                host.Start();
+                try
+                {
+                    System.ServiceModel.NetTcpBinding binding = ClientHelper.GetBufferedModeBinding();
+                    var callback = new ServiceContract.DuplexTestCallback();
+                    factory = new System.ServiceModel.DuplexChannelFactory<ServiceContract.IDuplexTestService>(
+                        new System.ServiceModel.InstanceContext(callback),
+                        binding,
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + Startup.DuplexRelativeAddress));
+                    channel = factory.CreateChannel();
+                    ((IChannel)channel).Open();
+                    var registerSuccess = channel.RegisterDuplexChannel();
+                    Assert.True(registerSuccess, "Registration was not successful");
+                    channel.SendMessage(testString);
+                    Assert.Equal(1, callback.ReceivedMessages.Count);
+                    Assert.Equal(testString, callback.ReceivedMessages[0]);
+                    ((IChannel)channel).Close();
+                    factory.Close();
+                }
+                finally
+                {
+                    ServiceHelper.CloseServiceModelObjects((IChannel)channel, factory);
+                }
+            }
+        }
+
+        public class Startup
+        {
+            public const string DuplexRelativeAddress = "/nettcp.duplex.svc/";
+
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.DuplexTestService>();
+                    builder.AddServiceEndpoint<Services.DuplexTestService, ServiceContract.IDuplexTestService>(new CoreWCF.NetTcpBinding(SecurityMode.None), DuplexRelativeAddress);
+                });
+            }
+        }
+    }
+}

--- a/src/CoreWCF.NetTcp/tests/ServiceContract/IDuplexTestService.cs
+++ b/src/CoreWCF.NetTcp/tests/ServiceContract/IDuplexTestService.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using CoreWCF;
+
+namespace ServiceContract
+{
+    internal static partial class Constants
+    {
+        public const string DUPLEX_TESTSERVICE_NAME = nameof(IDuplexTestService);
+        public const string DUPLEX_TESTCALLBACK_NAME = nameof(IDuplexTestCallback);
+        public const string DUPLEX_OPERATION_BASE = NS + DUPLEX_TESTSERVICE_NAME + "/";
+    }
+
+    [ServiceContract(Namespace = Constants.NS, Name = Constants.DUPLEX_TESTCALLBACK_NAME, SessionMode = SessionMode.Allowed)]
+    [System.ServiceModel.ServiceContract(Namespace = Constants.NS, Name = Constants.DUPLEX_TESTCALLBACK_NAME, SessionMode = System.ServiceModel.SessionMode.Allowed)]
+    public interface IDuplexTestCallback
+    {
+        [OperationContract(Name = "AddMessage", Action = Constants.DUPLEX_OPERATION_BASE + "AddMessage",
+            ReplyAction = Constants.DUPLEX_OPERATION_BASE + "AddMessageResponse")]
+        [System.ServiceModel.OperationContract(Name = "AddMessage", Action = Constants.DUPLEX_OPERATION_BASE + "AddMessage",
+            ReplyAction = Constants.DUPLEX_OPERATION_BASE + "AddMessageResponse")]
+        void AddMessage(string message);
+    }
+
+
+    public class DuplexTestCallback : IDuplexTestCallback
+    {
+        public IList<string> ReceivedMessages { get; } = new List<string>();
+
+        public void AddMessage(string message)
+        {
+            ReceivedMessages.Add(message);
+        }
+    }
+
+    [ServiceContract(Namespace = Constants.NS, Name = Constants.DUPLEX_TESTSERVICE_NAME, CallbackContract = typeof(IDuplexTestCallback))]
+    [System.ServiceModel.ServiceContract(Namespace = Constants.NS, Name = Constants.DUPLEX_TESTSERVICE_NAME, CallbackContract = typeof(IDuplexTestCallback))]
+    public interface IDuplexTestService
+    {
+        [OperationContract(Name = "RegisterDuplexChannel", Action = Constants.DUPLEX_OPERATION_BASE + "Echo",
+            ReplyAction = Constants.DUPLEX_OPERATION_BASE + "RegisterDuplexChannelResponse")]
+        [System.ServiceModel.OperationContract(Name = "RegisterDuplexChannel", Action = Constants.DUPLEX_OPERATION_BASE + "Echo",
+            ReplyAction = Constants.DUPLEX_OPERATION_BASE + "RegisterDuplexChannelResponse")]
+        bool RegisterDuplexChannel();
+
+        [OperationContract(Name = "SendMessage", Action = Constants.DUPLEX_OPERATION_BASE + "SendMessage",
+            ReplyAction = Constants.DUPLEX_OPERATION_BASE + "SendMessageResponse")]
+        [System.ServiceModel.OperationContract(Name = "SendMessage", Action = Constants.DUPLEX_OPERATION_BASE + "SendMessage",
+            ReplyAction = Constants.DUPLEX_OPERATION_BASE + "SendMessageResponse")]
+        void SendMessage(string message);
+    }
+}

--- a/src/CoreWCF.NetTcp/tests/ServiceContract/ITestService.cs
+++ b/src/CoreWCF.NetTcp/tests/ServiceContract/ITestService.cs
@@ -5,7 +5,7 @@ using CoreWCF;
 
 namespace ServiceContract
 {
-    internal static class Constants
+    internal static partial class Constants
     {
         public const string NS = "http://tempuri.org/";
         public const string TESTSERVICE_NAME = nameof(ITestService);

--- a/src/CoreWCF.NetTcp/tests/Services/DuplexTestService.cs
+++ b/src/CoreWCF.NetTcp/tests/Services/DuplexTestService.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using CoreWCF;
+using ServiceContract;
+
+namespace Services
+{
+    [ServiceBehavior(ConcurrencyMode = ConcurrencyMode.Multiple, InstanceContextMode = InstanceContextMode.Single)]
+    public class DuplexTestService : IDuplexTestService
+    {
+        private readonly IProducerConsumerCollection<IDuplexTestCallback> _registeredClients = new ConcurrentBag<IDuplexTestCallback>();
+
+        public bool RegisterDuplexChannel()
+        {
+            var callback = OperationContext.Current.GetCallbackChannel<IDuplexTestCallback>();
+            return _registeredClients.TryAdd(callback);
+        }
+
+        public void SendMessage(string message)
+        {
+            foreach (var client in _registeredClients)
+            {
+                client.AddMessage(message);
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/ServiceChannelProxy.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/ServiceChannelProxy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Reflection;
@@ -15,6 +16,9 @@ using CoreWCF.Runtime;
 
 namespace CoreWCF.Channels
 {
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.")]
     public class ServiceChannelProxy : DispatchProxy, ICommunicationObject, IChannel, IClientChannel, IOutputChannel, IRequestChannel, IServiceChannel, IDuplexContextChannel
     {
         private const string activityIdSlotName = "E2ETrace.ActivityID";
@@ -45,7 +49,7 @@ namespace CoreWCF.Channels
         //Workaround is to set the activityid in remoting call's LogicalCallContext
 
         // Override ToString() to reveal only the expected proxy type, not the generated one
-        public override string ToString()
+        public sealed override string ToString()
         {
             return _proxiedType.ToString();
         }
@@ -115,7 +119,7 @@ namespace CoreWCF.Channels
             return _serviceChannel;
         }
 
-        protected override object Invoke(MethodInfo targetMethod, object[] args)
+        protected sealed override object Invoke(MethodInfo targetMethod, object[] args)
         {
             if (args == null)
             {
@@ -659,14 +663,14 @@ namespace CoreWCF.Channels
             return _serviceChannel.RequestAsync(message, token);
         }
 
-        public Task CloseOutputSessionAsync(CancellationToken token)
+        Task IDuplexContextChannel.CloseOutputSessionAsync(CancellationToken token)
         {
             return ((IDuplexContextChannel)_serviceChannel).CloseOutputSessionAsync(token);
         }
 
         EndpointAddress IRequestChannel.RemoteAddress
         {
-            get { return ((IContextChannel)_serviceChannel).RemoteAddress; }
+            get { return _serviceChannel.RemoteAddress; }
         }
 
         Uri IRequestChannel.Via
@@ -679,7 +683,7 @@ namespace CoreWCF.Channels
             get { return _serviceChannel.ListenUri; }
         }
 
-        public bool AutomaticInputSessionShutdown
+        bool IDuplexContextChannel.AutomaticInputSessionShutdown
         {
             get
             {
@@ -692,7 +696,7 @@ namespace CoreWCF.Channels
             }
         }
 
-        public InstanceContext CallbackInstance
+        InstanceContext IDuplexContextChannel.CallbackInstance
         {
             get
             {
@@ -705,7 +709,7 @@ namespace CoreWCF.Channels
             }
         }
 
-        public IServiceChannelDispatcher ChannelDispatcher { get => ((IChannel)_serviceChannel).ChannelDispatcher; set => ((IChannel)_serviceChannel).ChannelDispatcher = value; }
+        IServiceChannelDispatcher IChannel.ChannelDispatcher { get => ((IChannel)_serviceChannel).ChannelDispatcher; set => ((IChannel)_serviceChannel).ChannelDispatcher = value; }
         #endregion // Channel interfaces
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/ServiceChannelProxy.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/ServiceChannelProxy.cs
@@ -15,7 +15,7 @@ using CoreWCF.Runtime;
 
 namespace CoreWCF.Channels
 {
-    internal sealed class ServiceChannelProxy : DispatchProxy, ICommunicationObject, IChannel, IClientChannel, IOutputChannel, IRequestChannel, IServiceChannel, IDuplexContextChannel
+    public class ServiceChannelProxy : DispatchProxy, ICommunicationObject, IChannel, IClientChannel, IOutputChannel, IRequestChannel, IServiceChannel, IDuplexContextChannel
     {
         private const string activityIdSlotName = "E2ETrace.ActivityID";
         private Type _proxiedType;


### PR DESCRIPTION
Relates to #318, #398
This PR adds a simple test for a duplex service where the server is broadcasting messages to clients. 

To get it actually green and working there was only a very small change needed. During some proxy class generation an exception was raised because the base class for the proxy was sealed and internal. By making it public the proxy generation works and the calls start to succeed. 

Please note that this is just a very basic minor patch to make a happy path working. I am not aware yet of certain paths which might not work. 