### PR TITLE
Use compiled lambda to access aspnetcore 5.0 remote endpoint

### DIFF
--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -28,13 +28,15 @@
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing">
-      <Version Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'net472'">2.2.0</Version>
-      <Version Condition="!('$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'net472')">3.1.17</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.17" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -23,16 +23,25 @@
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0'">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing">
       <Version Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'net472'">2.2.0</Version>
       <Version Condition="!('$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'net472')">3.1.17</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.8.1" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />
     <ProjectReference Include="..\src\CoreWCF.Http.csproj" />

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingConnection.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingConnection.cs
@@ -23,7 +23,6 @@ namespace CoreWCF.Channels.Framing
     {
         private readonly ConnectionContext _context;
         private IDuplexPipe _transport;
-        private Lazy<IPEndPoint> _remoteEndpoint;
 
         public FramingConnection(ConnectionContext context) : this(context, NullLogger.Instance) { }
 
@@ -38,7 +37,7 @@ namespace CoreWCF.Channels.Framing
 #else
             Transport = RawTransport = _context.Transport;
 #endif
-            _remoteEndpoint = new Lazy<IPEndPoint>(() => GetRemoteEndPoint(context));
+            RemoteEndpoint = GetRemoteEndPoint(context);
         }
 
         public MessageEncoderFactory MessageEncoderFactory { get; internal set; }
@@ -69,7 +68,7 @@ namespace CoreWCF.Channels.Framing
         public TransferMode TransferMode { get; internal set; }
         internal Stream RawStream { get; set; }
         public ILogger Logger { get; }
-        public IPEndPoint RemoteEndpoint => _remoteEndpoint.Value;
+        public IPEndPoint RemoteEndpoint { get; }
 
         internal void Reset()
         {

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -23,13 +23,13 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -18,13 +18,21 @@
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.8.1" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0'">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\src\CoreWCF.NetTcp.csproj" />
     <ProjectReference Include="..\..\CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -18,9 +18,17 @@
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0'">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="../src/CoreWCF.Primitives.csproj" />
   </ItemGroup>

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -21,11 +21,11 @@
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/CoreWCF.Primitives/tests/DispatchBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/DispatchBuilderTests.cs
@@ -2,14 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Threading;
 using CoreWCF.Channels;
 using CoreWCF.Configuration;
 using Helpers;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/CoreWCF.Primitives/tests/DispatchBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/DispatchBuilderTests.cs
@@ -29,7 +29,7 @@ namespace DispatchBuilder
             IServer server = new MockServer();
             services.AddSingleton(server);
             services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
-            services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
+            services.RegisterApplicationLifetime();
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             IServiceBuilder serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
             serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
@@ -62,7 +62,7 @@ namespace DispatchBuilder
             IServer server = new MockServer();
             services.AddSingleton(server);
             services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
-            services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
+            services.RegisterApplicationLifetime();
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             IServiceBuilder serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
             serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
@@ -96,7 +96,7 @@ namespace DispatchBuilder
             services.AddSingleton(server);
             services.AddSingleton(new SimpleSingletonService());
             services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
-            services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
+            services.RegisterApplicationLifetime();
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             IServiceBuilder serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
             serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
@@ -131,7 +131,7 @@ namespace DispatchBuilder
             IServer server = new MockServer();
             services.AddSingleton(server);
             services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
-            services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
+            services.RegisterApplicationLifetime();
 
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             IServiceBuilder serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();

--- a/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherHelper.cs
+++ b/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ServiceModel;
 using CoreWCF.Description;
+using Helpers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -26,7 +27,7 @@ namespace DispatcherClient
                 serverAddressesFeature.Addresses.Add(new Uri(s_endpointAddress).GetLeftPart(UriPartial.Authority) + "/");
                 services.AddSingleton(serverAddressesFeature);
                 services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
-                services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
+                services.RegisterApplicationLifetime();
             }, configureServiceHostBase);
             return new ChannelFactory<TContract>(binding, new EndpointAddress(s_endpointAddress));
         }

--- a/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherHelper.cs
+++ b/src/CoreWCF.Primitives/tests/DispatcherClient/DispatcherHelper.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.ServiceModel;
-using CoreWCF.Description;
 using Helpers;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/CoreWCF.Primitives/tests/Helpers/TestHelper.cs
