### PR TITLE
Add net5.0 unit test target

### DIFF
--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/templates/TestStage.yml
+++ b/templates/TestStage.yml
@@ -18,6 +18,10 @@ stages:
           imageName: 'windows-latest'
           targetFramework: 'netcoreapp3.1'
           testArgs: ''
+        Windows_net5.0:
+          imageName: 'windows-latest'
+          targetFramework: 'net5.0'
+          testArgs: ''
         Windows_netfx:
           imageName: 'windows-latest'
           targetFramework: 'net472'
@@ -29,6 +33,10 @@ stages:
         Linux_netcore3.1:
           imageName: 'ubuntu-latest'
           targetFramework: 'netcoreapp3.1'
+          testArgs: '--filter Category!=WindowsOnly'
+        Linux_net5.0:
+          imageName: 'ubuntu-latest'
+          targetFramework: 'net5.0'
           testArgs: '--filter Category!=WindowsOnly'
     displayName: Test Release
     pool:
@@ -70,6 +78,10 @@ stages:
         Windows_netcore3.1:
           imageName: 'windows-latest'
           targetFramework: 'netcoreapp3.1'
+          testArgs: ''       
+        Windows_net5.0:
+          imageName: 'windows-latest'
+          targetFramework: 'net5.0'
           testArgs: ''
         Windows_netfx:
           imageName: 'windows-latest'
@@ -82,6 +94,10 @@ stages:
         Linux_netcore3.1:
           imageName: 'ubuntu-latest'
           targetFramework: 'netcoreapp3.1'
+          testArgs: '--filter Category!=WindowsOnly'
+        Linux_net5.0:
+          imageName: 'ubuntu-latest'
+          targetFramework: 'net5.0'
           testArgs: '--filter Category!=WindowsOnly'
     displayName: Test Debug
     pool:


### PR DESCRIPTION
As CoreWCF 0.2.0 is released and supports .net5 unit tests should also be ran targeting .net5