### PR TITLE
Fixing build warnings

### DIFF
--- a/src/CoreWCF.Http/tests/AggregateExceptionTests.cs
+++ b/src/CoreWCF.Http/tests/AggregateExceptionTests.cs
@@ -112,7 +112,7 @@ namespace CoreWCF.Http.Tests
             services.AddServiceModelServices();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app)
         {
             app.UseServiceModel(builder =>
             {

--- a/src/CoreWCF.Http/tests/Async767311Tests.cs
+++ b/src/CoreWCF.Http/tests/Async767311Tests.cs
@@ -126,7 +126,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/AsyncNetAdoptionTests.cs
+++ b/src/CoreWCF.Http/tests/AsyncNetAdoptionTests.cs
@@ -41,7 +41,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/BasicHttpTransportMessage.cs
+++ b/src/CoreWCF.Http/tests/BasicHttpTransportMessage.cs
@@ -141,14 +141,14 @@ namespace BasicHttp
 
         internal class CustomTestValidator : UserNamePasswordValidator
         {
-            public override void Validate(string userName, string password)
+            public override ValueTask ValidateAsync(string userName, string password)
             {
                 if (string.Compare(userName, "testuser@corewcf", StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    return;
+                    return new ValueTask(Task.CompletedTask);
                 }
 
-                throw new Exception("Permission Denied");
+                return new ValueTask(Task.FromException(new Exception("Permission Denied")));
             }
         }
 
@@ -231,7 +231,7 @@ namespace BasicHttp
                 return basicBinding;
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 CoreWCF.BasicHttpBinding serverBinding = new CoreWCF.BasicHttpBinding(_basicHttpSecurityMode);
                 serverBinding.Security.Message.ClientCredentialType = _credentialType;
@@ -252,7 +252,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 CoreWCF.Channels.CustomBinding customBinding = new CoreWCF.Channels.CustomBinding();
 

--- a/src/CoreWCF.Http/tests/BasicScenariosTest.cs
+++ b/src/CoreWCF.Http/tests/BasicScenariosTest.cs
@@ -85,7 +85,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/BasicValidationSoapTests.cs
+++ b/src/CoreWCF.Http/tests/BasicValidationSoapTests.cs
@@ -68,7 +68,7 @@ namespace CoreWCF.Http.Tests
             services.AddServiceModelServices();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app)
         {
             app.UseServiceModel(builder =>
             {

--- a/src/CoreWCF.Http/tests/ByRefTests.cs
+++ b/src/CoreWCF.Http/tests/ByRefTests.cs
@@ -108,7 +108,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ComplexSerializationTests.cs
+++ b/src/CoreWCF.Http/tests/ComplexSerializationTests.cs
@@ -1052,7 +1052,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {
@@ -1069,7 +1069,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {
@@ -1086,7 +1086,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {
@@ -1103,7 +1103,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {
@@ -1120,7 +1120,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {
@@ -1138,7 +1138,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ContractBehaviorTests.cs
+++ b/src/CoreWCF.Http/tests/ContractBehaviorTests.cs
@@ -274,7 +274,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ContractShapeTests.cs
+++ b/src/CoreWCF.Http/tests/ContractShapeTests.cs
@@ -88,7 +88,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {
@@ -105,7 +105,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/FaultContractNameTests.cs
+++ b/src/CoreWCF.Http/tests/FaultContractNameTests.cs
@@ -361,7 +361,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/FaultContractTests.cs
+++ b/src/CoreWCF.Http/tests/FaultContractTests.cs
@@ -440,7 +440,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
@@ -81,6 +81,9 @@ namespace Helpers
         //    };
         //}
 
+#if NET5_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public static IWebHostBuilder CreateHttpSysBuilder<TStartup>(ITestOutputHelper outputHelper = default) where TStartup : class =>
             WebHost.CreateDefaultBuilder(Array.Empty<string>())
 #if DEBUG

--- a/src/CoreWCF.Http/tests/HttpClientTests.cs
+++ b/src/CoreWCF.Http/tests/HttpClientTests.cs
@@ -79,7 +79,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/HttpContextTests.cs
+++ b/src/CoreWCF.Http/tests/HttpContextTests.cs
@@ -64,7 +64,7 @@ namespace DependencyInjection
                 services.AddTransient<TService>();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/HttpRequestMessagePropertyTests.cs
+++ b/src/CoreWCF.Http/tests/HttpRequestMessagePropertyTests.cs
@@ -102,7 +102,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/HttpSysTests.cs
+++ b/src/CoreWCF.Http/tests/HttpSysTests.cs
@@ -24,6 +24,9 @@ namespace CoreWCF.Http.Tests
 
         [Fact]
         [Trait("Category", "WindowsOnly")]
+#if NET5_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public void BasicHttpRequestReplyEchoString()
         {
             string testString = new string('a', 3000);

--- a/src/CoreWCF.Http/tests/HttpsService.cs
+++ b/src/CoreWCF.Http/tests/HttpsService.cs
@@ -50,7 +50,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/InterestingTypeTests.cs
+++ b/src/CoreWCF.Http/tests/InterestingTypeTests.cs
@@ -100,7 +100,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/InterfaceOnlyServiceTest.cs
+++ b/src/CoreWCF.Http/tests/InterfaceOnlyServiceTest.cs
@@ -97,7 +97,7 @@ namespace BasicHttp
                 services.AddSingleton<ServiceContract.IEchoService>(sp => sp.GetRequiredService<EchoServiceInterceptor>());
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/LargeRequestTests.cs
+++ b/src/CoreWCF.Http/tests/LargeRequestTests.cs
@@ -73,7 +73,7 @@ namespace CoreWCF.Http.Tests
             {
                 services.AddServiceModelServices();
             }
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/MCWrappedMultiNSTests.cs
+++ b/src/CoreWCF.Http/tests/MCWrappedMultiNSTests.cs
@@ -46,7 +46,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/MessageEncoderTests.cs
+++ b/src/CoreWCF.Http/tests/MessageEncoderTests.cs
@@ -71,7 +71,7 @@ namespace CoreWCF.Http.Tests
             {
                 services.AddServiceModelServices();
             }
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/MessageEncodingTests.cs
+++ b/src/CoreWCF.Http/tests/MessageEncodingTests.cs
@@ -79,7 +79,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/OpActionReplyActionBehaviorTests.cs
+++ b/src/CoreWCF.Http/tests/OpActionReplyActionBehaviorTests.cs
@@ -180,7 +180,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/OpContractInvalidActionReplyActionTests.cs
+++ b/src/CoreWCF.Http/tests/OpContractInvalidActionReplyActionTests.cs
@@ -72,7 +72,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {
@@ -89,7 +89,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/OperationFaultContractInfoAwareServiceTests.cs
+++ b/src/CoreWCF.Http/tests/OperationFaultContractInfoAwareServiceTests.cs
@@ -51,7 +51,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/RegressionFixes.cs
+++ b/src/CoreWCF.Http/tests/RegressionFixes.cs
@@ -44,7 +44,7 @@ namespace CoreWCF.Http.Tests
 
         internal class StartupCharSetQuotes : StartupBase
         {
-            public override void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public override void Configure(IApplicationBuilder app)
             {
                 app.Use(async (context, next) =>
                 {
@@ -54,7 +54,7 @@ namespace CoreWCF.Http.Tests
                     typedHeaders.ContentType = contentType;
                     await next.Invoke();
                 });
-                base.Configure(app, env);
+                base.Configure(app);
             }
         }
 
@@ -65,7 +65,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public virtual void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public virtual void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/RequestPathModificationTests.cs
+++ b/src/CoreWCF.Http/tests/RequestPathModificationTests.cs
@@ -56,7 +56,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UsePathBase("/BasePath");
                 app.UseServiceModel(builder =>

--- a/src/CoreWCF.Http/tests/RequestReplyTests.cs
+++ b/src/CoreWCF.Http/tests/RequestReplyTests.cs
@@ -76,7 +76,7 @@ namespace CoreWCF.Http.Tests
             {
                 services.AddServiceModelServices();
             }
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceAuthBehaviorTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceAuthBehaviorTest.cs
@@ -69,7 +69,7 @@ namespace CoreWCF.Http.Tests
                 services.AddSingleton<ServiceAuthorizationManager, MyTestServiceAuthorizationManager>();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 ServiceAuthorizationBehavior authBehavior = app.ApplicationServices.GetRequiredService<ServiceAuthorizationBehavior>();
                 var authPolicies = new List<IAuthorizationPolicy>

--- a/src/CoreWCF.Http/tests/ServiceContract/TestTypes.cs
+++ b/src/CoreWCF.Http/tests/ServiceContract/TestTypes.cs
@@ -117,7 +117,13 @@ namespace ServiceContract
     public class H
     {
         [DataMember]
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable IDE1006 // Naming Styles
         private int i = 99;
+#pragma warning restore IDE1006 // Naming Styles
+#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore IDE0044 // Add readonly modifier
     }
 
     [Serializable]
@@ -132,7 +138,13 @@ namespace ServiceContract
     public struct mYStruct : ICloneable
     {
         [DataMember]
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable IDE1006 // Naming Styles
         private int i;
+#pragma warning restore IDE1006 // Naming Styles
+#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore IDE0044 // Add readonly modifier
 
         public object Clone()
         {

--- a/src/CoreWCF.Http/tests/ServiceContractNameSpaceTests.cs
+++ b/src/CoreWCF.Http/tests/ServiceContractNameSpaceTests.cs
@@ -199,7 +199,7 @@ namespace CoreWCF.Http.Tests
             services.AddServiceModelServices();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app)
         {
             app.UseServiceModel(builder =>
             {

--- a/src/CoreWCF.Http/tests/ServiceContractNameTests.cs
+++ b/src/CoreWCF.Http/tests/ServiceContractNameTests.cs
@@ -195,7 +195,7 @@ namespace CoreWCF.Http.Tests
             services.AddServiceModelServices();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app)
         {
             app.UseServiceModel(builder =>
             {

--- a/src/CoreWCF.Http/tests/ServiceWithContractInheritanceTests.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithContractInheritanceTests.cs
@@ -331,7 +331,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {
@@ -366,7 +366,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 Type serviceContractType = null;
                 app.UseServiceModel(builder =>
@@ -403,7 +403,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractTest.cs
@@ -102,7 +102,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevelTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFFaultContractWithNamespaceAtServiceContractLevelTest.cs
@@ -102,7 +102,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFMessageParameterTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFMessageParameterTest.cs
@@ -96,7 +96,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFXmlSerializerFormatOnOperationTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFXmlSerializerFormatOnOperationTest.cs
@@ -98,7 +98,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceWithCoreWCFXmlSerializerFormatTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithCoreWCFXmlSerializerFormatTest.cs
@@ -97,7 +97,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceWithMessageBodyAndHeaderTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithMessageBodyAndHeaderTest.cs
@@ -52,7 +52,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractTest.cs
@@ -102,7 +102,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevelTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMFaultContractWithNamespaceAtServiceContractLevelTest.cs
@@ -102,7 +102,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceWithSSMMessageParameterTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMMessageParameterTest.cs
@@ -96,7 +96,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceWithSSMXmlSerializerFormatOnOperationTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMXmlSerializerFormatOnOperationTest.cs
@@ -98,7 +98,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/ServiceWithSSMXmlSerializerFormatTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithSSMXmlSerializerFormatTest.cs
@@ -97,7 +97,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/SimpleTest.cs
+++ b/src/CoreWCF.Http/tests/SimpleTest.cs
@@ -93,7 +93,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {
@@ -111,7 +111,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {
@@ -133,7 +133,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {
@@ -155,7 +155,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/SimpleWSHTTPTest.cs
+++ b/src/CoreWCF.Http/tests/SimpleWSHTTPTest.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.Threading;
+using System.Threading.Tasks;
 using CoreWCF;
 using CoreWCF.Configuration;
 using CoreWCF.IdentityModel.Selectors;
@@ -164,16 +165,14 @@ namespace WSHttp
 
         internal class CustomTestValidator : UserNamePasswordValidator
         {
-            public override void Validate(string userName, string password)
+            public override ValueTask ValidateAsync(string userName, string password)
             {
                 if (string.Compare(userName, "testuser@corewcf", StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    return;
+                    return new ValueTask(Task.CompletedTask);
                 }
-                else
-                {
-                    throw new Exception("Permission Denied");
-                }
+
+                return new ValueTask(Task.FromException(new Exception("Permission Denied")));
             }
         }
 
@@ -280,7 +279,7 @@ namespace WSHttp
                 return wsBInding;
             }
            
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 CoreWCF.WSHttpBinding serverBinding = new CoreWCF.WSHttpBinding(_wsHttpSecurityMode);
                 serverBinding.Security.Message.ClientCredentialType = _credentialType;

--- a/src/CoreWCF.Http/tests/StreamingServiceTests.cs
+++ b/src/CoreWCF.Http/tests/StreamingServiceTests.cs
@@ -210,7 +210,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/TaskCollectionsTests.cs
+++ b/src/CoreWCF.Http/tests/TaskCollectionsTests.cs
@@ -133,7 +133,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/TaskPrimitivesTest.cs
+++ b/src/CoreWCF.Http/tests/TaskPrimitivesTest.cs
@@ -97,7 +97,7 @@ namespace BasicHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/TestFaultContractName1Tests.cs
+++ b/src/CoreWCF.Http/tests/TestFaultContractName1Tests.cs
@@ -56,7 +56,7 @@ namespace CoreWCF.Http.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.Http/tests/WebSocketsTests.cs
+++ b/src/CoreWCF.Http/tests/WebSocketsTests.cs
@@ -119,7 +119,7 @@ namespace NetHttp
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingConnection.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingConnection.cs
@@ -22,7 +22,6 @@ namespace CoreWCF.Channels.Framing
     public class FramingConnection
     {
         private readonly ConnectionContext _context;
-        private IDuplexPipe _transport;
 
         public FramingConnection(ConnectionContext context) : this(context, NullLogger.Instance) { }
 

--- a/src/CoreWCF.NetTcp/tests/AuthorizationTest.cs
+++ b/src/CoreWCF.NetTcp/tests/AuthorizationTest.cs
@@ -74,7 +74,7 @@ namespace CoreWCF.NetTcp.Tests
             services.AddServiceModelServices();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app)
         {
             app.UseServiceModel(builder =>
             {

--- a/src/CoreWCF.NetTcp/tests/ConnectionHandlerBufferedModeTests.cs
+++ b/src/CoreWCF.NetTcp/tests/ConnectionHandlerBufferedModeTests.cs
@@ -228,7 +228,7 @@ namespace ConnectionHandler
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.NetTcp/tests/ConnectionHandlerStreamedModeTests.cs
+++ b/src/CoreWCF.NetTcp/tests/ConnectionHandlerStreamedModeTests.cs
@@ -223,7 +223,7 @@ namespace ConnectionHandler
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.NetTcp/tests/DuplexServiceTests.cs
+++ b/src/CoreWCF.NetTcp/tests/DuplexServiceTests.cs
@@ -65,7 +65,7 @@ namespace CoreWCF.NetTcp.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.NetTcp/tests/LoopBackIPAdressTests.cs
+++ b/src/CoreWCF.NetTcp/tests/LoopBackIPAdressTests.cs
@@ -50,7 +50,7 @@ namespace CoreWCF.NetTcp.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
+++ b/src/CoreWCF.NetTcp/tests/ServiceAuthBehaviorTest.cs
@@ -200,7 +200,7 @@ namespace CoreWCF.NetTcp.Tests
             services.AddServiceModelServices();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app)
         {
             ServiceAuthorizationBehavior authBehavior = app.ApplicationServices.GetRequiredService<ServiceAuthorizationBehavior>();
             authBehavior.PrincipalPermissionMode = principalMode;
@@ -228,7 +228,7 @@ namespace CoreWCF.NetTcp.Tests
             services.AddSingleton<ServiceAuthorizationManager, MyTestServiceAuthorizationManager>();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app)
         {
             ServiceAuthorizationBehavior authBehavior = app.ApplicationServices.GetRequiredService<ServiceAuthorizationBehavior>();
             var authPolicies = new List<IAuthorizationPolicy>

--- a/src/CoreWCF.NetTcp/tests/TaskBasedOperationTests.cs
+++ b/src/CoreWCF.NetTcp/tests/TaskBasedOperationTests.cs
@@ -148,7 +148,7 @@ namespace AsyncServices
             services.AddServiceModelServices();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app)
         {
             app.UseServiceModel(builder =>
             {

--- a/src/CoreWCF.NetTcp/tests/TransportFrameworkTests.cs
+++ b/src/CoreWCF.NetTcp/tests/TransportFrameworkTests.cs
@@ -61,7 +61,7 @@ namespace CoreWCF.NetTcp.Tests
                 services.AddServiceModelServices();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 app.UseServiceModel(builder =>
                 {

--- a/src/CoreWCF.NetTcp/tests/TransportWithMessageCredentialNetTCPTest.cs
+++ b/src/CoreWCF.NetTcp/tests/TransportWithMessageCredentialNetTCPTest.cs
@@ -155,7 +155,7 @@ namespace CoreWCF.NetTcp.Tests
                 host.Description.Behaviors.Add(srvCredentials);
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app)
             {
                 CoreWCF.NetTcpBinding serverBinding = new CoreWCF.NetTcpBinding(SecurityMode.TransportWithMessageCredential);
                 serverBinding.Security.Message.ClientCredentialType = MessageCredentialType.UserName;
@@ -172,17 +172,14 @@ namespace CoreWCF.NetTcp.Tests
 
             internal class CustomTestValidator : UserNamePasswordValidator
             {
-                public override void Validate(string userName, string password)
+                public override ValueTask ValidateAsync(string userName, string password)
                 {
-                    if (string.Compare(userName, "testuser@corewcf", StringComparison.OrdinalIgnoreCase) == 0 && password.Length > 0)
+                    if (string.Compare(userName, "testuser@corewcf", StringComparison.OrdinalIgnoreCase) == 0)
                     {
-                        //Write custom logic
-                        return;
+                        return new ValueTask(Task.CompletedTask);
                     }
-                    else
-                    {
-                        throw new Exception("Permission Denied");
-                    }
+
+                    return new ValueTask(Task.FromException(new Exception("Permission Denied")));
                 }
             }
         }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/MessageEncoder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/MessageEncoder.cs
@@ -11,8 +11,6 @@ namespace CoreWCF.Channels
 {
     public abstract class MessageEncoder
     {
-        private string _traceSourceString;
-
         public abstract string ContentType { get; }
 
         public abstract string MediaType { get; }
@@ -221,7 +219,7 @@ namespace CoreWCF.Channels
             //     _traceSourceString = Runtime.Diagnostics.DiagnosticTraceBase.CreateDefaultSourceString(this);
             // }
 
-            return _traceSourceString;
+            return null;
         }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/ServiceChannelFactory.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/ServiceChannelFactory.cs
@@ -40,11 +40,14 @@ namespace CoreWCF.Channels
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.SFxChannelFactoryTypeMustBeInterface));
             }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             return ServiceChannelProxy.CreateProxy<TChannel>(direction, serviceChannel);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         internal static ServiceChannel GetServiceChannel(object transparentProxy)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             if (transparentProxy is ServiceChannelProxy proxy)
             {
                 return proxy.GetServiceChannel();
@@ -53,6 +56,7 @@ namespace CoreWCF.Channels
             {
                 return null;
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/DuplexChannelBinder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/DuplexChannelBinder.cs
@@ -18,8 +18,6 @@ namespace CoreWCF.Dispatcher
     {
         private IDuplexChannel _channel;
         private IRequestReplyCorrelator _correlator;
-        private TimeSpan _defaultCloseTimeout;
-        private TimeSpan _defaultSendTimeout;
         private IdentityVerifier _identityVerifier;
         private int _pending;
         private List<IDuplexRequest> _requests;

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/SecurityServiceDispatcher.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/SecurityServiceDispatcher.cs
@@ -546,7 +546,7 @@ namespace CoreWCF.Dispatcher
         public SecurityDuplexSessionChannelDispatcher(SecurityServiceDispatcher serviceDispatcher, IDuplexSessionChannel innerChannel, SecurityProtocol securityProtocol, SecurityListenerSettingsLifetimeManager settingsLifetimeManager)
             : base(serviceDispatcher, innerChannel, securityProtocol, settingsLifetimeManager)
         {
-            // sendUnsecuredFaults = channelManager.SendUnsecuredFaults;
+            _sendUnsecuredFaults = serviceDispatcher.SendUnsecuredFaults;
             SecurityServiceDispatcher = serviceDispatcher;
         }
 
@@ -563,11 +563,13 @@ namespace CoreWCF.Dispatcher
 
         public CommunicationState State => InnerDuplexChannel.State;
 
+#pragma warning disable CS0067 // The event is never used
         public event EventHandler Closing;
         public event EventHandler Faulted;
         public event EventHandler Opened;
         public event EventHandler Opening;
         public event EventHandler Closed;
+#pragma warning restore CS0067 // The event is never used
 
         public void Abort()
         {

--- a/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Selectors/SecurityTokenAuthenticator.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Selectors/SecurityTokenAuthenticator.cs
@@ -60,7 +60,9 @@ namespace CoreWCF.IdentityModel.Selectors
         protected virtual ValueTask<ReadOnlyCollection<IAuthorizationPolicy>> ValidateTokenCoreAsync(SecurityToken token)
         {
             // Default to calling sync implementation to support existing derived types which haven't overridden this method
+#pragma warning disable CS0618 // Type or member is obsolete
             return new ValueTask<ReadOnlyCollection<IAuthorizationPolicy>>(ValidateTokenCore(token));
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Selectors/UserNamePasswordValidator.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Selectors/UserNamePasswordValidator.cs
@@ -29,7 +29,9 @@ namespace CoreWCF.IdentityModel.Selectors
 
         public virtual ValueTask ValidateAsync(string userName, string password)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Validate(userName, password);
+#pragma warning restore CS0618 // Type or member is obsolete
             return new ValueTask();
         }
 

--- a/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Selectors/UserNameSecurityTokenAuthenticator.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Selectors/UserNameSecurityTokenAuthenticator.cs
@@ -9,7 +9,7 @@ using CoreWCF.IdentityModel.Tokens;
 
 namespace CoreWCF.IdentityModel.Selectors
 {
-    internal abstract class UserNameSecurityTokenAuthenticator : SecurityTokenAuthenticator
+    public abstract class UserNameSecurityTokenAuthenticator : SecurityTokenAuthenticator
     {
         protected UserNameSecurityTokenAuthenticator()
         {
@@ -29,7 +29,9 @@ namespace CoreWCF.IdentityModel.Selectors
         protected virtual ValueTask<ReadOnlyCollection<IAuthorizationPolicy>> ValidateUserNamePasswordCoreAsync(string userName, string password)
         {
             // Default to calling sync implementation to support existing derived types which haven't overridden this method
+#pragma warning disable CS0618 // Type or member is obsolete
             return new ValueTask<ReadOnlyCollection<IAuthorizationPolicy>>(ValidateUserNamePasswordCore(userName, password));
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/SecuritySessionServerSettings.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/SecuritySessionServerSettings.cs
@@ -2475,11 +2475,13 @@ namespace CoreWCF.Security
                 public IDuplexSessionChannel IncomingChannel { get; set; }
                 public IServiceChannelDispatcher ChannelDispatcher { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
+#pragma warning disable CS0067 // The event is never used
                 public event EventHandler Closed;
                 public event EventHandler Closing;
                 public event EventHandler Faulted;
                 public event EventHandler Opened;
                 public event EventHandler Opening;
+#pragma warning restore CS0067 // The event is never used
 
                 public Task DispatchAsync(RequestContext context)
                 {

--- a/src/CoreWCF.Primitives/tests/Helpers/TestHelper.cs
+++ b/src/CoreWCF.Primitives/tests/Helpers/TestHelper.cs
@@ -201,11 +201,16 @@ namespace Helpers
         public static void RegisterApplicationLifetime(this IServiceCollection services)
         {
 #if NETCOREAPP3_1_OR_GREATER
-            services.AddSingleton<Microsoft.Extensions.Hosting.IHostApplicationLifetime, Microsoft.Extensions.Hosting.Internal.ApplicationLifetime>();
-            var genericWebHostApplicationLifetimeType =
+            var applicationLifetimeType =
                 typeof(Microsoft.AspNetCore.Hosting.WebHostBuilder).Assembly.GetType(
-                    "Microsoft.AspNetCore.Hosting.GenericWebHostApplicationLifetime");
-            services.AddSingleton(typeof(Microsoft.AspNetCore.Hosting.IApplicationLifetime), genericWebHostApplicationLifetimeType!);
+                "Microsoft.AspNetCore.Hosting.ApplicationLifetime");
+            services.AddSingleton(typeof(Microsoft.Extensions.Hosting.IHostApplicationLifetime), applicationLifetimeType);
+#pragma warning disable CS0618 // Type or member is obsolete
+            services.AddSingleton(provider =>
+                provider.GetRequiredService<Microsoft.Extensions.Hosting.IHostApplicationLifetime>() as Microsoft.AspNetCore.Hosting.IApplicationLifetime);
+            services.AddSingleton(provider =>
+                provider.GetRequiredService<Microsoft.Extensions.Hosting.IHostApplicationLifetime>() as Microsoft.Extensions.Hosting.IApplicationLifetime);
+#pragma warning restore CS0618 // Type or member is obsolete
 #else
             services.AddSingleton<Microsoft.AspNetCore.Hosting.IApplicationLifetime, Microsoft.AspNetCore.Hosting.Internal.ApplicationLifetime>();
 #endif


### PR DESCRIPTION
Most of the changes were removing unused references to IHostingEnvironment in Startup.Configure method.
Suppressed message about HttpSys not being available when not solely targeting running on Windows.
Suppressed warning about calling obsolete methods when replacement async method falls back to calling virtual sync method for back compat.
Replaced sync override with async override as we return ValueTask so can stay sync with no allocations.
Suppressed warning about unused events on types which have those events to fulfill public contract.
Made UserNameSecurityTokenAuthenticator  public as it should have been already. Obsolete methods don't make sense otherwise.
Removed some unused fields. Fixed populating a field to enable unsecured faults.
Cleaned up primitives test helper for application lifetime support and suppressed warning about obsolete interfaces.