+++ b/src/CoreWCF.Primitives/tests/Helpers/TestHelper.cs
@@ -201,7 +201,11 @@ namespace Helpers
         public static void RegisterApplicationLifetime(this IServiceCollection services)
         {
 #if NET5_0
-            services.AddSingleton(typeof(Microsoft.AspNetCore.Hosting.IApplicationLifetime), typeof(Microsoft.AspNetCore.Hosting.IApplicationLifetime).Assembly.GetType("Microsoft.AspNetCore.Hosting.ApplicationLifetime"));
+            services.AddSingleton<Microsoft.Extensions.Hosting.IHostApplicationLifetime, Microsoft.Extensions.Hosting.Internal.ApplicationLifetime>();
+            var genericWebHostApplicationLifetimeType =
+                typeof(Microsoft.AspNetCore.Hosting.WebHostBuilder).Assembly.GetType(
+                    "Microsoft.AspNetCore.Hosting.GenericWebHostApplicationLifetime");
+            services.AddSingleton(typeof(Microsoft.AspNetCore.Hosting.IApplicationLifetime), genericWebHostApplicationLifetimeType!);
 #else
             services.AddSingleton<Microsoft.AspNetCore.Hosting.IApplicationLifetime, Microsoft.AspNetCore.Hosting.Internal.ApplicationLifetime>();
 #endif

--- a/src/CoreWCF.Primitives/tests/Helpers/TestHelper.cs
+++ b/src/CoreWCF.Primitives/tests/Helpers/TestHelper.cs
@@ -200,7 +200,7 @@ namespace Helpers
 
         public static void RegisterApplicationLifetime(this IServiceCollection services)
         {
-#if NET5_0
+#if NET5_0 || NETCOREAPP3_1
             services.AddSingleton<Microsoft.Extensions.Hosting.IHostApplicationLifetime, Microsoft.Extensions.Hosting.Internal.ApplicationLifetime>();
             var genericWebHostApplicationLifetimeType =
                 typeof(Microsoft.AspNetCore.Hosting.WebHostBuilder).Assembly.GetType(

--- a/src/CoreWCF.Primitives/tests/Helpers/TestHelper.cs
+++ b/src/CoreWCF.Primitives/tests/Helpers/TestHelper.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using CoreWCF;
 using CoreWCF.Channels;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Helpers
 {
@@ -195,6 +196,16 @@ namespace Helpers
                     comObj.Abort();
                 }
             }
+        }
+
+        public static void RegisterApplicationLifetime(this IServiceCollection services)
+        {
+#if NET5_0
+            services.AddSingleton(typeof(Microsoft.AspNetCore.Hosting.IApplicationLifetime), typeof(Microsoft.AspNetCore.Hosting.IApplicationLifetime).Assembly.GetType("Microsoft.AspNetCore.Hosting.ApplicationLifetime"));
+#else
+            services.AddSingleton<Microsoft.AspNetCore.Hosting.IApplicationLifetime, Microsoft.AspNetCore.Hosting.Internal.ApplicationLifetime>();
+#endif
+
         }
     }
 }

--- a/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
@@ -5,8 +5,6 @@ using System;
 using CoreWCF.Channels;
 using CoreWCF.Configuration;
 using Helpers;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
+++ b/src/CoreWCF.Primitives/tests/ServiceBuilderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using CoreWCF.Channels;
 using CoreWCF.Configuration;
+using Helpers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +22,7 @@ namespace CoreWCF.Primitives.Tests
             var services = new ServiceCollection();
             services.AddServiceModelServices();
             services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
-            services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
+            services.RegisterApplicationLifetime();
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             IServiceBuilder builder = serviceProvider.GetRequiredService<IServiceBuilder>();
 


### PR DESCRIPTION
Fixes #409 

As requested [here ](https://github.com/CoreWCF/CoreWCF/issues/409#issuecomment-897792477) I added a reflection access to the new ASP.net core 5.x RemoteEndPoint property on the ConnectionContext. 

I did a bit an optimization already: 

* I use `Lazy<>` to avoid access to the data unless really needed. 
* I use a compiled lambda instead of always using reflection. 

To actually test it, I needed to adapt a bit the targeting of the test projects because of the version differences. ASP.net core became a framework reference. 

It partly duplicates what was done in #404 but in extension to it, it really pulls ASP.net core 5.0 instead of running ASP.net core 2.x under .net 5