### PR TITLE
Add support for all values of MessageVersion

### DIFF
--- a/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
@@ -127,6 +127,7 @@ namespace Helpers
                     });
                 })
             .UseStartup<TStartup>();
+
         public static IWebHostBuilder CreateWebHostBuilder(ITestOutputHelper outputHelper, Type startupType) =>
             WebHost.CreateDefaultBuilder(Array.Empty<string>())
 #if DEBUG

--- a/src/CoreWCF.Http/tests/MessageVersionsTests.cs
+++ b/src/CoreWCF.Http/tests/MessageVersionsTests.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using CoreWCF.Channels;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Http.Tests
+{
+    public class MessageVersionsTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public MessageVersionsTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestVariations))]
+        public void EchoStringTest(Channels.MessageVersion messageVersion, System.ServiceModel.Channels.MessageVersion clientMessageVersion)
+        {
+            string testString = new string('a', 10);
+            var webHostBuilder = ServiceHelper.CreateWebHostBuilder<Startup>(_output);
+            webHostBuilder.ConfigureServices(services => services.AddServiceModelServices());
+            webHostBuilder.Configure(app =>
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.EchoService>();
+                    builder.AddServiceEndpoint<Services.EchoService, ServiceContract.IEchoService>(Startup.GetServerBinding(messageVersion), "/MessageVersionTest.svc");
+                });
+            });
+            var host = webHostBuilder.Build();
+            using (host)
+            {
+                host.Start();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IEchoService>(Startup.GetClientBinding(clientMessageVersion),
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/MessageVersionTest.svc")));
+                ClientContract.IEchoService channel = factory.CreateChannel();
+                var result = channel.EchoString(testString);
+                Assert.Equal(testString, result);
+                ((System.ServiceModel.IClientChannel)channel).Close();
+            }
+        }
+
+        public static IEnumerable<object[]> GetTestVariations()
+        {
+            yield return new object[] { MessageVersion.Soap11, System.ServiceModel.Channels.MessageVersion.Soap11 };
+            yield return new object[] { MessageVersion.Soap11WSAddressing10, System.ServiceModel.Channels.MessageVersion.CreateVersion(System.ServiceModel.EnvelopeVersion.Soap11, System.ServiceModel.Channels.AddressingVersion.WSAddressing10) };
+            yield return new object[] { MessageVersion.Soap11WSAddressingAugust2004, System.ServiceModel.Channels.MessageVersion.Soap11WSAddressingAugust2004 };
+            yield return new object[] { MessageVersion.Soap12, System.ServiceModel.Channels.MessageVersion.CreateVersion(System.ServiceModel.EnvelopeVersion.Soap12, System.ServiceModel.Channels.AddressingVersion.None) };
+            yield return new object[] { MessageVersion.Soap12WSAddressing10, System.ServiceModel.Channels.MessageVersion.CreateVersion(System.ServiceModel.EnvelopeVersion.Soap12, System.ServiceModel.Channels.AddressingVersion.WSAddressing10) };
+            yield return new object[] { MessageVersion.Soap12WSAddressingAugust2004, System.ServiceModel.Channels.MessageVersion.Soap12WSAddressingAugust2004 };
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app) { }
+
+            internal static Binding GetServerBinding(MessageVersion messageVersion)
+            {
+                return new CustomBinding(
+                    new TextMessageEncodingBindingElement { MessageVersion = messageVersion },
+                    new HttpTransportBindingElement { AuthenticationScheme = System.Net.AuthenticationSchemes.Anonymous });
+            }
+
+            internal static System.ServiceModel.Channels.Binding GetClientBinding(System.ServiceModel.Channels.MessageVersion clientMessageVersion)
+            {
+                return new System.ServiceModel.Channels.CustomBinding(
+                    new System.ServiceModel.Channels.TextMessageEncodingBindingElement { MessageVersion = clientMessageVersion },
+                    new System.ServiceModel.Channels.HttpTransportBindingElement { AuthenticationScheme = System.Net.AuthenticationSchemes.Anonymous });
+            }
+        }
+    }
+}

