### PR TITLE
Fix handling of ByRef parameters when generating invoke delegate.

### DIFF
--- a/src/CoreWCF.Http/tests/ByRefTests.cs
+++ b/src/CoreWCF.Http/tests/ByRefTests.cs
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Http.Tests
+{
+    public class ByRefTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ByRefTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void ByRefParams()
+        {
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                host.Start();
+
+                System.ServiceModel.BasicHttpBinding httpBinding = ClientHelper.GetBufferedModeBinding();
+
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IByRefService>(
+                    httpBinding,
+                    new System.ServiceModel.EndpointAddress(
+                        new Uri("http://localhost:8080/BasicWcfService/IByRefService.svc")));
+
+                ClientContract.IByRefService channel = factory.CreateChannel();
+
+                // Test that the out param is correctly decided by the input
+
+                channel.GetOutParam("test", out Guid guidA, true);
+                channel.GetOutParam("test", out Guid guidB, false);
+
+                Assert.Equal(Services.ByRefService.GuidA, guidA);
+                Assert.Equal(Services.ByRefService.GuidB, guidB);
+
+                // Test that the ref param is changed between ResultA and ResultB and the return value is correct
+
+                Guid refGuid = Services.ByRefService.GuidA;
+
+                bool exchangeResult1 = channel.ExchangeRefParam(ref refGuid);
+
+                Assert.True(exchangeResult1);
+                Assert.Equal(Services.ByRefService.GuidB, refGuid);
+
+                bool exchangeResult2 = channel.ExchangeRefParam(ref refGuid);
+
+                Assert.True(exchangeResult2);
+                Assert.Equal(Services.ByRefService.GuidA, refGuid);
+
+                Guid unknownGuid = Guid.Parse("11112222-3333-4444-5555-666677778888");
+
+                refGuid = unknownGuid;
+
+                bool exchangeResult3 = channel.ExchangeRefParam(ref refGuid);
+
+                Assert.False(exchangeResult3);
+                Assert.Equal(unknownGuid, refGuid);
+
+                // Test with both out and ref params. Chose which value is set using the bool argument.
+
+                string resultA = "unknown";
+                channel.SelectParam("test1", true, ref resultA, out string resultB);
+
+                Assert.Equal("test1", resultA);
+                Assert.Null(resultB);
+
+                string resultC = "test3";
+                channel.SelectParam("test2", false, ref resultC, out string resultD);
+
+                Assert.Equal("test2", resultD);
+                Assert.Equal("test3", resultC);
+            }
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.ByRefService>();
+                    builder.AddServiceEndpoint<Services.ByRefService, ServiceContract.IByRefService>(new BasicHttpBinding(), "/BasicWcfService/IByRefService.svc");
+                });
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Http/tests/ByRefTests.cs
+++ b/src/CoreWCF.Http/tests/ByRefTests.cs
@@ -38,6 +38,22 @@ namespace CoreWCF.Http.Tests
 
                 ClientContract.IByRefService channel = factory.CreateChannel();
 
+                // Test that out param behaves as expected
+
+                channel.SetNumber(33);
+
+                channel.GetNumber(out int num1);
+
+                Assert.Equal(33, num1);
+
+                // Test that InAttribute makes no difference
+
+                channel.SetNumberIn(41);
+
+                channel.GetNumber(out int num2);
+
+                Assert.Equal(41, num2);
+
                 // Test that the out param is correctly decided by the input
 
                 channel.GetOutParam("test", out Guid guidA, true);

--- a/src/CoreWCF.Http/tests/ClientContract/IByRefService.cs
+++ b/src/CoreWCF.Http/tests/ClientContract/IByRefService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.InteropServices;
 using System.ServiceModel;
 
 namespace ClientContract
@@ -17,5 +18,14 @@ namespace ClientContract
 
         [OperationContract]
         void SelectParam(string input, bool selection, ref string optionA, out string optionB);
+
+        [OperationContract]
+        void SetNumber(int number);
+
+        [OperationContract]
+        void SetNumberIn([In] int number);
+
+        [OperationContract]
+        void GetNumber(out int number);
     }
 }

--- a/src/CoreWCF.Http/tests/ClientContract/IByRefService.cs
+++ b/src/CoreWCF.Http/tests/ClientContract/IByRefService.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ServiceModel;
+
+namespace ClientContract
+{
+    [ServiceContract]
+    public interface IByRefService
+    {
+        [OperationContract]
+        void GetOutParam(string str, out Guid result, bool option);
+
+        [OperationContract]
+        bool ExchangeRefParam(ref Guid result);
+
+        [OperationContract]
+        void SelectParam(string input, bool selection, ref string optionA, out string optionB);
+    }
+}

