### PR TITLE
Fix FaultException<T> namespace not correctly handled when using SSM FaultContractAttribute

### DIFF
--- a/src/CoreWCF.Http/tests/ClientContract/IServiceWithFaultContract.cs
+++ b/src/CoreWCF.Http/tests/ClientContract/IServiceWithFaultContract.cs
@@ -23,11 +23,27 @@ namespace ClientContract
         string Identity(string msg);
     }
 
+    [ServiceContract(Namespace = SSMCompatibilityFault.Namespace)]
+    public interface IServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevel
+    {
+        [OperationContract]
+        [FaultContract(typeof(SSMCompatibilityFault), Name = SSMCompatibilityFault.Name)]
+        string Identity(string msg);
+    }
+
     [ServiceContract]
     public interface IServiceWithSSMFaultContract
     {
         [OperationContract]
         [FaultContract(typeof(SSMCompatibilityFault), Name = SSMCompatibilityFault.Name, Namespace = SSMCompatibilityFault.Namespace)]
+        string Identity(string msg);
+    }
+
+    [ServiceContract(Namespace = SSMCompatibilityFault.Namespace)]
+    public interface IServiceWithSSMFaultContractWithNamespaceAtServiceContractLevel
+    {
+        [OperationContract]
+        [FaultContract(typeof(SSMCompatibilityFault), Name = SSMCompatibilityFault.Name)]
         string Identity(string msg);
     }
 }

--- a/src/CoreWCF.Http/tests/ClientContract/IServiceWithFaultContract.cs
+++ b/src/CoreWCF.Http/tests/ClientContract/IServiceWithFaultContract.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ServiceModel;
+
+namespace ClientContract
+{
+    [System.Runtime.Serialization.DataContract]
+    public class SSMCompatibilityFault
+    {
+        public const string Name = nameof(SSMCompatibilityFault);
+        public const string Namespace = "https://ssm-fault-contract-compatibility.com";
+
+        [System.Runtime.Serialization.DataMember]
+        public string Message { get; set; }
+    }
+
+    [ServiceContract]
+    public interface IServiceWithCoreWCFFaultContract
+    {
+        [OperationContract]
+        [FaultContract(typeof(SSMCompatibilityFault), Name = SSMCompatibilityFault.Name, Namespace = SSMCompatibilityFault.Namespace)]
+        string Identity(string msg);
+    }
+
+    [ServiceContract]
+    public interface IServiceWithSSMFaultContract
+    {
+        [OperationContract]
+        [FaultContract(typeof(SSMCompatibilityFault), Name = SSMCompatibilityFault.Name, Namespace = SSMCompatibilityFault.Namespace)]
+        string Identity(string msg);
+    }
+}

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading.Tasks;
@@ -78,15 +79,30 @@ namespace BasicHttp
             var responseBody = await response.Content.ReadAsStringAsync();
             //_output.WriteLine(responseBody);
 
-            const string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+            string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
                 "<s:Body><s:Fault>"
                 +"<faultcode>s:Client</faultcode>"
-                +"<faultstring xml:lang=\"en-US\">The creator of this fault did not specify a Reason.</faultstring>"
+                +"<faultstring"
+                + $"{GetXmlLangAttributeOrNot()}"
+                + ">The creator of this fault did not specify a Reason.</faultstring>"
                 +"<detail>"
                 +"<SSMCompatibilityFault xmlns=\"https://ssm-fault-contract-compatibility.com\" xmlns:a=\"http://schemas.datacontract.org/2004/07/Services\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">"
                 +"<a:Message>An error occured</a:Message></SSMCompatibilityFault></detail></s:Fault></s:Body></s:Envelope>";
 
             Assert.Equal(expected, responseBody);