--- a/src/CoreWCF.NetTcp/tests/MessageVersionsTests.cs
+++ b/src/CoreWCF.NetTcp/tests/MessageVersionsTests.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using CoreWCF.Channels;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.NetTcp.Tests
+{
+    public class MessageVersionsTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public MessageVersionsTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestVariations))]
+        public void EchoStringTest(MessageVersion messageVersion, System.ServiceModel.Channels.MessageVersion clientMessageVersion)
+        {
+            string testString = new string('a', 10);
+            var webHostBuilder = ServiceHelper.CreateWebHostBuilder<Startup>(_output);
+            webHostBuilder.ConfigureServices(services => services.AddServiceModelServices());
+            webHostBuilder.Configure(app =>
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.TestService>();
+                    builder.AddServiceEndpoint<Services.TestService, ServiceContract.ITestService>(Startup.GetServerBinding(messageVersion), "/MessageVersionTest.svc");
+                });
+            });
+            var host = webHostBuilder.Build();
+            using (host)
+            {
+                host.Start();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(Startup.GetClientBinding(clientMessageVersion),
+                    new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + "/MessageVersionTest.svc"));
+                ClientContract.ITestService channel = factory.CreateChannel();
+                var result = channel.EchoString(testString);
+                Assert.Equal(testString, result);
+                ((System.ServiceModel.IClientChannel)channel).Close();
+            }
+        }
+
+        public static IEnumerable<object[]> GetTestVariations()
+        {
+            yield return new object[] { MessageVersion.Soap12WSAddressing10, System.ServiceModel.Channels.MessageVersion.CreateVersion(System.ServiceModel.EnvelopeVersion.Soap12, System.ServiceModel.Channels.AddressingVersion.WSAddressing10) };
+            yield return new object[] { MessageVersion.Soap12WSAddressingAugust2004, System.ServiceModel.Channels.MessageVersion.Soap12WSAddressingAugust2004 };
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app) { }
+
+            internal static Binding GetServerBinding(MessageVersion messageVersion)
+            {
+                return new CustomBinding(
+                    new BinaryMessageEncodingBindingElement { MessageVersion = messageVersion },
+                    new TcpTransportBindingElement());
+            }
+
+            internal static System.ServiceModel.Channels.Binding GetClientBinding(System.ServiceModel.Channels.MessageVersion clientMessageVersion)
+            {
+                return new System.ServiceModel.Channels.CustomBinding(
+                    new System.ServiceModel.Channels.BinaryMessageEncodingBindingElement { MessageVersion = clientMessageVersion },
+                    new System.ServiceModel.Channels.TcpTransportBindingElement() );
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/Addressing.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/Addressing.cs
@@ -358,7 +358,7 @@ namespace CoreWCF.Channels
     {
         private const bool mustUnderstandValue = true;
         private static ToHeader s_anonymousToHeader10;
-        //static ToHeader anonymousToHeader200408;
+        private static ToHeader s_anonymousToHeader200408;
 
         protected ToHeader(Uri to, AddressingVersion version)
             : base(version)
@@ -379,15 +379,15 @@ namespace CoreWCF.Channels
             }
         }
 
-        //static ToHeader AnonymousTo200408
-        //{
-        //    get
-        //    {
-        //        if (anonymousToHeader200408 == null)
-        //            anonymousToHeader200408 = new AnonymousToHeader(AddressingVersion.WSAddressingAugust2004);
-        //        return anonymousToHeader200408;
-        //    }
-        //}
+        static ToHeader AnonymousTo200408
+        {
+            get
+            {
+                if (s_anonymousToHeader200408 == null)
+                    s_anonymousToHeader200408 = new AnonymousToHeader(AddressingVersion.WSAddressingAugust2004);
+                return s_anonymousToHeader200408;
+            }
+        }
 
         public override XmlDictionaryString DictionaryName
         {
@@ -416,8 +416,7 @@ namespace CoreWCF.Channels
                 }
                 else
                 {
-                    //return AnonymousTo200408;
-                    throw new PlatformNotSupportedException($"Unsupported addressing version {addressingVersion.ToString()}");
+                    return AnonymousTo200408;
                 }
             }
             else
@@ -432,7 +431,7 @@ namespace CoreWCF.Channels
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(to));
             }
-            else if ((object)to == (object)addressingVersion.AnonymousUri)
+            else if ((object)to == addressingVersion.AnonymousUri)
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                 {
@@ -440,9 +439,8 @@ namespace CoreWCF.Channels
                 }
                 else
                 {
-                    throw new PlatformNotSupportedException($"Unsupported addressing version {addressingVersion.ToString()}");
+                    return AnonymousTo200408;
                 }