--- a/src/CoreWCF.Http/tests/ServiceContract/IByRefService.cs
+++ b/src/CoreWCF.Http/tests/ServiceContract/IByRefService.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using CoreWCF;
+
+namespace ServiceContract
+{
+    [ServiceContract]
+    public interface IByRefService
+    {
+        [OperationContract]
+        void GetOutParam(string str, out Guid result, bool option);
+
+        [OperationContract]
+        bool ExchangeRefParam(ref Guid result);
+
+        [OperationContract]
+        void SelectParam(string input, bool selection, ref string optionA, out string optionB);
+    }
+}

--- a/src/CoreWCF.Http/tests/ServiceContract/IByRefService.cs
+++ b/src/CoreWCF.Http/tests/ServiceContract/IByRefService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.InteropServices;
 using CoreWCF;
 
 namespace ServiceContract
@@ -17,5 +18,14 @@ namespace ServiceContract
 
         [OperationContract]
         void SelectParam(string input, bool selection, ref string optionA, out string optionB);
+
+        [OperationContract]
+        void SetNumber(int number);
+
+        [OperationContract]
+        void SetNumberIn([In] int number);
+
+        [OperationContract]
+        void GetNumber(out int number);
     }
 }

--- a/src/CoreWCF.Http/tests/Services/ByRefService.cs
+++ b/src/CoreWCF.Http/tests/Services/ByRefService.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using CoreWCF;
+
+namespace Services
+{
+    [ServiceBehavior]
+    public class ByRefService : ServiceContract.IByRefService
+    {
+        public static readonly Guid GuidA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        public static readonly Guid GuidB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+        public void GetOutParam(string str, out Guid result, bool option)
+        {
+            result = option ? GuidA : GuidB;
+        }
+
+        public bool ExchangeRefParam(ref Guid result)
+        {
+            if (result == GuidA)
+            {
+                result = GuidB;
+                return true;
+            }
+
+            if (result == GuidB)
+            {
+                result = GuidA;
+                return true;
+            }
+
+            return false;
+        }
+
+        public void SelectParam(string input, bool selection, ref string optionA, out string optionB)
+        {
+            if (selection)
+            {
+                optionA = input;
+                optionB = null;
+            }
+            else
+            {
+                optionB = input;
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Http/tests/Services/ByRefService.cs
+++ b/src/CoreWCF.Http/tests/Services/ByRefService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.InteropServices;
 using CoreWCF;
 
 namespace Services
@@ -11,6 +12,8 @@ namespace Services
     {
         public static readonly Guid GuidA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         public static readonly Guid GuidB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+        private static volatile int s_number;
 
         public void GetOutParam(string str, out Guid result, bool option)
         {
@@ -45,6 +48,21 @@ namespace Services
             {
                 optionB = input;
             }
+        }
+
+        public void SetNumber(int number)
+        {
+            s_number = number;
+        }
+
+        public void SetNumberIn([In] int number)
+        {
+            s_number = number;
+        }
+
+        public void GetNumber(out int number)
+        {
+            number = s_number;
         }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/InvokerUtil.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/InvokerUtil.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
+using CoreWCF.Description;
 
 namespace CoreWCF.Dispatcher
 {
@@ -93,21 +94,14 @@ namespace CoreWCF.Dispatcher
                 var outputParamPositions = new List<int>();
                 for (int i = 0; i < parameters.Length; i++)
                 {
-                    if (parameters[i].ParameterType.IsByRef)
-                    {
-                        if (parameters[i].IsOut)
-                        {
-                            outputParamPositions.Add(i);
-                        }
-                        else
-                        {
-                            inputParamPositions.Add(i);
-                            outputParamPositions.Add(i);
-                        }
-                    }
-                    else
+                    if (ServiceReflector.FlowsIn(parameters[i]))
                     {
                         inputParamPositions.Add(i);
+                    }
+
+                    if (ServiceReflector.FlowsOut(parameters[i]))
+                    {
+                        outputParamPositions.Add(i);
                     }
                 }
                 


### PR DESCRIPTION
Fixes handling of out and ref parameters when generating an invoke delegate.

https://github.com/CoreWCF/CoreWCF/issues/196

Unfortunately I'm rather late with this PR as other work got in the way.

Also, it seems this PR may conflict with #416. At a glance, I don't think the other PR addresses cases where out or ref parameters may appear before input parameters in the parameter list.