### PR TITLE
docs: update license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for details.
 This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our community.
 For more information see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
 
-Core WCF is Copyright &copy; 2019 .NET Foundation and other contributors under the [MIT license](LICENSE.txt).
+Core WCF is Copyright &copy; 2019 .NET Foundation and other contributors under the [MIT license](LICENSE).
 
 ### .NET Foundation
 


### PR DESCRIPTION
fix broken link to license file in readme