-                //return AnonymousTo200408;
             }
             else
             {
@@ -573,6 +571,7 @@ namespace CoreWCF.Channels
     {
         private const bool mustUnderstandValue = false;
         private static ReplyToHeader s_anonymousReplyToHeader10;
+        private static ReplyToHeader s_anonymousReplyToHeader200408;
 
         private ReplyToHeader(EndpointAddress replyTo, AddressingVersion version)
             : base(version)
@@ -605,15 +604,15 @@ namespace CoreWCF.Channels
             }
         }
 
-        //public static ReplyToHeader AnonymousReplyTo200408
-        //{
-        //    get
-        //    {
-        //        if (anonymousReplyToHeader200408 == null)
-        //            anonymousReplyToHeader200408 = new ReplyToHeader(EndpointAddress.AnonymousAddress, AddressingVersion.WSAddressingAugust2004);
-        //        return anonymousReplyToHeader200408;
-        //    }
-        //}
+        public static ReplyToHeader AnonymousReplyTo200408
+        {
+            get
+            {
+                if (s_anonymousReplyToHeader200408 == null)
+                    s_anonymousReplyToHeader200408 = new ReplyToHeader(EndpointAddress.AnonymousAddress, AddressingVersion.WSAddressingAugust2004);
+                return s_anonymousReplyToHeader200408;
+            }
+        }
 
         public static ReplyToHeader Create(EndpointAddress replyTo, AddressingVersion addressingVersion)
         {
@@ -642,7 +641,7 @@ namespace CoreWCF.Channels
 
             if (actor.Length == 0 && mustUnderstand == mustUnderstandValue && !relay)
             {
-                if ((object)replyTo == (object)EndpointAddress.AnonymousAddress)
+                if ((object)replyTo == EndpointAddress.AnonymousAddress)
                 {
                     if (version == AddressingVersion.WSAddressing10)
                     {
@@ -650,8 +649,7 @@ namespace CoreWCF.Channels
                     }
                     else
                     {
-                        //return AnonymousReplyTo200408;
-                        throw new PlatformNotSupportedException($"Addressing version {version.ToString()} not supported");
+                        return AnonymousReplyTo200408;
                     }
                 }
                 return new ReplyToHeader(replyTo, version);

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/MessageVersion.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/MessageVersion.cs
@@ -9,20 +9,23 @@ namespace CoreWCF.Channels
 {
     public sealed class MessageVersion
     {
-        private static readonly MessageVersion s_soap12Addressing10;
-
-        static MessageVersion()
-        {
-            None = new MessageVersion(EnvelopeVersion.None, AddressingVersion.None);
-            Soap11 = new MessageVersion(EnvelopeVersion.Soap11, AddressingVersion.None);
-            s_soap12Addressing10 = new MessageVersion(EnvelopeVersion.Soap12, AddressingVersion.WSAddressing10);
-        }
-
         private MessageVersion(EnvelopeVersion envelopeVersion, AddressingVersion addressingVersion)
         {
             Envelope = envelopeVersion;
             Addressing = addressingVersion;
         }
+
+        public AddressingVersion Addressing { get; }
+        public EnvelopeVersion Envelope { get; }
+
+        public static MessageVersion Default => Soap12WSAddressing10;
+        public static MessageVersion None { get; } = new MessageVersion(EnvelopeVersion.None, AddressingVersion.None);
+        public static MessageVersion Soap11 { get; } = new MessageVersion(EnvelopeVersion.Soap11, AddressingVersion.None);
+        public static MessageVersion Soap12 { get; } = new MessageVersion(EnvelopeVersion.Soap12, AddressingVersion.None);
+        public static MessageVersion Soap11WSAddressing10 { get; } = new MessageVersion(EnvelopeVersion.Soap11, AddressingVersion.WSAddressing10);
+        public static MessageVersion Soap12WSAddressing10 { get; } = new MessageVersion(EnvelopeVersion.Soap12, AddressingVersion.WSAddressing10);
+        public static MessageVersion Soap11WSAddressingAugust2004 { get; } = new MessageVersion(EnvelopeVersion.Soap11, AddressingVersion.WSAddressingAugust2004);
+        public static MessageVersion Soap12WSAddressingAugust2004 { get; } = new MessageVersion(EnvelopeVersion.Soap12, AddressingVersion.WSAddressingAugust2004);
 
         public static MessageVersion CreateVersion(EnvelopeVersion envelopeVersion)
         {
@@ -45,7 +48,15 @@ namespace CoreWCF.Channels
             {
                 if (addressingVersion == AddressingVersion.WSAddressing10)
                 {
-                    return s_soap12Addressing10;
+                    return Soap12WSAddressing10;
+                }
+                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
+                {
+                    return Soap12WSAddressingAugust2004;
+                }
+                else if (addressingVersion == AddressingVersion.None)
+                {
+                    return Soap12;
                 }
                 else
                 {
@@ -55,7 +66,15 @@ namespace CoreWCF.Channels
             }
             else if (envelopeVersion == EnvelopeVersion.Soap11)
             {
-                if (addressingVersion == AddressingVersion.None)
+                if (addressingVersion == AddressingVersion.WSAddressing10)
+                {
+                    return Soap11WSAddressing10;
+                }
+                else if (addressingVersion == AddressingVersion.WSAddressingAugust2004)
+                {
+                    return Soap11WSAddressingAugust2004;
+                }
+                else if (addressingVersion == AddressingVersion.None)
                 {
                     return Soap11;
                 }
@@ -84,15 +103,6 @@ namespace CoreWCF.Channels
             }
         }
 
-        public AddressingVersion Addressing { get; }
-
-        public static MessageVersion Default
-        {
-            get { return s_soap12Addressing10; }
-        }
-
-        public EnvelopeVersion Envelope { get; }
-
         public override bool Equals(object obj)
         {
             return this == obj;
@@ -108,15 +118,6 @@ namespace CoreWCF.Channels
 
             return code;
         }
-
-        public static MessageVersion None { get; private set; }
-
-        public static MessageVersion Soap12WSAddressing10
-        {
-            get { return s_soap12Addressing10; }
-        }
-
-        public static MessageVersion Soap11 { get; private set; }
 
         public override string ToString()
         {

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MetadataStrings.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MetadataStrings.cs
@@ -5,6 +5,13 @@ namespace CoreWCF.Description
 {
     internal static class MetadataStrings
     {
+        public static class MetadataExchangeStrings
+        {
+            public const string Namespace = "http://schemas.xmlsoap.org/ws/2004/09/mex";
+            public const string Metadata = "Metadata";
+
+        }
+
         public static class WSPolicy
         {
             public const string Prefix = "wsp";

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/PrimitiveOperationFormatter.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/PrimitiveOperationFormatter.cs
@@ -24,6 +24,7 @@ namespace CoreWCF.Dispatcher
         private ActionHeader _actionHeader10;
         private ActionHeader _replyActionHeaderNone;
         private ActionHeader _replyActionHeader10;
+        private ActionHeader _replyActionHeaderAugust2004;
         private readonly XmlDictionaryString _requestWrapperName;
         private readonly XmlDictionaryString _requestWrapperNamespace;
         private readonly XmlDictionaryString _responseWrapperName;
@@ -158,19 +159,19 @@ namespace CoreWCF.Dispatcher
             }
         }
 
-        //ActionHeader ReplyActionHeaderAugust2004
-        //{
-        //    get
-        //    {
-        //        if (replyActionHeaderAugust2004 == null)
-        //        {
-        //            replyActionHeaderAugust2004 =
-        //                ActionHeader.Create(this.replyAction, AddressingVersion.WSAddressingAugust2004);
-        //        }
+        ActionHeader ReplyActionHeaderAugust2004
+        {
+            get
+            {
+                if (_replyActionHeaderAugust2004 == null)
+                {
+                    _replyActionHeaderAugust2004 =
+                        ActionHeader.Create(_replyAction, AddressingVersion.WSAddressingAugust2004);
+                }
 
-        //        return replyActionHeaderAugust2004;
-        //    }
-        //}
+                return _replyActionHeaderAugust2004;
+            }
+        }
 
         private static XmlDictionaryString AddToDictionary(XmlDictionary dictionary, string s)
         {
@@ -225,12 +226,11 @@ namespace CoreWCF.Dispatcher
                 return null;
             }
 
-            //if (addressing == AddressingVersion.WSAddressingAugust2004)
-            //{
-            //    return ReplyActionHeaderAugust2004;
-            //}
-            //else 
-            if (addressing == AddressingVersion.WSAddressing10)
+            if (addressing == AddressingVersion.WSAddressingAugust2004)
+            {
+                return ReplyActionHeaderAugust2004;
+            }
+            else if (addressing == AddressingVersion.WSAddressing10)
             {
                 return ReplyActionHeader10;
             }


### PR DESCRIPTION
Replaces #495 
This adds support for all MessageVersion variations that exist in WCF, with tests to validate them (Excluding None which is for special purposes which CoreWCF doesn't support yet).