### PR TITLE
Fixing when name is empty, support clientcredentialtype and refractoring

### DIFF
--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/BasicHttpBindingElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/BasicHttpBindingElement.cs
@@ -40,6 +40,7 @@ namespace CoreWCF.Configuration
                 ReaderQuotas = ReaderQuotas.Clone(),
             };
 
+            Security.ApplyConfiguration(binding.Security);
             return binding;
         }
     }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/BasicHttpMessageCredentialTypeHelper.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/BasicHttpMessageCredentialTypeHelper.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace CoreWCF.Configuration
+{
+    internal static class BasicHttpMessageCredentialTypeHelper
+    {
+        internal static bool IsDefined(BasicHttpMessageCredentialType value)
+        {
+            return (value == BasicHttpMessageCredentialType.UserName ||
+                value == BasicHttpMessageCredentialType.Certificate);
+        }
+    }
+}

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/BasicHttpMessageSecurityElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/BasicHttpMessageSecurityElement.cs
@@ -9,13 +9,14 @@ namespace CoreWCF.Configuration
 {
     public class BasicHttpMessageSecurityElement : ServiceModelConfigurationElement
     {
-        //[ConfigurationProperty(ConfigurationStrings.ClientCredentialType, DefaultValue = BasicHttpMessageSecurity.DefaultClientCredentialType)]
-        //[ServiceModelEnumValidator(typeof(BasicHttpMessageCredentialTypeHelper))]
-        //public BasicHttpMessageCredentialType ClientCredentialType
-        //{
-        //    get { return (BasicHttpMessageCredentialType)base[ConfigurationStrings.ClientCredentialType]; }
-        //    set { base[ConfigurationStrings.ClientCredentialType] = value; }
-        //}
+        internal const BasicHttpMessageCredentialType DefaultClientCredentialType = BasicHttpMessageCredentialType.UserName;
+
+        [ConfigurationProperty(ConfigurationStrings.ClientCredentialType, DefaultValue = DefaultClientCredentialType)]
+        public BasicHttpMessageCredentialType ClientCredentialType
+        {
+            get { return (BasicHttpMessageCredentialType)base[ConfigurationStrings.ClientCredentialType]; }
+            set { base[ConfigurationStrings.ClientCredentialType] = value; }
+        }
 
         [ConfigurationProperty(ConfigurationStrings.AlgorithmSuite, DefaultValue = ConfigurationStrings.Default)]
         [TypeConverter(typeof(SecurityAlgorithmSuiteConverter))]
@@ -23,6 +24,21 @@ namespace CoreWCF.Configuration
         {
             get { return (SecurityAlgorithmSuite)base[ConfigurationStrings.AlgorithmSuite]; }
             set { base[ConfigurationStrings.AlgorithmSuite] = value; }
+        }
+
+        internal void ApplyConfiguration(BasicHttpMessageSecurity security)
+        {
+            if (security == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(security));
+            }
+
+            security.ClientCredentialType = ClientCredentialType;
+
+            if (PropertyValueOrigin.Default != ElementInformation.Properties[ConfigurationStrings.AlgorithmSuite].ValueOrigin)
+            {
+                security.AlgorithmSuite = AlgorithmSuite;
+            }
         }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/BasicHttpSecurityElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/BasicHttpSecurityElement.cs
@@ -26,5 +26,17 @@ namespace CoreWCF.Configuration
         {
             get { return (BasicHttpMessageSecurityElement)base[ConfigurationStrings.Message]; }
         }
+
+        internal void ApplyConfiguration(BasicHttpSecurity security)
+        {
+            if (security == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(security));
+            }
+
+            security.Mode = Mode;
+            Transport.ApplyConfiguration(security.Transport);
+            Message.ApplyConfiguration(security.Message);
+        }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ConfigurationManagerServiceModelOptions.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ConfigurationManagerServiceModelOptions.cs
@@ -61,9 +61,9 @@ namespace CoreWCF.Configuration
         public void Configure(ServiceModelOptions options)
         {
             var configHolder = ParseConfig();
-            foreach (var endpointName in configHolder.Endpoints.Keys)
+            foreach (var serviceEndPoint in configHolder.Endpoints)
             {
-                IXmlConfigEndpoint configEndpoint = configHolder.GetXmlConfigEndpoint(endpointName);
+               IXmlConfigEndpoint configEndpoint = configHolder.GetXmlConfigEndpoint(serviceEndPoint);
                 options.ConfigureService(configEndpoint.Service, serviceConfig =>
                 {
                     serviceConfig.AddServiceEndpoint(configEndpoint.Contract, configEndpoint.Binding, configEndpoint.Address, null);

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/HttpTransportSecurityElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/HttpTransportSecurityElement.cs
@@ -15,14 +15,6 @@ namespace CoreWCF.Configuration
             set { base[ConfigurationStrings.ClientCredentialType] = value; }
         }
 
-        //[ConfigurationProperty(ConfigurationStrings.ProxyCredentialType, DefaultValue = HttpTransportSecurity.DefaultProxyCredentialType)]
-        //[ServiceModelEnumValidator(typeof(HttpProxyCredentialTypeHelper))]
-        //public HttpProxyCredentialType ProxyCredentialType
-        //{
-        //    get { return (HttpProxyCredentialType)base[ConfigurationStrings.ProxyCredentialType]; }
-        //    set { base[ConfigurationStrings.ProxyCredentialType] = value; }
-        //}
-
         //[ConfigurationProperty(ConfigurationStrings.ExtendedProtectionPolicy)]
         //public ExtendedProtectionPolicyElement ExtendedProtectionPolicy
         //{
@@ -53,7 +45,6 @@ namespace CoreWCF.Configuration
             }
 
             security.ClientCredentialType = ClientCredentialType;
-           // security.ProxyCredentialType = this.ProxyCredentialType;
             security.Realm = Realm;
            // security.ExtendedProtectionPolicy = ChannelBindingUtility.BuildPolicy(this.ExtendedProtectionPolicy);
         }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/HttpTransportSecurityElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/HttpTransportSecurityElement.cs
@@ -44,5 +44,18 @@ namespace CoreWCF.Configuration
                 base[ConfigurationStrings.Realm] = value;
             }
         }
