### PR TITLE
Fixing typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ You will need to sign a [Contributor License Agreement](https://cla.dotnetfounda
 
 Make sure you can build the code. Familiarize yourself with the project workflow and our coding conventions. If you don't know what a pull request is read this article: https://help.github.com/articles/using-pull-requests.
 
-**We only accept PRs to the master branch.**
+**We only accept PRs to the main branch.**
 
 Before submitting a feature or substantial code contribution please discuss it with the team and ensure it follows the product roadmap. Here's a list of blog posts that are worth reading before doing a pull request:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There are pre-release packages available from a NuGet feed hosted in Azure DevOp
 
     https://pkgs.dev.azure.com/dotnet/CoreWCF/_packaging/CoreWCF/nuget/v3/index.json
 
-If you are using a nuget.config file with only the default nuget.org package source, after adding the CoreWCF feed it would like like this:
+If you are using a nuget.config file with only the default nuget.org package source, after adding the CoreWCF feed it would look like this:
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>


### PR DESCRIPTION
- Fixed a typo in the main readme.
- Changed the branch name from master to main in the contribution guideline.