+
+            string GetXmlLangAttributeOrNot()
+            {
+                const string enUsXmlLang = " xml:lang=\"en-US\"";
+#if NETCOREAPP3_1_OR_GREATER
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
+                    string.Empty
+                    : enUsXmlLang;
+#else
+                return enUsXmlLang;
+#endif
+            }
+
         }
 
         public class Startup

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
@@ -49,6 +49,7 @@ namespace BasicHttp
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public async Task BasicScenarioServiceMessageParameterWithHttpClient()
         {
             var client = _factory.CreateClient();
@@ -80,7 +81,7 @@ namespace BasicHttp
             const string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
                 "<s:Body><s:Fault>"
                 +"<faultcode>s:Client</faultcode>"
-                +"<faultstring xml:lang=\"fr-FR\">The creator of this fault did not specify a Reason.</faultstring>"
+                +"<faultstring xml:lang=\"en-US\">The creator of this fault did not specify a Reason.</faultstring>"
                 +"<detail>"
                 +"<SSMCompatibilityFault xmlns=\"https://ssm-fault-contract-compatibility.com\" xmlns:a=\"http://schemas.datacontract.org/2004/07/Services\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">"
                 +"<a:Message>An error occured</a:Message></SSMCompatibilityFault></detail></s:Fault></s:Body></s:Envelope>";

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
@@ -31,7 +31,7 @@ namespace BasicHttp
         }
 
         [Fact]
-        public void BasicScenarioServiceMessageParameter()
+        public void BasicScenarioServiceWithCoreWCFFaultContract()
         {
             IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
             using (host)
@@ -50,7 +50,7 @@ namespace BasicHttp
 
         [Fact]
         [UseCulture("en-US")]
-        public async Task BasicScenarioServiceMessageParameterWithHttpClient()
+        public async Task BasicScenarioServiceWithCoreWCFFaultContractWithHttpClient()
         {
             var client = _factory.CreateClient();
             const string action = "http://tempuri.org/IServiceWithCoreWCFFaultContract/Identity";

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Http;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Threading.Tasks;
+using ClientContract;
+using CoreWCF;
+using CoreWCF.Configuration;
+using CoreWCF.Http.Tests.Helpers;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BasicHttp
+{
+    public class ServiceWithCoreWCFFaultContractTest : IClassFixture<IntegrationTest<ServiceWithCoreWCFFaultContractTest.Startup>>
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly IntegrationTest<Startup> _factory;
+
+        public ServiceWithCoreWCFFaultContractTest(ITestOutputHelper output, IntegrationTest<Startup> factory)
+        {
+            _output = output;
+            _factory = factory;
+        }
+
+        [Fact]
+        public void BasicScenarioServiceMessageParameter()
+        {
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                System.ServiceModel.BasicHttpBinding httpBinding = ClientHelper.GetBufferedModeBinding();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IServiceWithCoreWCFFaultContract>(httpBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/Service.svc")));
+                IServiceWithCoreWCFFaultContract channel = factory.CreateChannel();
+
+                var e = Assert.Throws<System.ServiceModel.FaultException<ClientContract.SSMCompatibilityFault>>(() => channel.Identity("test"));
+
+                ((IChannel)channel).Close();
+            }
+        }
+
+        [Fact]
+        public async Task BasicScenarioServiceMessageParameterWithHttpClient()
+        {
+            var client = _factory.CreateClient();
+            const string action = "http://tempuri.org/IServiceWithCoreWCFFaultContract/Identity";
+
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri("http://localhost:8080/BasicWcfService/Service.svc", UriKind.Absolute));
+            request.Headers.TryAddWithoutValidation("SOAPAction", $"\"{action}\"");
+
+            const string requestBody = @"<s:Envelope xmlns:s=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:tem=""http://tempuri.org/"">
+   <s:Header/>
+   <s:Body>
+      <tem:Identity>
+         <tem:Input>A</tem:Input>
+      </tem:Identity>
+   </s:Body>
+</s:Envelope>";
+
+            request.Content = new StringContent(requestBody, Encoding.UTF8, "text/xml");
+
+            //// FIXME: Commenting out this line will induce a chunked response, which will break the pre-read message parser
+            request.Content.Headers.ContentLength = Encoding.UTF8.GetByteCount(requestBody);
+
+            var response = await client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            //_output.WriteLine(responseBody);
+
+            const string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+                "<s:Body><s:Fault>"
+                +"<faultcode>s:Client</faultcode>"
+                +"<faultstring xml:lang=\"fr-FR\">The creator of this fault did not specify a Reason.</faultstring>"
+                +"<detail>"
+                +"<SSMCompatibilityFault xmlns=\"https://ssm-fault-contract-compatibility.com\" xmlns:a=\"http://schemas.datacontract.org/2004/07/Services\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">"
+                +"<a:Message>An error occured</a:Message></SSMCompatibilityFault></detail></s:Fault></s:Body></s:Envelope>";
+
+            Assert.Equal(expected, responseBody);
+        }
+
+        public class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.ServiceWithCoreWCFFaultContract>();
+                    builder.AddServiceEndpoint<Services.ServiceWithCoreWCFFaultContract, Services.IServiceWithCoreWCFFaultContract>(new BasicHttpBinding(), "/BasicWcfService/Service.svc");
+                });
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Globalization;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading.Tasks;
@@ -50,7 +50,6 @@ namespace BasicHttp
         }
 
         [Fact]
