### PR TITLE
Set en-US culture to unit tests depending on en-US culture

### DIFF
--- a/src/Common/tests/UseCultureAttribute.cs
+++ b/src/Common/tests/UseCultureAttribute.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Xunit.Sdk;
+
+/// <summary>
+/// Apply this attribute to your test method to replace the
+/// <see cref="Thread.CurrentThread" /> <see cref="CultureInfo.CurrentCulture" /> and
+/// <see cref="CultureInfo.CurrentUICulture" /> with another culture.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public class UseCultureAttribute : BeforeAfterTestAttribute
+{
+    readonly Lazy<CultureInfo> culture;
+    readonly Lazy<CultureInfo> uiCulture;
+
+    CultureInfo originalCulture;
+    CultureInfo originalUICulture;
+
+    /// <summary>
+    /// Replaces the culture and UI culture of the current thread with
+    /// <paramref name="culture" />
+    /// </summary>
+    /// <param name="culture">The name of the culture.</param>
+    /// <remarks>
+    /// <para>
+    /// This constructor overload uses <paramref name="culture" /> for both
+    /// <see cref="Culture" /> and <see cref="UICulture" />.
+    /// </para>
+    /// </remarks>
+    public UseCultureAttribute(string culture)
+        : this(culture, culture) { }
+
+    /// <summary>
+    /// Replaces the culture and UI culture of the current thread with
+    /// <paramref name="culture" /> and <paramref name="uiCulture" />
+    /// </summary>
+    /// <param name="culture">The name of the culture.</param>
+    /// <param name="uiCulture">The name of the UI culture.</param>
+    public UseCultureAttribute(string culture, string uiCulture)
+    {
+        this.culture = new Lazy<CultureInfo>(() => new CultureInfo(culture, false));
+        this.uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture, false));
+    }
+
+    /// <summary>
+    /// Gets the culture.
+    /// </summary>
+    public CultureInfo Culture { get { return culture.Value; } }
+
+    /// <summary>
+    /// Gets the UI culture.
+    /// </summary>
+    public CultureInfo UICulture { get { return uiCulture.Value; } }
+
+    /// <summary>
+    /// Stores the current <see cref="Thread.CurrentPrincipal" />
+    /// <see cref="CultureInfo.CurrentCulture" /> and <see cref="CultureInfo.CurrentUICulture" />
+    /// and replaces them with the new cultures defined in the constructor.
+    /// </summary>
+    /// <param name="methodUnderTest">The method under test</param>
+    public override void Before(MethodInfo methodUnderTest)
+    {
+        originalCulture = Thread.CurrentThread.CurrentCulture;
+        originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+        Thread.CurrentThread.CurrentCulture = Culture;
+        Thread.CurrentThread.CurrentUICulture = UICulture;
+
+        CultureInfo.CurrentCulture.ClearCachedData();
+        CultureInfo.CurrentUICulture.ClearCachedData();
+    }
+
+    /// <summary>
+    /// Restores the original <see cref="CultureInfo.CurrentCulture" /> and
+    /// <see cref="CultureInfo.CurrentUICulture" /> to <see cref="Thread.CurrentPrincipal" />
+    /// </summary>
+    /// <param name="methodUnderTest">The method under test</param>
+    public override void After(MethodInfo methodUnderTest)
+    {
+        Thread.CurrentThread.CurrentCulture = originalCulture;
+        Thread.CurrentThread.CurrentUICulture = originalUICulture;
+
+        CultureInfo.CurrentCulture.ClearCachedData();
+        CultureInfo.CurrentUICulture.ClearCachedData();
+    }
+}

--- a/src/CoreWCF.Primitives/tests/ErrorHandling/ExceptionHandling.cs
+++ b/src/CoreWCF.Primitives/tests/ErrorHandling/ExceptionHandling.cs
@@ -2,7 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Runtime.CompilerServices;
+using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using CoreWCF;
 using DispatcherClient;
@@ -83,6 +84,7 @@ namespace ErrorHandling
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public static void ServiceThrowsExceptionDetailsIncludedInFault()
         {
             string exceptionMessage = "This is the exception message";

--- a/src/CoreWCF.Primitives/tests/MessageTests.cs
+++ b/src/CoreWCF.Primitives/tests/MessageTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Globalization;
 using System.Text;
+using System.Threading;
 using CoreWCF.Channels;
 using Xunit;
 
@@ -11,6 +13,7 @@ namespace CoreWCF.Primitives.Tests
     public static class MessageTests
     {
         [Fact]
+        [UseCulture("en-US")]
         public static void InvalidCharToString()
         {
             string invalidSoap11Message = @"<?xml version=""1.0"" encoding=""utf-8""?>


### PR DESCRIPTION
.net472 unit tests exception messages rely on user specific .net fwk language pack installed. fix #410 