### PR TITLE
Throw InvalidOperationException if Service Model Web ServiceNotRegistered

### DIFF
--- a/src/CoreWCF.WebHttp/src/CoreWCF/Configuration/ServiceModelWebServiceBuilderExtensions.cs
+++ b/src/CoreWCF.WebHttp/src/CoreWCF/Configuration/ServiceModelWebServiceBuilderExtensions.cs
@@ -230,11 +230,7 @@ namespace CoreWCF.Configuration
             builder.AddServiceEndpoint(service, implementedContract, binding, address, listenUri, serviceEndpoint =>
             {
                 KeyedByTypeCollection<IEndpointBehavior> behaviors = (KeyedByTypeCollection<IEndpointBehavior>)serviceEndpoint.EndpointBehaviors;
-                WebHttpBehavior webHttpBehavior = behaviors.Find<WebHttpBehavior>();
-                if (webHttpBehavior is null)
-                {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ServiceModelWebServiceNotRegistered)));
-                }
+                WebHttpBehavior webHttpBehavior = behaviors.Find<WebHttpBehavior>() ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ServiceModelWebServiceNotRegistered, address)));
                 configureWebBehavior?.Invoke(webHttpBehavior);
 
                 if (webHttpBehavior.HelpEnabled)

--- a/src/CoreWCF.WebHttp/src/CoreWCF/Configuration/ServiceModelWebServiceBuilderExtensions.cs
+++ b/src/CoreWCF.WebHttp/src/CoreWCF/Configuration/ServiceModelWebServiceBuilderExtensions.cs
@@ -231,6 +231,10 @@ namespace CoreWCF.Configuration
             {
                 KeyedByTypeCollection<IEndpointBehavior> behaviors = (KeyedByTypeCollection<IEndpointBehavior>)serviceEndpoint.EndpointBehaviors;
                 WebHttpBehavior webHttpBehavior = behaviors.Find<WebHttpBehavior>();
+                if (webHttpBehavior is null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ServiceModelWebServiceNotRegistered)));
+                }
                 configureWebBehavior?.Invoke(webHttpBehavior);
 
                 if (webHttpBehavior.HelpEnabled)

--- a/src/CoreWCF.WebHttp/src/CoreWCF/Configuration/ServiceModelWebServiceBuilderExtensions.cs
+++ b/src/CoreWCF.WebHttp/src/CoreWCF/Configuration/ServiceModelWebServiceBuilderExtensions.cs
@@ -230,7 +230,7 @@ namespace CoreWCF.Configuration
             builder.AddServiceEndpoint(service, implementedContract, binding, address, listenUri, serviceEndpoint =>
             {
                 KeyedByTypeCollection<IEndpointBehavior> behaviors = (KeyedByTypeCollection<IEndpointBehavior>)serviceEndpoint.EndpointBehaviors;
-                WebHttpBehavior webHttpBehavior = behaviors.Find<WebHttpBehavior>() ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ServiceModelWebServiceNotRegistered, address)));
+                WebHttpBehavior webHttpBehavior = behaviors.Find<WebHttpBehavior>() ?? throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.Format(SR.ServiceModelWebServicesNotRegistered, address)));
                 configureWebBehavior?.Invoke(webHttpBehavior);
 
                 if (webHttpBehavior.HelpEnabled)

--- a/src/CoreWCF.WebHttp/src/Resources/Strings.resx
+++ b/src/CoreWCF.WebHttp/src/Resources/Strings.resx
@@ -375,6 +375,9 @@
   <data name="SerializingRequestNotSupportedByFormatter" xml:space="preserve">
     <value>The formatter '{0}' does not support serializing requests.</value>
   </data>
+  <data name="ServiceModelWebServiceNotRegistered" xml:space="preserve">
+    <value>Service Model Web Service not registered, call IServiceCollection.AddServiceModelWebServices() in Startup.cs.</value>
+  </data>
   <data name="SFxInvalidCallbackIAsyncResult" xml:space="preserve">
     <value>IAsyncResult not provided or of wrong type.</value>
   </data>

--- a/src/CoreWCF.WebHttp/src/Resources/Strings.resx
+++ b/src/CoreWCF.WebHttp/src/Resources/Strings.resx
@@ -375,8 +375,8 @@
   <data name="SerializingRequestNotSupportedByFormatter" xml:space="preserve">
     <value>The formatter '{0}' does not support serializing requests.</value>
   </data>
-  <data name="ServiceModelWebServiceNotRegistered" xml:space="preserve">
-    <value>Service Model Web Service not registered, call IServiceCollection.AddServiceModelWebServices() in Startup.cs.</value>
+  <data name="ServiceModelWebServicesNotRegistered" xml:space="preserve">
+    <value>Unable to find the endpoint behavior WebHttpBehavior for endpoint address '{0}'. This is possibly caused by not calling ServiceModelWebServiceCollectionExtensions.AddServiceModelWebServices(IServiceCollection services).</value>
   </data>
   <data name="SFxInvalidCallbackIAsyncResult" xml:space="preserve">
     <value>IAsyncResult not provided or of wrong type.</value>


### PR DESCRIPTION
This PR throws an InvalidOperationException, with a message, if the Service Model Web Service is not registered.