### PR TITLE
Allow registering services without known implementation type

### DIFF
--- a/src/CoreWCF.Http/tests/InterfaceOnlyServiceTest.cs
+++ b/src/CoreWCF.Http/tests/InterfaceOnlyServiceTest.cs
@@ -1,0 +1,113 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BasicHttp
+{
+    public class InterfaceOnlyServiceTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public InterfaceOnlyServiceTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void BasicHttpRequestReplyEchoString()
+        {
+            string testString = new string('a', 3000);
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                System.ServiceModel.BasicHttpBinding httpBinding = ClientHelper.GetBufferedModeBinding();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IEchoService>(httpBinding,
+                    new System.ServiceModel.EndpointAddress(
+                        new Uri("http://localhost:8080/BasicWcfService/basichttp.svc")));
+                ClientContract.IEchoService channel = factory.CreateChannel();
+                string result = channel.EchoString(testString);
+                Assert.Equal(testString, result);
+
+                var interceptor = host.Services.GetRequiredService<EchoServiceInterceptor>();
+                Assert.Equal(1, interceptor.NumberOfIntercepts);
+            }
+        }
+
+        private class EchoServiceInterceptor : ServiceContract.IEchoService
+        {
+            private readonly ServiceContract.IEchoService _underlyingService;
+
+            public int NumberOfIntercepts { get; private set; }
+
+            public EchoServiceInterceptor(ServiceContract.IEchoService underlyingService)
+            {
+                _underlyingService = underlyingService;
+            }
+
+            public string EchoString(string echo)
+            {
+                NumberOfIntercepts++;
+                return _underlyingService.EchoString(echo);
+            }
+
+            public Stream EchoStream(Stream echo)
+            {
+                NumberOfIntercepts++;
+                return _underlyingService.EchoStream(echo);
+            }
+
+            public async Task<string> EchoStringAsync(string echo)
+            {
+                NumberOfIntercepts++;
+                return await _underlyingService.EchoStringAsync(echo);
+            }
+
+            public async Task<Stream> EchoStreamAsync(Stream echo)
+            {
+                NumberOfIntercepts++;
+                return await _underlyingService.EchoStreamAsync(echo);
+            }
+
+            public string EchoToFail(string echo)
+            {
+                NumberOfIntercepts++;
+                return _underlyingService.EchoToFail(echo);
+            }
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+                services.AddSingleton(new EchoServiceInterceptor(new Services.EchoService()));
+                // register service implementation in DI and let CoreWCF resolve it as instance
+                // in some cases implementation could be without known type (e.g. could be a castle proxy)
+                services.AddSingleton<ServiceContract.IEchoService>(sp => sp.GetRequiredService<EchoServiceInterceptor>());
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    // we fully register the service through interfaces
+                    builder.AddService<ServiceContract.IEchoService>();
+                    builder.AddServiceEndpoint<ServiceContract.IEchoService, ServiceContract.IEchoService>(
+                        new CoreWCF.BasicHttpBinding(), "/BasicWcfService/basichttp.svc");
+                });
+            }
+        }
+    }
+}
+

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/TypeLoader.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/TypeLoader.cs
@@ -204,7 +204,7 @@ namespace CoreWCF.Description
             return contract;
         }
 
-        //This needs proper review. 
+        //This needs proper review.
         private void AddAuthorizeOperations(ContractDescription contractDesc, bool implIsCallback, ContractReflectionInfo reflectionInfo)
         {
 
@@ -429,8 +429,13 @@ namespace CoreWCF.Description
             {
                 if (targetIface.IsAssignableFrom(implType) && targetIface.IsInterface)
                 {
-                    ifaceMap = implType.GetInterfaceMap(targetIface);
-                    useImplAttrs = true;
+                    // if implType is an interface not an implementation class
+                    // we cannot use the interface map for looking up the implementation methods
+                    if (!implType.IsInterface)
+                    {
+                        ifaceMap = implType.GetInterfaceMap(targetIface);
+                        useImplAttrs = true;
+                    }
                 }
                 else
                 {
@@ -825,9 +830,9 @@ namespace CoreWCF.Description
                 }
             }
 
-            // this contract 
+            // this contract
             CreateOperationDescriptions(contractDescription, reflectionInfo, contractType, contractDescription, MessageDirection.Input);
-            // CallbackContract 
+            // CallbackContract
             if (callbackType != null && !inheritedCallbackTypes.Contains(callbackType))
             {
                 CreateOperationDescriptions(contractDescription, reflectionInfo, callbackType, contractDescription, MessageDirection.Output);
@@ -943,7 +948,7 @@ namespace CoreWCF.Description
                         existingOp.TaskTResult = newOp.TaskTResult;
                         if (existingOp.SyncMethod != null)
                         {
-                            // Task vs. Sync 
+                            // Task vs. Sync
                             VerifyConsistency(new SyncTaskOperationConsistencyVerifier(existingOp, newOp));
                         }
                         else
@@ -2007,10 +2012,10 @@ namespace CoreWCF.Description
         //  - the service type you want to pull behavior attributes from
         //  - the "destination" behavior collection, where all the right behavior attributes should be added to
         //  - a delegate
-        // The delegate is just a function you write that behaves like this: 
+        // The delegate is just a function you write that behaves like this:
         //    imagine that "currentType" was the only type (imagine there was no inheritance hierarchy)
         //    find desired behavior attributes on this type, and add them to "behaviors"
-        // ApplyServiceInheritance then uses the logic you provide for getting behavior attributes from a single type, 
+        // ApplyServiceInheritance then uses the logic you provide for getting behavior attributes from a single type,
         // and it walks the actual type hierarchy and does the inheritance/override logic for you.
         public static void ApplyServiceInheritance<IBehavior, TBehaviorCollection>(
                      TBehaviorCollection descriptionBehaviors,
@@ -2032,10 +2037,10 @@ namespace CoreWCF.Description
         //  - the type you want to pull behavior attributes from
         //  - the "destination" behavior collection, where all the right behavior attributes should be added to
         //  - a delegate
-        // The delegate is just a function you write that behaves like this: 
+        // The delegate is just a function you write that behaves like this:
         //    imagine that "currentType" was the only type (imagine there was no inheritance hierarchy)
         //    find desired behavior attributes on this type, and add them to "behaviors"
-        // AddBehaviorsAtOneScope then uses the logic you provide for getting behavior attributes from a single type, 
+        // AddBehaviorsAtOneScope then uses the logic you provide for getting behavior attributes from a single type,
         // and it does the override logic for you (only add the behavior if it wasn't already in the descriptionBehaviors)
         private static void AddBehaviorsAtOneScope<IBehavior, TBehaviorCollection>(
                      Type type,


### PR DESCRIPTION
Fixes #467 

As described in the issue CoreWCF does not allow registering services purely using the contract interface and a provided implementation through DI (yet!). This PR adds support for exactly this. 

It seems there was only one execution path on the TypeLoader which needed to be adapted.  