+
+        internal void ApplyConfiguration(HttpTransportSecurity security)
+        {
+            if (security == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(security));
+            }
+
+            security.ClientCredentialType = ClientCredentialType;
+           // security.ProxyCredentialType = this.ProxyCredentialType;
+            security.Realm = Realm;
+           // security.ExtendedProtectionPolicy = ChannelBindingUtility.BuildPolicy(this.ExtendedProtectionPolicy);
+        }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/IConfigurationHolder.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/IConfigurationHolder.cs
@@ -3,16 +3,17 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using CoreWCF.Channels;
 
 namespace CoreWCF.Configuration
 {
     public interface IConfigurationHolder
     {
-        ConcurrentDictionary<string, ServiceEndpoint> Endpoints { get; }
+        ISet<ServiceEndpoint> Endpoints { get; }
         void AddBinding(Binding binding);
         void AddServiceEndpoint(string name, string serviceName, Uri address, string contract, string bindingType, string bindingName);
         Binding ResolveBinding(string bindingType, string name);
-        IXmlConfigEndpoint GetXmlConfigEndpoint(string name);
+        IXmlConfigEndpoint GetXmlConfigEndpoint(ServiceEndpoint endPoint);
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/MessageSecurityOverHttpElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/MessageSecurityOverHttpElement.cs
@@ -30,5 +30,21 @@ namespace CoreWCF.Configuration
             get { return (SecurityAlgorithmSuite)base[ConfigurationStrings.AlgorithmSuite]; }
             set { base[ConfigurationStrings.AlgorithmSuite] = value; }
         }
+
+        internal void ApplyConfiguration(MessageSecurityOverHttp security)
+        {
+            if (security == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(security));
+            }
+
+            security.ClientCredentialType = ClientCredentialType;
+            security.NegotiateServiceCredential = NegotiateServiceCredential;
+
+            if (PropertyValueOrigin.Default != ElementInformation.Properties[ConfigurationStrings.AlgorithmSuite].ValueOrigin)
+            {
+                security.AlgorithmSuite = AlgorithmSuite;
+            }
+        }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/MessageSecurityOverTcpElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/MessageSecurityOverTcpElement.cs
@@ -23,5 +23,20 @@ namespace CoreWCF.Configuration
             get { return (SecurityAlgorithmSuite)base[ConfigurationStrings.AlgorithmSuite]; }
             set { base[ConfigurationStrings.AlgorithmSuite] = value; }
         }
