### PR TITLE
Pared-down sample for .NET 6 with a single endpoint

### DIFF
--- a/src/Samples/dotnet6server/EchoService.cs
+++ b/src/Samples/dotnet6server/EchoService.cs
@@ -1,6 +1,5 @@
-using System.Threading.Tasks;
-using MyContracts;
 using CoreWCF;
+using MyContracts;
 
 namespace dotnet6Server
 {
@@ -21,10 +20,5 @@ namespace dotnet6Server
         public string FailEcho(string text)
             => throw new FaultException<EchoFault>(new EchoFault() { Text = "WCF Fault OK" }, new FaultReason("FailReason"));
 
-        [AuthorizeRole("CoreWCFGroupAdmin")]
-        public string EchoForPermission(string echo)
-        {
-            return echo;
-        }
     }
 }

--- a/src/Samples/dotnet6server/EchoService.cs
+++ b/src/Samples/dotnet6server/EchoService.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using MyContracts;
+using CoreWCF;
+
+namespace dotnet6Server
+{
+    public class EchoService : IEchoService
+    {
+        public string Echo(string text)
+        {
+            System.Console.WriteLine($"Received {text} from client!");
+            return text;
+        }
+
+        public string ComplexEcho(EchoMessage text)
+        {
+            System.Console.WriteLine($"Received {text.Text} from client!");
+            return text.Text;
+        }
+
+        public string FailEcho(string text)
+            => throw new FaultException<EchoFault>(new EchoFault() { Text = "WCF Fault OK" }, new FaultReason("FailReason"));
+
+        [AuthorizeRole("CoreWCFGroupAdmin")]
+        public string EchoForPermission(string echo)
+        {
+            return echo;
+        }
+    }
+}

--- a/src/Samples/dotnet6server/IEchoService.cs
+++ b/src/Samples/dotnet6server/IEchoService.cs
@@ -1,0 +1,42 @@
+﻿using CoreWCF;
+using System.Runtime.Serialization;
+
+namespace MyContracts
+{
+    [DataContract]
+    public class EchoFault
+    {
+        private string text;
+
+        [DataMember]
+        public string Text
+        {
+            get { return text; }
+            set { text = value; }
+        }
+    }
+
+    [ServiceContract]
+    public interface IEchoService
+    {
+        [OperationContract]
+        string Echo(string text);
+
+        [OperationContract]
+        string ComplexEcho(EchoMessage text);
+
+        [OperationContract]
+        [FaultContract(typeof(EchoFault))]
+        string FailEcho(string text);
+
+        [OperationContract]
+        string EchoForPermission(string text);
+    }
+
+    [DataContract]
+    public class EchoMessage
+    {
+        [DataMember]
+        public string Text { get; set; }
+    }
+}

--- a/src/Samples/dotnet6server/IEchoService.cs
+++ b/src/Samples/dotnet6server/IEchoService.cs
@@ -1,18 +1,21 @@
-﻿using CoreWCF;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+using CoreWCF;
 
 namespace MyContracts
 {
     [DataContract]
     public class EchoFault
     {
-        private string text;
+        [AllowNull]
+        private string _text;
 
         [DataMember]
+        [AllowNull]
         public string Text
         {
-            get { return text; }
-            set { text = value; }
+            get { return _text; }
+            set { _text = value; }
         }
     }
 
@@ -29,13 +32,12 @@ namespace MyContracts
         [FaultContract(typeof(EchoFault))]
         string FailEcho(string text);
 
-        [OperationContract]
-        string EchoForPermission(string text);
     }
 
     [DataContract]
     public class EchoMessage
     {
+        [AllowNull]
         [DataMember]
         public string Text { get; set; }
     }

--- a/src/Samples/dotnet6server/Program.cs
+++ b/src/Samples/dotnet6server/Program.cs
@@ -15,7 +15,7 @@ var app = builder.Build();
 app.UseServiceModel(builder =>
 {
     builder.AddService<EchoService>()
-    .AddServiceEndpoint<EchoService, IEchoService>(new BasicHttpBinding(), "/EchoService/basichttp")
+    .AddServiceEndpoint<EchoService, IEchoService>(new BasicHttpBinding(), "/EchoService/basichttp");
 });
 
 app.Run();

--- a/src/Samples/dotnet6server/Program.cs
+++ b/src/Samples/dotnet6server/Program.cs
@@ -1,7 +1,7 @@
-using MyContracts;
-using CoreWCF.Configuration;
 using CoreWCF;
+using CoreWCF.Configuration;
 using dotnet6Server;