-        [UseCulture("en-US")]
         public async Task BasicScenarioServiceWithCoreWCFFaultContractWithHttpClient()
         {
             var client = _factory.CreateClient();
@@ -91,18 +90,9 @@ namespace BasicHttp
 
             Assert.Equal(expected, responseBody);
 
-            string GetXmlLangAttributeOrNot()
-            {
-                const string enUsXmlLang = " xml:lang=\"en-US\"";
-#if NETCOREAPP3_1_OR_GREATER
-                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
-                    string.Empty
-                    : enUsXmlLang;
-#else
-                return enUsXmlLang;
-#endif
-            }
-
+            string GetXmlLangAttributeOrNot() => CultureInfo.CurrentCulture.Name.Length == 0
+                    ? string.Empty
+                    : $@" xml:lang=""{CultureInfo.CurrentCulture.Name}""";
         }
 
         public class Startup

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevelTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevelTest.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Threading.Tasks;
+using ClientContract;
+using CoreWCF;
+using CoreWCF.Configuration;
+using CoreWCF.Http.Tests.Helpers;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BasicHttp
+{
+    public class ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevelTest : IClassFixture<IntegrationTest<ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevelTest.Startup>>
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly IntegrationTest<Startup> _factory;
+
+        public ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevelTest(ITestOutputHelper output, IntegrationTest<Startup> factory)
+        {
+            _output = output;
+            _factory = factory;
+        }
+
+        [Fact]
+        public void BasicScenarioServiceWithCoreWCFFaultContract()
+        {
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                System.ServiceModel.BasicHttpBinding httpBinding = ClientHelper.GetBufferedModeBinding();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevel>(httpBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/Service.svc")));
+                IServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevel channel = factory.CreateChannel();
+
+                var e = Assert.Throws<System.ServiceModel.FaultException<ClientContract.SSMCompatibilityFault>>(() => channel.Identity("test"));
+
+                ((IChannel)channel).Close();
+            }
+        }
+
+        [Fact]
+        [UseCulture("en-US")]
+        public async Task BasicScenarioServiceWithCoreWCFFaultContractWithHttpClient()
+        {
+            var client = _factory.CreateClient();
+            const string action = "https://ssm-fault-contract-compatibility.com/IServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevel/Identity";
+
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri("http://localhost:8080/BasicWcfService/Service.svc", UriKind.Absolute));
+            request.Headers.TryAddWithoutValidation("SOAPAction", $"\"{action}\"");
+
+            const string requestBody = @"<s:Envelope xmlns:s=""http://schemas.xmlsoap.org/soap/envelope/"">
+   <s:Header/>
+   <s:Body>
+      <Identity xmlns=""https://ssm-fault-contract-compatibility.com"">
+         <Input>A</Input>
+      </Identity>
+   </s:Body>
+</s:Envelope>";
+
+            request.Content = new StringContent(requestBody, Encoding.UTF8, "text/xml");
+
+            //// FIXME: Commenting out this line will induce a chunked response, which will break the pre-read message parser
+            request.Content.Headers.ContentLength = Encoding.UTF8.GetByteCount(requestBody);
+
+            var response = await client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            //_output.WriteLine(responseBody);
+
+            string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+                "<s:Body><s:Fault>"
+                +"<faultcode>s:Client</faultcode>"
+                +"<faultstring"
+                + $"{GetXmlLangAttributeOrNot()}"
+                + ">The creator of this fault did not specify a Reason.</faultstring>"
+                +"<detail>"
+                +"<SSMCompatibilityFault xmlns=\"https://ssm-fault-contract-compatibility.com\" xmlns:a=\"http://schemas.datacontract.org/2004/07/Services\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">"
+                +"<a:Message>An error occured</a:Message></SSMCompatibilityFault></detail></s:Fault></s:Body></s:Envelope>";
+
+            Assert.Equal(expected, responseBody);
+
+            string GetXmlLangAttributeOrNot()
+            {
+                const string enUsXmlLang = " xml:lang=\"en-US\"";
+#if NETCOREAPP3_1_OR_GREATER
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
+                    string.Empty
+                    : enUsXmlLang;
+#else
+                return enUsXmlLang;
+#endif
+            }
+
+        }
+
+        public class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevel>();
+                    builder.AddServiceEndpoint<Services.ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevel, Services.IServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevel>(new BasicHttpBinding(), "/BasicWcfService/Service.svc");
+                });
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevelTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevelTest.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Globalization;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading.Tasks;
@@ -50,7 +50,6 @@ namespace BasicHttp
         }
 
         [Fact]