+
+        internal void ApplyConfiguration(MessageSecurityOverTcp security)
+        {
+            if (security == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(security));
+            }
+
+            security.ClientCredentialType = ClientCredentialType;
+
+            if (PropertyValueOrigin.Default != ElementInformation.Properties[ConfigurationStrings.AlgorithmSuite].ValueOrigin)
+            {
+                security.AlgorithmSuite = AlgorithmSuite;
+            }
+        }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/NetHttpBindingElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/NetHttpBindingElement.cs
@@ -65,6 +65,10 @@ namespace CoreWCF.Configuration
                 ReaderQuotas = ReaderQuotas.Clone(),
             };
 
+            binding.MessageEncoding = MessageEncoding;
+            //WebSocketSettings.ApplyConfiguration(netHttpBinding.WebSocketSettings);
+            // this.ReliableSession.ApplyConfiguration(netHttpBinding.ReliableSession);
+            Security.ApplyConfiguration(binding.Security);
             return binding;
         }
     }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/NetTcpBindingElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/NetTcpBindingElement.cs
@@ -126,6 +126,9 @@ namespace CoreWCF.Configuration
                 HostNameComparisonMode = HostNameComparisonMode
             };
 
+            //this.ReliableSession.ApplyConfiguration(nptBinding.ReliableSession);
+            Security.ApplyConfiguration(binding.Security);
+            //this.ReaderQuotas.ApplyConfiguration(nptBinding.ReaderQuotas);
             return binding;
         }
     }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/NetTcpBindingElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/NetTcpBindingElement.cs
@@ -128,7 +128,6 @@ namespace CoreWCF.Configuration
 
             //this.ReliableSession.ApplyConfiguration(nptBinding.ReliableSession);
             Security.ApplyConfiguration(binding.Security);
-            //this.ReaderQuotas.ApplyConfiguration(nptBinding.ReaderQuotas);
             return binding;
         }
     }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/NetTcpSecurityElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/NetTcpSecurityElement.cs
@@ -25,5 +25,17 @@ namespace CoreWCF.Configuration
         {
             get { return (MessageSecurityOverTcpElement)base[ConfigurationStrings.Message]; }
         }
+
+        internal void ApplyConfiguration(NetTcpSecurity security)
+        {
+            if (security == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(security));
+            }
+
+            security.Mode = Mode;
+            Transport.ApplyConfiguration(security.Transport);
+            Message.ApplyConfiguration(security.Message);
+        }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/NonDualMessageSecurityOverHttpElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/NonDualMessageSecurityOverHttpElement.cs
@@ -14,5 +14,12 @@ namespace CoreWCF.Configuration
             get { return (bool)base[ConfigurationStrings.EstablishSecurityContext]; }
             set { base[ConfigurationStrings.EstablishSecurityContext] = value; }
         }
+
+        internal void ApplyConfiguration(NonDualMessageSecurityOverHttp security)
+        {
+            base.ApplyConfiguration(security);
+            security.EstablishSecurityContext = EstablishSecurityContext;
+        }
+
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ServiceReflector.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ServiceReflector.cs
@@ -10,6 +10,7 @@ namespace CoreWCF.Configuration
     {
         internal static Type ResolveTypeFromName(string name)
         {
+            //First check if present in loaded assemblies
             foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 if (assembly.GetType(name) is Type found)
@@ -18,6 +19,7 @@ namespace CoreWCF.Configuration
                 }
             }
 
