### PR TITLE
Fix error with counting the number of incoming and outgoing parameters

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <!-- Configuring strong name signing -->
-  <PropertyGroup Condition="!($(IsTestProject) OR $(IsSampleProject)) AND Exists('$(ProjectDir)corewcf.snk')">
+  <PropertyGroup Condition="!$(IsSampleProject) AND Exists('$(ProjectDir)corewcf.snk')">
     <AssemblyOriginatorKeyFile>$(ProjectDir)corewcf.snk</AssemblyOriginatorKeyFile>
 	<SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/InvokerUtil.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/InvokerUtil.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 
@@ -87,10 +88,10 @@ namespace CoreWCF.Dispatcher
                 ParameterInfo[] parameters = method.GetParameters();
                 bool returnsValue = method.ReturnType != typeof(void);
                 int inputCount = parameters.Length;
-                inputParameterCount = inputCount;
+                inputParameterCount = parameters.Where(t => !t.IsOut || t.IsIn).Count();
 
                 var outputParamPositions = new List<int>();
-                for (int i = 0; i < inputParameterCount; i++)
+                for (int i = 0; i < inputCount; i++)
                 {
                     if (parameters[i].ParameterType.IsByRef)
                     {
@@ -108,7 +109,7 @@ namespace CoreWCF.Dispatcher
                     if (inputCount > 0)
                     {
                         inputsLocal = new object[inputCount];
-                        for (int i = 0; i < inputCount; i++)
+                        for (int i = 0; i < inputs.Length; i++)
                         {
                             inputsLocal[i] = inputs[i];
                         }

--- a/src/CoreWCF.Primitives/src/Properties/AssemblyInfo.cs
+++ b/src/CoreWCF.Primitives/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("CoreWCF.Primitives.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100cdf2c0662d7ab9ed20ea1a8013659f058589b0ee55f917f93f341459f392638c0da1a528ea5f6768bbb6d54b9e8b1a7fcf46b5b383f733126e0a1d7f7c19597f2c45237b36ac9fbe3459fd5060ba7381c15152dbe140cf1d137ab33540c1be4fbd9049f3ebc5c5471daf80d21a6456a17f53d73e383051cc899948c9c38cf4bf")]

--- a/src/CoreWCF.Primitives/tests/DispatcherServer/InvokerUtilGenerateInvokeDelegateTests.cs
+++ b/src/CoreWCF.Primitives/tests/DispatcherServer/InvokerUtilGenerateInvokeDelegateTests.cs
@@ -1,0 +1,199 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+using CoreWCF.Dispatcher;
+using CoreWCF.Primitives.Tests.DispatcherServer;
+
+using Xunit;
+
+namespace DispatcherServerTests
+{
+    public class InvokerUtilGenerateInvokeDelegateTests
+    {
+        [Fact]
+        public void MethodWithoutParams()
+        {
+            // void WithoutParams()
+            MethodInfo withoutParamsMethod = typeof(ServerMethods).GetMethod(nameof(ServerMethods.WithoutParams));
+
+            InvokeDelegateInfo invokeDelegateInfo = GenerateInvokeDelegate(withoutParamsMethod);
+
+            Assert.Equal(0, invokeDelegateInfo.InputParameterCount);
+            Assert.Equal(0, invokeDelegateInfo.OutputParameterCount);
+            Assert.Empty(invokeDelegateInfo.OutputParameters);
+        }
+
+        [Fact]
+        public void MethodWithoutParamsWithReturn()
+        {
+            //  byte WithoutParamsWithReturn()
+            MethodInfo withoutParamsWithReturnMethod = typeof(ServerMethods).GetMethod(nameof(ServerMethods.WithoutParamsWithReturn));
+
+            InvokeDelegateInfo invokeDelegateInfo = GenerateInvokeDelegate(withoutParamsWithReturnMethod);
+
+            Assert.Equal(0, invokeDelegateInfo.InputParameterCount);
+            Assert.Equal(0, invokeDelegateInfo.OutputParameterCount);
+            Assert.Equal(byte.MinValue, invokeDelegateInfo.Result);
+            Assert.Empty(invokeDelegateInfo.OutputParameters);
+        }
+
+        [Fact]
+        public void MethodWithoutParamsWithReturnGenericType()
+        {
+            // T WithoutParamsWithReturnGenericType<T>()
+            MethodInfo withoutParamsWithReturnGenericTypeMethod = typeof(ServerMethods).GetMethod(nameof(ServerMethods.WithoutParamsWithReturnGenericType));
+
+            Assert.ThrowsAny<InvalidOperationException>(() => GenerateInvokeDelegate(withoutParamsWithReturnGenericTypeMethod));
+
+        }
+
+        [Fact]
+        public void MethodWithOneValueParam()
+        {
+            MethodInfo withOneParamMethod = typeof(ServerMethods).GetMethod(nameof(ServerMethods.WithOneValueParam));
+            // void WithOneValueParam(byte param)
+            InvokeDelegateInfo invokeDelegateInfo = GenerateInvokeDelegate(withOneParamMethod, byte.MaxValue);
+
+            Assert.Equal(1, invokeDelegateInfo.InputParameterCount);
+            Assert.Equal(0, invokeDelegateInfo.OutputParameterCount);
+            Assert.Empty(invokeDelegateInfo.OutputParameters);
+        }
+
+        [Fact]
+        public void MethodWithOneOutParam()
+        {
+            // void WithOneOutParam(out byte param)
+            MethodInfo withOneOutParamMethod = typeof(ServerMethods).GetMethod(nameof(ServerMethods.WithOneOutParam));
+
+            InvokeDelegateInfo invokeDelegateInfo = GenerateInvokeDelegate(withOneOutParamMethod, byte.MaxValue);
+
+            Assert.Equal(0, invokeDelegateInfo.InputParameterCount);
+            Assert.Equal(1, invokeDelegateInfo.OutputParameterCount);
+            Assert.Equal(byte.MinValue, invokeDelegateInfo.OutputParameters[0]);
+        }
+
+        [Fact]
+        public void MethodWithOneRefParam()
+        {
+            // void WithOneRefParam(ref byte param)
+            MethodInfo withOneRefParamMethod = typeof(ServerMethods).GetMethod(nameof(ServerMethods.WithOneRefParam));
+
+            InvokeDelegateInfo invokeDelegateInfo = GenerateInvokeDelegate(withOneRefParamMethod, byte.MaxValue);
+
+            // ref is input and output type at the same time
+            Assert.Equal(1, invokeDelegateInfo.InputParameterCount);
+            Assert.Equal(1, invokeDelegateInfo.OutputParameterCount);
+            // WithOneRefParam set ref-param to byte.MinValue
+            Assert.Equal(byte.MinValue, invokeDelegateInfo.OutputParameters[0]);
+        }
+
+        [Fact]
+        public void MethodWithOneInParam()
+        {
+            MethodInfo withOneInParamMethod = typeof(ServerMethods).GetMethod(nameof(ServerMethods.WithOneInParam));
+
+            // void WithOneInParam(in byte param)
+            InvokeDelegateInfo invokeDelegateInfo = GenerateInvokeDelegate(withOneInParamMethod, byte.MaxValue);
+
+            // as ref param
+            Assert.Equal(1, invokeDelegateInfo.InputParameterCount);
+            Assert.Equal(1, invokeDelegateInfo.OutputParameterCount);
+            // in parameters doesn`t set up
+            Assert.Equal(byte.MaxValue, invokeDelegateInfo.OutputParameters[0]);
+        }
+
+        [Fact]
+        public void MethodWithOneValueAndTwoOutParam()
+        {
+            MethodInfo withOneValueAndTwoOutParamMethod = typeof(ServerMethods).GetMethod(nameof(ServerMethods.WithOneValueAndTwoOutParam));
+
+            //void WithOneValueAndTwoOutParam(out byte param1, byte param2, out byte param3)
+            InvokeDelegateInfo invokeDelegateInfo = GenerateInvokeDelegate(withOneValueAndTwoOutParamMethod, byte.MaxValue, byte.MaxValue, byte.MaxValue);
+
+            Assert.Equal(1, invokeDelegateInfo.InputParameterCount);
+            Assert.Equal(2, invokeDelegateInfo.OutputParameterCount);
+            // WithOneValueAndOutParam set out-param to byte.MinValue
+            Assert.Equal(byte.MinValue, invokeDelegateInfo.OutputParameters[0]);
+            Assert.Equal(byte.MinValue, invokeDelegateInfo.OutputParameters[1]);
+        }
+
+
+        [Fact]
+        public void MethodWithOneValueAndTwoRefParam()
+        {
+            MethodInfo withOneValueAndTwoRefParamMethod = typeof(ServerMethods).GetMethod(nameof(ServerMethods.WithOneValueAndTwoRefParam));
+
+            //void WithOneValueAndTwoRefParam(ref byte param1, byte param2, ref byte param3)
+            InvokeDelegateInfo invokeDelegateInfo = GenerateInvokeDelegate(withOneValueAndTwoRefParamMethod, byte.MaxValue, byte.MaxValue, byte.MaxValue);
+
+            // ref is input and output type at the same time
+            Assert.Equal(3, invokeDelegateInfo.InputParameterCount);
+            Assert.Equal(2, invokeDelegateInfo.OutputParameterCount);
+            // WithOneValueAndTwoRefParam set ref-param to byte.MinValue
+            Assert.Equal(byte.MinValue, invokeDelegateInfo.OutputParameters[0]);
+            Assert.Equal(byte.MinValue, invokeDelegateInfo.OutputParameters[1]);
+        }
+
+        [Fact]
+        public void MethodWithOneValueAndTwoInParam()
+        {
+            MethodInfo withOneValueAndTwoInParamMethod = typeof(ServerMethods).GetMethod(nameof(ServerMethods.WithOneValueAndTwoInParam));
+
+            //void WithOneValueAndTwoInParam(in byte param1, byte param2, in byte param3)
+            InvokeDelegateInfo invokeDelegateInfo = GenerateInvokeDelegate(withOneValueAndTwoInParamMethod, byte.MaxValue, byte.MaxValue, byte.MaxValue);
+
+            // as ref param
+            Assert.Equal(3, invokeDelegateInfo.InputParameterCount);
+            Assert.Equal(2, invokeDelegateInfo.OutputParameterCount);
+            // in parameters doesn`t set up
+            Assert.Equal(byte.MaxValue, invokeDelegateInfo.OutputParameters[0]);
+            Assert.Equal(byte.MaxValue, invokeDelegateInfo.OutputParameters[1]);
+        }
+
+        [Fact]
+        public void MethodWithAllTypeParam()
+        {
+            MethodInfo withAllTypeParamMethod = typeof(ServerMethods).GetMethod(nameof(ServerMethods.WithAllTypeParam));
+
+            //void WithAllTypeParam(in byte param1, byte param2, ref byte param3, out byte param4)
+            InvokeDelegateInfo invokeDelegateInfo = GenerateInvokeDelegate(withAllTypeParamMethod, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue);
+
+            // ref and in are input and output types at the same time
+            Assert.Equal(3, invokeDelegateInfo.InputParameterCount);
+            Assert.Equal(3, invokeDelegateInfo.OutputParameterCount);
+            // WithAllTypeParam set ref and out-param to byte.MinValue
+            // in parameters doesn`t set up
+            Assert.Equal(byte.MaxValue, invokeDelegateInfo.OutputParameters[0]);
+            Assert.Equal(byte.MinValue, invokeDelegateInfo.OutputParameters[1]);
+            Assert.Equal(byte.MinValue, invokeDelegateInfo.OutputParameters[2]);
+        }
+
+        private InvokeDelegateInfo GenerateInvokeDelegate(MethodInfo method, params object[] inputParameters)
+        {
+            InvokeDelegate invokeDelegate = InvokerUtil.GenerateInvokeDelegate(method, out int inputParameterCount, out int outputParameterCount);
+
+            object[] outputParameters = new object[outputParameterCount];
+            object result = invokeDelegate(ServerMethods.GetInstance(), inputParameters, outputParameters);
+
+            return new InvokeDelegateInfo
+            {
+                Result = result,
+                InputParameterCount = inputParameterCount,
+                OutputParameterCount = outputParameterCount,
+                OutputParameters = outputParameters
+            };
+        }
+
+        internal class InvokeDelegateInfo
+        {
+            public object Result;
+            public int InputParameterCount;
+            public int OutputParameterCount;
+            public object[] OutputParameters;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/tests/DispatcherServer/ServerMethods.cs
+++ b/src/CoreWCF.Primitives/tests/DispatcherServer/ServerMethods.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace CoreWCF.Primitives.Tests.DispatcherServer
+{
+    internal class ServerMethods
+    {
+        public static ServerMethods GetInstance()
+        {
+            return new ServerMethods();
+        }
+
+        public void WithoutParams()
+        {
+        }
+
+        public byte WithoutParamsWithReturn()
+        {
+            return byte.MinValue;
+        }
+
+        public T WithoutParamsWithReturnGenericType<T>()
+        {
+            return default(T);
+        }
+
+        public void WithOneValueParam(byte param)
+        {
+        }
+
+        public void WithOneOutParam(out byte param)
+        {
+            param = byte.MinValue;
+        }
+
+        public void WithOneInParam(in byte param)
+        {
+        }
+
+        public void WithOneRefParam(ref byte param)
+        {
+            param = byte.MinValue;
+        }
+
+        public void WithOneValueAndTwoOutParam(out byte param1, byte param2, out byte param3)
+        {
+            param1 = byte.MinValue;
+            param3 = byte.MinValue;
+        }
+
+        public void WithOneValueAndTwoRefParam(ref byte param1, byte param2, ref byte param3)
+        {
+            param1 = byte.MinValue;
+            param3 = byte.MinValue;
+        }
+
+        public void WithOneValueAndTwoInParam(in byte param1, byte param2, in byte param3)
+        {
+        }
+
+        public void WithAllTypeParam(in byte param1, byte param2, ref byte param3, out byte param4)
+        {
+            param3 = byte.MinValue;
+            param4 = byte.MinValue;
+        }
+        
+    }
+}


### PR DESCRIPTION
Fixes an error with counting method parameters if there are out parameters. The error can be reproduced if the method has only one parameter and it is out:
`void Test(out double count)`