-        [UseCulture("en-US")]
         public async Task BasicScenarioServiceWithCoreWCFFaultContractWithHttpClient()
         {
             var client = _factory.CreateClient();
@@ -91,18 +90,9 @@ namespace BasicHttp
 
             Assert.Equal(expected, responseBody);
 
-            string GetXmlLangAttributeOrNot()
-            {
-                const string enUsXmlLang = " xml:lang=\"en-US\"";
-#if NETCOREAPP3_1_OR_GREATER
-                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
-                    string.Empty
-                    : enUsXmlLang;
-#else
-                return enUsXmlLang;
-#endif
-            }
-
+            string GetXmlLangAttributeOrNot() => CultureInfo.CurrentCulture.Name.Length == 0
+                    ? string.Empty
+                    : $@" xml:lang=""{CultureInfo.CurrentCulture.Name}""";
         }
 
         public class Startup

--- a/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Http;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Threading.Tasks;
+using ClientContract;
+using CoreWCF;
+using CoreWCF.Configuration;
+using CoreWCF.Http.Tests.Helpers;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BasicHttp
+{
+    public class ServiceWithSSMFaultContractTest : IClassFixture<IntegrationTest<ServiceWithSSMFaultContractTest.Startup>>
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly IntegrationTest<Startup> _factory;
+
+        public ServiceWithSSMFaultContractTest(ITestOutputHelper output, IntegrationTest<Startup> factory)
+        {
+            _output = output;
+            _factory = factory;
+        }
+
+        [Fact]
+        public void BasicScenarioServiceMessageParameter()
+        {
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                System.ServiceModel.BasicHttpBinding httpBinding = ClientHelper.GetBufferedModeBinding();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IServiceWithSSMFaultContract>(httpBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/Service.svc")));
+                IServiceWithSSMFaultContract channel = factory.CreateChannel();
+
+                var e = Assert.Throws<System.ServiceModel.FaultException<ClientContract.SSMCompatibilityFault>>(() => channel.Identity("test"));
+
+                ((IChannel)channel).Close();
+            }
+        }
+
+        [Fact]
+        public async Task BasicScenarioServiceMessageParameterWithHttpClient()
+        {
+            var client = _factory.CreateClient();
+            const string action = "http://tempuri.org/IServiceWithSSMFaultContract/Identity";
+
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri("http://localhost:8080/BasicWcfService/Service.svc", UriKind.Absolute));
+            request.Headers.TryAddWithoutValidation("SOAPAction", $"\"{action}\"");
+
+            const string requestBody = @"<s:Envelope xmlns:s=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:tem=""http://tempuri.org/"">
+   <s:Header/>
+   <s:Body>
+      <tem:Identity>
+         <tem:Input>A</tem:Input>
+      </tem:Identity>
+   </s:Body>
+</s:Envelope>";
+
+            request.Content = new StringContent(requestBody, Encoding.UTF8, "text/xml");
+
+            //// FIXME: Commenting out this line will induce a chunked response, which will break the pre-read message parser
+            request.Content.Headers.ContentLength = Encoding.UTF8.GetByteCount(requestBody);
+
+            var response = await client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            //_output.WriteLine(responseBody);
+
+            const string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+                "<s:Body><s:Fault>"
+                +"<faultcode>s:Client</faultcode>"
+                +"<faultstring xml:lang=\"fr-FR\">The creator of this fault did not specify a Reason.</faultstring>"
+                +"<detail>"
+                +"<SSMCompatibilityFault xmlns=\"https://ssm-fault-contract-compatibility.com\" xmlns:a=\"http://schemas.datacontract.org/2004/07/Services\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">"
+                +"<a:Message>An error occured</a:Message></SSMCompatibilityFault></detail></s:Fault></s:Body></s:Envelope>";
+
+            Assert.Equal(expected, responseBody);
+        }
+
+        public class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.ServiceWithSSMFaultContract>();
+                    builder.AddServiceEndpoint<Services.ServiceWithSSMFaultContract, Services.IServiceWithSSMFaultContract>(new BasicHttpBinding(), "/BasicWcfService/Service.svc");
+                });
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
@@ -49,6 +49,7 @@ namespace BasicHttp
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public async Task BasicScenarioServiceMessageParameterWithHttpClient()
         {
             var client = _factory.CreateClient();
@@ -80,7 +81,7 @@ namespace BasicHttp
             const string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
                 "<s:Body><s:Fault>"
                 +"<faultcode>s:Client</faultcode>"
-                +"<faultstring xml:lang=\"fr-FR\">The creator of this fault did not specify a Reason.</faultstring>"
+                +"<faultstring xml:lang=\"en-US\">The creator of this fault did not specify a Reason.</faultstring>"
                 +"<detail>"
                 +"<SSMCompatibilityFault xmlns=\"https://ssm-fault-contract-compatibility.com\" xmlns:a=\"http://schemas.datacontract.org/2004/07/Services\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">"
                 +"<a:Message>An error occured</a:Message></SSMCompatibilityFault></detail></s:Fault></s:Body></s:Envelope>";

--- a/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading.Tasks;
@@ -78,15 +79,29 @@ namespace BasicHttp
             var responseBody = await response.Content.ReadAsStringAsync();
             //_output.WriteLine(responseBody);
 
-            const string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+            string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
                 "<s:Body><s:Fault>"
                 +"<faultcode>s:Client</faultcode>"
-                +"<faultstring xml:lang=\"en-US\">The creator of this fault did not specify a Reason.</faultstring>"
+                +"<faultstring"
+                +$"{GetXmlLangAttributeOrNot()}"
+                +">The creator of this fault did not specify a Reason.</faultstring>"
                 +"<detail>"
                 +"<SSMCompatibilityFault xmlns=\"https://ssm-fault-contract-compatibility.com\" xmlns:a=\"http://schemas.datacontract.org/2004/07/Services\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">"
                 +"<a:Message>An error occured</a:Message></SSMCompatibilityFault></detail></s:Fault></s:Body></s:Envelope>";
 
             Assert.Equal(expected, responseBody);
+
+            string GetXmlLangAttributeOrNot()
+            {
+                const string enUsXmlLang = " xml:lang=\"en-US\"";
+#if NETCOREAPP3_1_OR_GREATER
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
+                    string.Empty
+                    : enUsXmlLang;
+#else
+                return enUsXmlLang;
+#endif
+            }
         }
 
         public class Startup