+            //If not present in loaded assemblies, AssemblyQualifiedName  should be "FooNameSpace.BarInterface,FooNameSpace".
             return Type.GetType(name, true);
         }
     }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ServiceReflector.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ServiceReflector.cs
@@ -18,7 +18,7 @@ namespace CoreWCF.Configuration
                 }
             }
 
-            return default;
+            return Type.GetType(name, true);
         }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/TcpTransportSecurityElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/TcpTransportSecurityElement.cs
@@ -36,5 +36,18 @@ namespace CoreWCF.Configuration
         //    get { return (SslProtocols)base[ConfigurationStrings.SslProtocols]; }
         //    private set { base[ConfigurationStrings.SslProtocols] = value; }
         //}
+
+        internal void ApplyConfiguration(TcpTransportSecurity security)
+        {
+            if (security == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(security));
+            }
+
+            security.ClientCredentialType = ClientCredentialType;
+            //security.ProtectionLevel = this.ProtectionLevel;
+            //security.ExtendedProtectionPolicy = ChannelBindingUtility.BuildPolicy(this.ExtendedProtectionPolicy);
+            //security.SslProtocols = this.SslProtocols;
+        }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/TcpTransportSecurityElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/TcpTransportSecurityElement.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Configuration;
+using System.Security.Authentication;
+using CoreWCF.Channels;
 
 namespace CoreWCF.Configuration
 {
@@ -29,13 +31,12 @@ namespace CoreWCF.Configuration
         //    private set { base[ConfigurationStrings.ExtendedProtectionPolicy] = value; }
         //}
 
-        //[ConfigurationProperty(ConfigurationStrings.SslProtocols, DefaultValue = TransportDefaults.OldDefaultSslProtocols)]
-        //[ServiceModelEnumValidator(typeof(SslProtocolsHelper))]
-        //public SslProtocols SslProtocols
-        //{
-        //    get { return (SslProtocols)base[ConfigurationStrings.SslProtocols]; }
-        //    private set { base[ConfigurationStrings.SslProtocols] = value; }
-        //}
+        [ConfigurationProperty(ConfigurationStrings.SslProtocols, DefaultValue = SslProtocols.None)]
+        public SslProtocols SslProtocols
+        {
+            get { return (SslProtocols)base[ConfigurationStrings.SslProtocols]; }
+            private set { base[ConfigurationStrings.SslProtocols] = value; }
+        }
 
         internal void ApplyConfiguration(TcpTransportSecurity security)
         {
@@ -47,7 +48,7 @@ namespace CoreWCF.Configuration
             security.ClientCredentialType = ClientCredentialType;
             //security.ProtectionLevel = this.ProtectionLevel;
             //security.ExtendedProtectionPolicy = ChannelBindingUtility.BuildPolicy(this.ExtendedProtectionPolicy);
-            //security.SslProtocols = this.SslProtocols;
+            security.SslProtocols = this.SslProtocols;
         }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/WSHttpBindingElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/WSHttpBindingElement.cs
@@ -46,6 +46,8 @@ namespace CoreWCF.Configuration
                 SendTimeout = SendTimeout,              
             };
 
+            //binding.AllowCookies = this.AllowCookies;
+            Security.ApplyConfiguration(binding.Security);
             return binding;
         }
     }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/WSHttpSecurityElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/WSHttpSecurityElement.cs
@@ -25,5 +25,17 @@ namespace CoreWCF.Configuration
         {
             get { return (NonDualMessageSecurityOverHttpElement)base[ConfigurationStrings.Message]; }
         }