+using MyContracts;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.ConfigureKestrel((context, options) =>
@@ -15,7 +15,10 @@ var app = builder.Build();
 app.UseServiceModel(builder =>
 {
     builder.AddService<EchoService>()
-    .AddServiceEndpoint<EchoService, IEchoService>(new BasicHttpBinding(), "/EchoService/basichttp");
+    .AddServiceEndpoint<EchoService, IEchoService>(new BasicHttpBinding(), "/EchoService/basichttp")
 });
 
 app.Run();
+
+
+

--- a/src/Samples/dotnet6server/Program.cs
+++ b/src/Samples/dotnet6server/Program.cs
@@ -1,0 +1,21 @@
+using MyContracts;
+using CoreWCF.Configuration;
+using CoreWCF;
+using dotnet6Server;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.ConfigureKestrel((context, options) =>
+{
+    options.AllowSynchronousIO = true;
+});
+
+builder.Services.AddServiceModelServices();
+var app = builder.Build();
+
+app.UseServiceModel(builder =>
+{
+    builder.AddService<EchoService>()
+    .AddServiceEndpoint<EchoService, IEchoService>(new BasicHttpBinding(), "/EchoService/basichttp");
+});
+
+app.Run();

--- a/src/Samples/dotnet6server/Properties/launchSettings.json
+++ b/src/Samples/dotnet6server/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8113",
+      "sslPort": 44345
+    }
+  },
+  "profiles": {
+    "dotnet6Server": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7119;http://localhost:5078",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Samples/dotnet6server/Properties/launchSettings.json
+++ b/src/Samples/dotnet6server/Properties/launchSettings.json
@@ -1,28 +1,11 @@
 ﻿{
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:8113",
-      "sslPort": 44345
+    "profiles": {
+        "dotnet6Server": {
+            "commandName": "Project",
+            "dotnetRunMessages": true,
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        }
     }
-  },
-  "profiles": {
-    "dotnet6Server": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7119;http://localhost:5078",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    }
-  }
 }

--- a/src/Samples/dotnet6server/Readme.md
+++ b/src/Samples/dotnet6server/Readme.md
@@ -1,0 +1,24 @@
+# .NET 6 Core WCF Sample
+
+This sample shows how to use Core WCF with .NET 6 using the [Minimal API Syntax](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis?view=aspnetcore-6.0). 
+
+This sample uses the BasicHttpBinding and exposes EndPoints at `http://localhost:5000/EchoService/basichttp` and `https://localhost:5001/EchoService/basichttp`. The base url comes from the Urls property in appsettings.json, and the path from the EndPoint registration in code.
+
+## Bindings
+
+The bindings can be changed via code, for example to use WSHttpBinding, the Endpoint can be changed to (or additionally exposed with):
+
+``` C#
+    .AddServiceEndpoint<EchoService, IEchoService>(new WSHttpBinding(SecurityMode.Transport), "/EchoService/wshttp");
+```
+
+## Nuget References
+
+The project is configured to pull the CoreWCF binaries from Nuget.org. If you are building CoreWCF locally, change the project references to relative paths:
+
+```xml
+  <ItemGroup>
+    <ProjectReference Include="..\..\CoreWCF.Http\src\CoreWCF.Http.csproj" />
+    <ProjectReference Include="..\..\CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />
+  </ItemGroup>
+```

--- a/src/Samples/dotnet6server/appsettings.Development.json
+++ b/src/Samples/dotnet6server/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Samples/dotnet6server/appsettings.json
+++ b/src/Samples/dotnet6server/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Samples/dotnet6server/appsettings.json
+++ b/src/Samples/dotnet6server/appsettings.json
@@ -1,9 +1,10 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*"
+    "Urls": "http://localhost:5000;https://localhost:5001",
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*"
 }

--- a/src/Samples/dotnet6server/dotnet6Server.csproj
+++ b/src/Samples/dotnet6server/dotnet6Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,9 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreWCF.ConfigurationManager" Version="0.4.0" />
     <PackageReference Include="CoreWCF.Http" Version="0.4.0" />
-    <PackageReference Include="CoreWCF.NetTcp" Version="0.4.0" />
     <PackageReference Include="CoreWCF.Primitives" Version="0.4.0" />
   </ItemGroup>
 

--- a/src/Samples/dotnet6server/dotnet6Server.csproj
+++ b/src/Samples/dotnet6server/dotnet6Server.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CoreWCF.ConfigurationManager" Version="0.4.0" />
+    <PackageReference Include="CoreWCF.Http" Version="0.4.0" />
+    <PackageReference Include="CoreWCF.NetTcp" Version="0.4.0" />
+    <PackageReference Include="CoreWCF.Primitives" Version="0.4.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Note this sample uses nuget package refs rather than relative project refs. This makes it easier for project consumers who probably are after something that doesn't require them to build the entire repo.