--- a/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Globalization;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading.Tasks;
@@ -50,7 +50,6 @@ namespace BasicHttp
         }
 
         [Fact]
-        [UseCulture("en-US")]
         public async Task BasicScenarioServiceWithSSMFaultContractWithHttpClient()
         {
             var client = _factory.CreateClient();
@@ -91,17 +90,9 @@ namespace BasicHttp
 
             Assert.Equal(expected, responseBody);
 
-            string GetXmlLangAttributeOrNot()
-            {
-                const string enUsXmlLang = " xml:lang=\"en-US\"";
-#if NETCOREAPP3_1_OR_GREATER
-                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
-                    string.Empty
-                    : enUsXmlLang;
-#else
-                return enUsXmlLang;
-#endif
-            }
+            string GetXmlLangAttributeOrNot() => CultureInfo.CurrentCulture.Name.Length == 0
+                    ? string.Empty
+                    : $@" xml:lang=""{CultureInfo.CurrentCulture.Name}""";
         }
 
         public class Startup

--- a/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
@@ -31,7 +31,7 @@ namespace BasicHttp
         }
 
         [Fact]
-        public void BasicScenarioServiceMessageParameter()
+        public void BasicScenarioServiceWithSSMFaultContract()
         {
             IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
             using (host)
@@ -50,7 +50,7 @@ namespace BasicHttp
 
         [Fact]
         [UseCulture("en-US")]
-        public async Task BasicScenarioServiceMessageParameterWithHttpClient()
+        public async Task BasicScenarioServiceWithSSMFaultContractWithHttpClient()
         {
             var client = _factory.CreateClient();
             const string action = "http://tempuri.org/IServiceWithSSMFaultContract/Identity";

--- a/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevelTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevelTest.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Threading.Tasks;
+using ClientContract;
+using CoreWCF;
+using CoreWCF.Configuration;
+using CoreWCF.Http.Tests.Helpers;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BasicHttp
+{
+    public class ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevelTest : IClassFixture<IntegrationTest<ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevelTest.Startup>>
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly IntegrationTest<Startup> _factory;
+
+        public ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevelTest(ITestOutputHelper output, IntegrationTest<Startup> factory)
+        {
+            _output = output;
+            _factory = factory;
+        }
+
+        [Fact]
+        public void BasicScenarioServiceWithSSMFaultContract()
+        {
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                host.Start();
+                System.ServiceModel.BasicHttpBinding httpBinding = ClientHelper.GetBufferedModeBinding();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IServiceWithSSMFaultContractWithNamespaceAtServiceContractLevel>(httpBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/Service.svc")));
+                IServiceWithSSMFaultContractWithNamespaceAtServiceContractLevel channel = factory.CreateChannel();
+
+                var e = Assert.Throws<System.ServiceModel.FaultException<ClientContract.SSMCompatibilityFault>>(() => channel.Identity("test"));
+
+                ((IChannel)channel).Close();
+            }
+        }
+
+        [Fact]
+        [UseCulture("en-US")]
+        public async Task BasicScenarioServiceWithSSMFaultContractWithHttpClient()
+        {
+            var client = _factory.CreateClient();
+            const string action = "https://ssm-fault-contract-compatibility.com/IServiceWithSSMFaultContractWithNamespaceAtServiceContractLevel/Identity";
+
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri("http://localhost:8080/BasicWcfService/Service.svc", UriKind.Absolute));
+            request.Headers.TryAddWithoutValidation("SOAPAction", $"\"{action}\"");
+
+            const string requestBody = @"<s:Envelope xmlns:s=""http://schemas.xmlsoap.org/soap/envelope/"">
+   <s:Header/>
+   <s:Body>
+      <Identity xmlns=""https://ssm-fault-contract-compatibility.com"">
+         <Input>A</Input>
+      </Identity>
+   </s:Body>
+</s:Envelope>";
+
+            request.Content = new StringContent(requestBody, Encoding.UTF8, "text/xml");
+
+            //// FIXME: Commenting out this line will induce a chunked response, which will break the pre-read message parser
+            request.Content.Headers.ContentLength = Encoding.UTF8.GetByteCount(requestBody);
+
+            var response = await client.SendAsync(request);
+            Assert.False(response.IsSuccessStatusCode);
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            //_output.WriteLine(responseBody);
+
+            string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+                "<s:Body><s:Fault>"
+                +"<faultcode>s:Client</faultcode>"
+                +"<faultstring"
+                + $"{GetXmlLangAttributeOrNot()}"
+                + ">The creator of this fault did not specify a Reason.</faultstring>"
+                +"<detail>"
+                +"<SSMCompatibilityFault xmlns=\"https://ssm-fault-contract-compatibility.com\" xmlns:a=\"http://schemas.datacontract.org/2004/07/Services\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">"
+                +"<a:Message>An error occured</a:Message></SSMCompatibilityFault></detail></s:Fault></s:Body></s:Envelope>";
+
+            Assert.Equal(expected, responseBody);
+
+            string GetXmlLangAttributeOrNot()
+            {
+                const string enUsXmlLang = " xml:lang=\"en-US\"";
+#if NETCOREAPP3_1_OR_GREATER
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
+                    string.Empty
+                    : enUsXmlLang;
+#else
+                return enUsXmlLang;
+#endif
+            }
+
+        }
+
+        public class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevel>();
+                    builder.AddServiceEndpoint<Services.ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevel, Services.IServiceWithSSMFaultContractWithNamespaceAtServiceContractLevel>(new BasicHttpBinding(), "/BasicWcfService/Service.svc");
+                });
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevelTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevelTest.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Globalization;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading.Tasks;
@@ -50,7 +50,6 @@ namespace BasicHttp
         }
 
         [Fact]