+
+        internal void ApplyConfiguration(WSHTTPSecurity security)
+        {
+            if (security == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(security));
+            }
+
+            security.Mode = Mode;
+            Transport.ApplyConfiguration(security.Transport);
+            Message.ApplyConfiguration(security.Message);
+        }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/WSHttpTransportSecurityElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/WSHttpTransportSecurityElement.cs
@@ -14,14 +14,6 @@ namespace CoreWCF.Configuration
             set { base[ConfigurationStrings.ClientCredentialType] = value; }
         }
 
-        //[ConfigurationProperty(ConfigurationStrings.ProxyCredentialType, DefaultValue = HttpTransportSecurity.DefaultProxyCredentialType)]
-        //[ServiceModelEnumValidator(typeof(HttpProxyCredentialTypeHelper))]
-        //public HttpProxyCredentialType ProxyCredentialType
-        //{
-        //    get { return (HttpProxyCredentialType)base[ConfigurationStrings.ProxyCredentialType]; }
-        //    set { base[ConfigurationStrings.ProxyCredentialType] = value; }
-        //}
-
         //[ConfigurationProperty(ConfigurationStrings.ExtendedProtectionPolicy)]
         //public ExtendedProtectionPolicyElement ExtendedProtectionPolicy
         //{

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/WSHttpTransportSecurityElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/WSHttpTransportSecurityElement.cs
@@ -43,5 +43,18 @@ namespace CoreWCF.Configuration
                 base[ConfigurationStrings.Realm] = value;
             }
         }
+
+        internal void ApplyConfiguration(HttpTransportSecurity security)
+        {
+            if (security == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("security");
+            }
+
+            security.ClientCredentialType = ClientCredentialType;
+           // security.ProxyCredentialType = this.ProxyCredentialType;
+            security.Realm = Realm;
+           // security.ExtendedProtectionPolicy = ChannelBindingUtility.BuildPolicy(this.ExtendedProtectionPolicy);
+        }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/WSHttpTransportSecurityElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/WSHttpTransportSecurityElement.cs
@@ -48,11 +48,10 @@ namespace CoreWCF.Configuration
         {
             if (security == null)
             {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("security");
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(security));
             }
 
             security.ClientCredentialType = ClientCredentialType;
-           // security.ProxyCredentialType = this.ProxyCredentialType;
             security.Realm = Realm;
            // security.ExtendedProtectionPolicy = ChannelBindingUtility.BuildPolicy(this.ExtendedProtectionPolicy);
         }

--- a/src/CoreWCF.ConfigurationManager/tests/BasicHttpBindingTests.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/BasicHttpBindingTests.cs
@@ -21,6 +21,7 @@ namespace CoreWCF.ConfigurationManager.Tests
             TimeSpan expectedReceiveTimeout = TimeSpan.FromMinutes(10);
             TimeSpan expectedDefaultTimeout = TimeSpan.FromMinutes(1);
             BasicHttpSecurityMode expectedSecurityMode = BasicHttpSecurityMode.TransportWithMessageCredential;
+            BasicHttpMessageCredentialType clientCredType = BasicHttpMessageCredentialType.Certificate;
 
             string xml = $@"
 <configuration> 
@@ -31,7 +32,9 @@ namespace CoreWCF.ConfigurationManager.Tests
                          maxReceivedMessageSize=""{expectedMaxReceivedMessageSize}""
                          maxBufferSize=""{expectedMaxBufferSize}""
                          receiveTimeout=""00:10:00"">
-                    <security mode=""{expectedSecurityMode}""/>
+                    <security mode=""{expectedSecurityMode}"">
+                     <message clientCredentialType=""Certificate"" />
+                     </security>
                     <readerQuotas maxDepth=""{expectedMaxDepth}"" />   
                 </binding >
             </basicHttpBinding>                             
@@ -55,6 +58,7 @@ namespace CoreWCF.ConfigurationManager.Tests
                     Assert.Equal(expectedReceiveTimeout, actualBinding.ReceiveTimeout);
                     Assert.Equal(TransferMode.Buffered, actualBinding.TransferMode);
                     Assert.Equal(expectedSecurityMode, actualBinding.Security.Mode);
+                    Assert.Equal(clientCredType, actualBinding.Security.Message.ClientCredentialType);
                     Assert.Equal(expectedMaxDepth, actualBinding.ReaderQuotas.MaxDepth);
                 }
             }

--- a/src/CoreWCF.ConfigurationManager/tests/BasicHttpBindingTests.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/BasicHttpBindingTests.cs
@@ -33,7 +33,7 @@ namespace CoreWCF.ConfigurationManager.Tests
                          maxBufferSize=""{expectedMaxBufferSize}""
                          receiveTimeout=""00:10:00"">
                     <security mode=""{expectedSecurityMode}"">
-                     <message clientCredentialType=""Certificate"" />
+                     <message clientCredentialType=""{clientCredType}"" />
                      </security>
                     <readerQuotas maxDepth=""{expectedMaxDepth}"" />   
                 </binding >

--- a/src/CoreWCF.ConfigurationManager/tests/ConfigurationHolderTests.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/ConfigurationHolderTests.cs
@@ -35,8 +35,7 @@ namespace CoreWCF.ConfigurationManager.Tests
                 using (ServiceProvider provider = CreateProvider(fs.Name))
                 {
                     IConfigurationHolder settingHolder = GetConfigurationHolder(provider);
-                    IXmlConfigEndpoint endpoint = settingHolder.GetXmlConfigEndpoint(expectedEndpointName);
-
+                    IXmlConfigEndpoint endpoint = GetXmlConfigEndpoinByEndpointName(settingHolder, expectedEndpointName);
                     Assert.Equal(expectedServiceName, endpoint.Service.FullName);
                     Assert.IsType<NetTcpBinding>(endpoint.Binding);
                     Assert.Equal("NetTcpBinding", endpoint.Binding.Name);
@@ -67,7 +66,7 @@ namespace CoreWCF.ConfigurationManager.Tests
                 {
                     IConfigurationHolder settingHolder = GetConfigurationHolder(provider);
 
-                    Assert.Throws<EndpointNotFoundException>(() => settingHolder.GetXmlConfigEndpoint(string.Empty));
+                    Assert.Throws<EndpointNotFoundException>(() => GetXmlConfigEndpoinByEndpointName(settingHolder, string.Empty));
                 }
             }
         }

--- a/src/CoreWCF.ConfigurationManager/tests/ConfigurationHolderTests.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/ConfigurationHolderTests.cs
@@ -35,7 +35,7 @@ namespace CoreWCF.ConfigurationManager.Tests
                 using (ServiceProvider provider = CreateProvider(fs.Name))
                 {
                     IConfigurationHolder settingHolder = GetConfigurationHolder(provider);
-                    IXmlConfigEndpoint endpoint = GetXmlConfigEndpoinByEndpointName(settingHolder, expectedEndpointName);
+                    IXmlConfigEndpoint endpoint = GetXmlConfigEndpointByEndpointName(settingHolder, expectedEndpointName);
                     Assert.Equal(expectedServiceName, endpoint.Service.FullName);
                     Assert.IsType<NetTcpBinding>(endpoint.Binding);
                     Assert.Equal("NetTcpBinding", endpoint.Binding.Name);
@@ -66,7 +66,7 @@ namespace CoreWCF.ConfigurationManager.Tests
                 {
                     IConfigurationHolder settingHolder = GetConfigurationHolder(provider);
 
-                    Assert.Throws<EndpointNotFoundException>(() => GetXmlConfigEndpoinByEndpointName(settingHolder, string.Empty));
+                    Assert.Throws<EndpointNotFoundException>(() => GetXmlConfigEndpointByEndpointName(settingHolder, string.Empty));
                 }
             }
         }