-        [UseCulture("en-US")]
         public async Task BasicScenarioServiceWithSSMFaultContractWithHttpClient()
         {
             var client = _factory.CreateClient();
@@ -91,18 +90,9 @@ namespace BasicHttp
 
             Assert.Equal(expected, responseBody);
 
-            string GetXmlLangAttributeOrNot()
-            {
-                const string enUsXmlLang = " xml:lang=\"en-US\"";
-#if NETCOREAPP3_1_OR_GREATER
-                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
-                    string.Empty
-                    : enUsXmlLang;
-#else
-                return enUsXmlLang;
-#endif
-            }
-
+            string GetXmlLangAttributeOrNot() => CultureInfo.CurrentCulture.Name.Length == 0
+                    ? string.Empty
+                    : $@" xml:lang=""{CultureInfo.CurrentCulture.Name}""";
         }
 
         public class Startup

--- a/src/CoreWCF.Http/tests/Services/ServiceWithFaultContract.cs
+++ b/src/CoreWCF.Http/tests/Services/ServiceWithFaultContract.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Services
+{
+    [System.Runtime.Serialization.DataContract]
+    public class SSMCompatibilityFault
+    {
+        public const string Name = nameof(SSMCompatibilityFault);
+        public const string Namespace = "https://ssm-fault-contract-compatibility.com";
+
+        [System.Runtime.Serialization.DataMember]
+        public string Message { get; set; }
+    }
+
+    [CoreWCF.ServiceContract]
+    public interface IServiceWithCoreWCFFaultContract
+    {
+        [CoreWCF.OperationContract]
+        [CoreWCF.FaultContract(typeof(SSMCompatibilityFault), Name = SSMCompatibilityFault.Name, Namespace = SSMCompatibilityFault.Namespace)]
+        string Identity(string msg);
+    }
+
+    public class ServiceWithCoreWCFFaultContract : IServiceWithCoreWCFFaultContract
+    {
+        public string Identity(string msg) => throw new CoreWCF.FaultException<SSMCompatibilityFault>(new SSMCompatibilityFault()
+        {
+            Message = "An error occured"
+        });
+    }
+
+    [System.ServiceModel.ServiceContract]
+    public interface IServiceWithSSMFaultContract
+    {
+        [System.ServiceModel.OperationContract]
+        [System.ServiceModel.FaultContract(typeof(SSMCompatibilityFault), Name = SSMCompatibilityFault.Name, Namespace = SSMCompatibilityFault.Namespace)]
+        string Identity(string msg);
+    }
+
+    public class ServiceWithSSMFaultContract : IServiceWithSSMFaultContract
+    {
+        public string Identity(string msg) => throw new CoreWCF.FaultException<SSMCompatibilityFault>(new SSMCompatibilityFault()
+        {
+            Message = "An error occured"
+        });
+    }
+}

--- a/src/CoreWCF.Http/tests/Services/ServiceWithFaultContract.cs
+++ b/src/CoreWCF.Http/tests/Services/ServiceWithFaultContract.cs
@@ -29,6 +29,22 @@ namespace Services
         });
     }
 
+    [CoreWCF.ServiceContract(Namespace = SSMCompatibilityFault.Namespace)]
+    public interface IServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevel
+    {
+        [CoreWCF.OperationContract]
+        [CoreWCF.FaultContract(typeof(SSMCompatibilityFault), Name = SSMCompatibilityFault.Name)]
+        string Identity(string msg);
+    }
+
+    public class ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevel : IServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevel
+    {
+        public string Identity(string msg) => throw new CoreWCF.FaultException<SSMCompatibilityFault>(new SSMCompatibilityFault()
+        {
+            Message = "An error occured"
+        });
+    }
+
     [System.ServiceModel.ServiceContract]
     public interface IServiceWithSSMFaultContract
     {
@@ -38,6 +54,22 @@ namespace Services
     }
 
     public class ServiceWithSSMFaultContract : IServiceWithSSMFaultContract
+    {
+        public string Identity(string msg) => throw new CoreWCF.FaultException<SSMCompatibilityFault>(new SSMCompatibilityFault()
+        {
+            Message = "An error occured"
+        });
+    }
+
+    [System.ServiceModel.ServiceContract(Namespace = SSMCompatibilityFault.Namespace)]
+    public interface IServiceWithSSMFaultContractWithNamespaceAtServiceContractLevel
+    {
+        [System.ServiceModel.OperationContract]
+        [System.ServiceModel.FaultContract(typeof(SSMCompatibilityFault), Name = SSMCompatibilityFault.Name)]
+        string Identity(string msg);
+    }
+
+    public class ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevel : IServiceWithSSMFaultContractWithNamespaceAtServiceContractLevel
     {
         public string Identity(string msg) => throw new CoreWCF.FaultException<SSMCompatibilityFault>(new SSMCompatibilityFault()
         {

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/CustomAttributeProvider.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/CustomAttributeProvider.cs
@@ -270,6 +270,7 @@ namespace CoreWCF.Description
 
         private static MessagePropertyAttribute ConvertFromServiceModelMessagePropertyAttribute(object attr)
         {
+            Fx.Assert(attr.GetType().FullName.Equals(ServiceReflector.SMMessagePropertyAttributeFullName), "Expected attribute of type S.SM.MessagePropertyAttribute");
             var messageProperty = new MessagePropertyAttribute();
             string tmpStr = GetProperty<string>(attr, nameof(MessagePropertyAttribute.Name));
             if (!string.IsNullOrEmpty(tmpStr))
@@ -282,6 +283,7 @@ namespace CoreWCF.Description
 
         private static MessageParameterAttribute ConvertFromServiceModelMessageParameterAttribute(object attr)
         {
+            Fx.Assert(attr.GetType().FullName.Equals(ServiceReflector.SMMessageParameterAttributeFullName), "Expected attribute of type S.SM.MessageParameterAttribute");
             var messageParameter = new MessageParameterAttribute();
             string tmpStr = GetProperty<string>(attr, nameof(MessageParameterAttribute.Name));
             if (!string.IsNullOrEmpty(tmpStr))
@@ -294,6 +296,7 @@ namespace CoreWCF.Description
 
         private static XmlSerializerFormatAttribute ConvertFromServiceModelXmlSerializerFormatAttribute(object attr)
         {
+            Fx.Assert(attr.GetType().FullName.Equals(ServiceReflector.SMXmlSerializerFormatAttributeFullName), "Expected attribute of type S.SM.XmlSerializerFormatAttribute");
             var xmlSerializerFormatAttribute = new XmlSerializerFormatAttribute();
 
             xmlSerializerFormatAttribute.Style = GetProperty<OperationFormatStyle>(attr, nameof(XmlSerializerFormatAttribute.Style));

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceReflector.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceReflector.cs
@@ -383,6 +383,7 @@ namespace CoreWCF.Description
         internal const string SMMessageBodyMemberAttributeFullName = "System.ServiceModel.MessageBodyMemberAttribute";
         internal const string SMMessageParameterAttributeFullName = "System.ServiceModel.MessageParameterAttribute";
         internal const string SMXmlSerializerFormatAttributeFullName = "System.ServiceModel.XmlSerializerFormatAttribute";
+        internal const string SMFaultContractAttributeFullName = "System.ServiceModel.FaultContractAttribute";
 
         internal static readonly string CWCFMesssageHeaderAttribute = "CoreWCF.MessageHeaderAttribute";
         internal static readonly string CWCFMesssageHeaderArrayAttribute = "CoreWCF.MessageHeaderArrayAttribute";


### PR DESCRIPTION
Fixes #472 