--- a/src/CoreWCF.ConfigurationManager/tests/ServiceSectionTests.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/ServiceSectionTests.cs
@@ -42,7 +42,7 @@ namespace CoreWCF.ConfigurationManager.Tests
                 {
                     IConfigurationHolder settingHolder = GetConfigurationHolder(provider);
 
-                    IXmlConfigEndpoint endpoint = GetXmlConfigEndpoinByEndpointName(settingHolder, expectedEndpointName);
+                    IXmlConfigEndpoint endpoint = GetXmlConfigEndpointByEndpointName(settingHolder, expectedEndpointName);
                     Assert.Equal(expectedServiceName, endpoint.Service.FullName);
                     Assert.Equal(expectedContractName, endpoint.Contract.FullName);
                     Assert.Equal(expectedAddress, endpoint.Address.AbsoluteUri);
@@ -96,12 +96,12 @@ namespace CoreWCF.ConfigurationManager.Tests
                 using (ServiceProvider provider = CreateProvider(fs.Name))
                 {
                     IConfigurationHolder settingHolder = GetConfigurationHolder(provider);
-                    IXmlConfigEndpoint endpoint = GetXmlConfigEndpoinByEndpointName(settingHolder, expectedEndpointNameForBasicHttp);
+                    IXmlConfigEndpoint endpoint = GetXmlConfigEndpointByEndpointName(settingHolder, expectedEndpointNameForBasicHttp);
                     Assert.Equal(expectedServiceName, endpoint.Service.FullName);
                     Assert.Equal(expectedContractName, endpoint.Contract.FullName);
                     Assert.Equal(expectedBasicHttpAddress, endpoint.Address.AbsoluteUri);
 
-                    endpoint = GetXmlConfigEndpoinByEndpointName(settingHolder, string.Empty);
+                    endpoint = GetXmlConfigEndpointByEndpointName(settingHolder, string.Empty);
                     Assert.Equal(expectedServiceName, endpoint.Service.FullName);
                     Assert.Equal(expectedContractName, endpoint.Contract.FullName);
                     Assert.Equal(expectedNetTCPAddress, endpoint.Address.AbsoluteUri);

--- a/src/CoreWCF.ConfigurationManager/tests/TestBase.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/TestBase.cs
@@ -25,5 +25,18 @@ namespace CoreWCF.ConfigurationManager.Tests
             IConfigurationHolder settingHolder = provider.GetService<IConfigurationHolder>();
             return settingHolder;
         }
+
+        //Limiting this logic for test purpose.
+        protected static IXmlConfigEndpoint GetXmlConfigEndpoinByEndpointName(IConfigurationHolder configHolder, string name)
+        {
+           foreach(var serviceEndPoint in configHolder.Endpoints)
+            {
+                if (string.Compare(serviceEndPoint.Name, name, true) == 0)
+                {
+                    return configHolder.GetXmlConfigEndpoint(serviceEndPoint);
+                }
+            }
+            throw new EndpointNotFoundException();
+        }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/tests/TestBase.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/TestBase.cs
@@ -27,7 +27,7 @@ namespace CoreWCF.ConfigurationManager.Tests
         }
 
         //Limiting this logic for test purpose.
-        protected static IXmlConfigEndpoint GetXmlConfigEndpoinByEndpointName(IConfigurationHolder configHolder, string name)
+        protected static IXmlConfigEndpoint GetXmlConfigEndpointByEndpointName(IConfigurationHolder configHolder, string name)
         {
            foreach(var serviceEndPoint in configHolder.Endpoints)
             {

--- a/src/CoreWCF.ConfigurationManager/tests/WSHttpBindingTests.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/WSHttpBindingTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.InteropServices;
 using CoreWCF.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -30,7 +31,9 @@ namespace CoreWCF.ConfigurationManager.Tests
                          maxReceivedMessageSize=""{expectedMaxReceivedMessageSize}""
                          maxBufferPoolSize=""{expectedMaxBufferPoolSize}""
                          receiveTimeout=""00:10:00"">
-                    <security mode=""{expectedSecurityMode}""/>
+                    <security mode=""{expectedSecurityMode}"">
+                    <message clientCredentialType=""UserName"" />
+                     </security>
                     <readerQuotas maxDepth=""{expectedMaxDepth}"" />                    
                 </binding >
             </wsHttpBinding>                             
@@ -61,6 +64,13 @@ namespace CoreWCF.ConfigurationManager.Tests
         [Fact]
         public void WSHttpBinding_WithDefaultSetting()
         {
+            //TODO:- Check if there is a better way to skip the test
+            string frameworkDescription = RuntimeInformation.FrameworkDescription;
+            if (frameworkDescription.IndexOf(".NET Framework", StringComparison.Ordinal) >= 0)
+            {
+                return;
+            }
+
             string expectedName = "wsHttpBindingConfig";
             long expectedMaxReceivedMessageSize = 65536;
             long expectedMaxBufferPoolSize = 65536;

--- a/src/CoreWCF.ConfigurationManager/tests/WSHttpBindingTests.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/WSHttpBindingTests.cs
@@ -20,7 +20,8 @@ namespace CoreWCF.ConfigurationManager.Tests
             int expectedMaxDepth = 2147483647;
             TimeSpan expectedReceiveTimeout = TimeSpan.FromMinutes(10);
             TimeSpan expectedDefaultTimeout = TimeSpan.FromMinutes(1);
-            SecurityMode expectedSecurityMode = SecurityMode.TransportWithMessageCredential; 
+            SecurityMode expectedSecurityMode = SecurityMode.TransportWithMessageCredential;
+            MessageCredentialType clientCredType = MessageCredentialType.UserName;
 
             string xml = $@"
 <configuration> 
@@ -32,7 +33,7 @@ namespace CoreWCF.ConfigurationManager.Tests
                          maxBufferPoolSize=""{expectedMaxBufferPoolSize}""
                          receiveTimeout=""00:10:00"">
                     <security mode=""{expectedSecurityMode}"">
-                    <message clientCredentialType=""UserName"" />
+                    <message clientCredentialType=""{clientCredType}"" />
                      </security>
                     <readerQuotas maxDepth=""{expectedMaxDepth}"" />                    
                 </binding >
@@ -57,20 +58,15 @@ namespace CoreWCF.ConfigurationManager.Tests
                     Assert.Equal(expectedMaxBufferPoolSize, actualBinding.MaxBufferPoolSize);
                     Assert.Equal(expectedMaxDepth, actualBinding.ReaderQuotas.MaxDepth);
                     Assert.Equal(expectedSecurityMode, actualBinding.Security.Mode);
+                    Assert.Equal(clientCredType, actualBinding.Security.Message.ClientCredentialType);
                 }
             }
         }
 
         [Fact]
+        [Trait("Category", "NetCoreOnly")]
         public void WSHttpBinding_WithDefaultSetting()
         {
-            //TODO:- Check if there is a better way to skip the test
-            string frameworkDescription = RuntimeInformation.FrameworkDescription;
-            if (frameworkDescription.IndexOf(".NET Framework", StringComparison.Ordinal) >= 0)
-            {
-                return;
-            }
-
             string expectedName = "wsHttpBindingConfig";
             long expectedMaxReceivedMessageSize = 65536;
             long expectedMaxBufferPoolSize = 65536;

--- a/templates/TestStage.yml
+++ b/templates/TestStage.yml
@@ -25,7 +25,7 @@ stages:
         Windows_netfx:
           imageName: 'windows-latest'
           targetFramework: 'net472'
-          testArgs: ''
+          testArgs: '--filter Category!=NetCoreOnly'
         Linux_netcore2.1:
           imageName: 'ubuntu-latest'
           targetFramework: 'netcoreapp2.1'

--- a/templates/TestStage.yml
+++ b/templates/TestStage.yml
@@ -99,7 +99,7 @@ stages:
         Windows_netfx:
           imageName: 'windows-latest'
           targetFramework: 'net472'
-          testArgs: ''
+          testArgs: '--filter Category!=NetCoreOnly'
         Linux_netcore2.1:
           imageName: 'ubuntu-latest'
           targetFramework: 'netcoreapp2.1'


### PR DESCRIPTION
1)Support for ClientCredential type across all bindings
2)Fixing when Name is empty #445 
3)Refactoring and adding test 
