### PR TITLE
Workaround runtime DataContract bugs

### DIFF
--- a/src/CoreWCF.Metadata/tests/Contracts/ICollectionsService.cs
+++ b/src/CoreWCF.Metadata/tests/Contracts/ICollectionsService.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using CoreWCF;
+
+namespace ServiceContract
+{
+    [ServiceContract(Namespace = Constants.NS, Name = "CollectionsService")]
+    public interface ICollectionsService
+    {
+        [OperationContract]
+        List<string> EchoStringList(List<string> echo);
+
+        [OperationContract]
+        IEnumerable<string> EchoStringEnumerable(IEnumerable<string> echo);
+
+        [OperationContract]
+        string[] EchoStringArray(string[] echo);
+
+        [OperationContract]
+        Dictionary<string, string> EchoDictionary(Dictionary<string, string> echo);
+
+        [OperationContract]
+        IDictionary<string, string> EchoIDictionary(IDictionary<string, string> echo);
+    }
+}

--- a/src/CoreWCF.Metadata/tests/Contracts/IComplexTypesWithCollectionsService.cs
+++ b/src/CoreWCF.Metadata/tests/Contracts/IComplexTypesWithCollectionsService.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using CoreWCF;
+
+namespace ServiceContract
+{
+    [ServiceContract(Namespace = Constants.NS, Name = "ComplexTypesWithCollectionsService")]
+    public interface IComplexTypesWithCollectionsService
+    {
+        [OperationContract]
+        DataContainingList EchoComplexTypeWithList(DataContainingList echo);
+
+        [OperationContract]
+        DataContainingArray EchoComplexTypeWithArray(DataContainingArray echo);
+    }
+
+    [DataContract]
+    public class DataContainingArray
+    {
+        [DataMember]
+        public string[] StringDataArray { get; set; }
+    }
+
+    [DataContract]
+    public class DataContainingList
+    {
+        [DataMember]
+        public List<string> StringDataList { get; set; }
+    }
+}

--- a/src/CoreWCF.Metadata/tests/Contracts/IEnumService.cs
+++ b/src/CoreWCF.Metadata/tests/Contracts/IEnumService.cs
@@ -9,8 +9,11 @@ namespace ServiceContract
     [ServiceContract(Namespace = Constants.NS, Name = "EnumService")]
     public interface IEnumService
     {
-        [OperationContract] void AcceptWrapped(TestWrappedEnum accept);
-        [OperationContract] TestWrappedEnum RequestWrapped();
+        [OperationContract]
+        void AcceptWrapped(TestWrappedEnum accept);
+
+        [OperationContract]
+        TestWrappedEnum RequestWrapped();
     }
 
     [DataContract]

--- a/src/CoreWCF.Metadata/tests/Contracts/IPrimitivesService.cs
+++ b/src/CoreWCF.Metadata/tests/Contracts/IPrimitivesService.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using CoreWCF;
+
+namespace ServiceContract
+{
+    [ServiceContract(Namespace = Constants.NS, Name = "PrimitivesService")]
+    internal interface IPrimitivesService
+    {
+        [OperationContract]
+        Uri EchoUri(Uri data);
+
+        [OperationContract]
+        sbyte[] EchoSbyte(sbyte[] data);
+
+        [OperationContract]
+        bool EchoBool(bool data);
+
+        [OperationContract]
+        DateTime EchoDateTime(DateTime data);
+
+        [OperationContract]
+        decimal EchoDecimal(decimal data);
+
+        [OperationContract]
+        double EchoDouble(double data);
+
+        [OperationContract]
+        float EchoFloat(float data);
+
+        [OperationContract]
+        int EchoInt(int data);
+
+        [OperationContract]
+        long EchoLong(long data);
+
+        [OperationContract]
+        short EchoShort(short data);
+
+        [OperationContract]
+        string EchoString(string data);
+
+        [OperationContract]
+        byte EchoByte(byte data);
+
+        [OperationContract]
+        uint EchoUint(uint data);
+
+        [OperationContract]
+        ulong EchoUlong(ulong data);
+
+        [OperationContract]
+        ushort EchoUshort(ushort data);
+
+        [OperationContract]
+        char EchoChar(char data);
+
+        [OperationContract]
+        TimeSpan EchoTimeSpan(TimeSpan data);
+
+        [OperationContract]
+        Guid EchoGuid(Guid data);
+    }
+}

--- a/src/CoreWCF.Metadata/tests/DataTypesTest.cs
+++ b/src/CoreWCF.Metadata/tests/DataTypesTest.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using CoreWCF.Metadata.Tests.Helpers;
+using ServiceContract;
+using Services;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Metadata.Tests
+{
+    public class DataTypesTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public DataTypesTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task CollectionsDataContract()
+        {
+            await TestHelper.RunSingleWsdlTestAsync<CollectionsService, ICollectionsService>(new BasicHttpBinding(), _output);
+        }
+
+        [Fact]
+        public async Task PrimitivesDataContract()
+        {
+            await TestHelper.RunSingleWsdlTestAsync<PrimitivesService, IPrimitivesService>(new BasicHttpBinding(), _output);
+        }
+    }
+}

--- a/src/CoreWCF.Metadata/tests/DataTypesTest.cs
+++ b/src/CoreWCF.Metadata/tests/DataTypesTest.cs
@@ -30,5 +30,11 @@ namespace CoreWCF.Metadata.Tests
         {
             await TestHelper.RunSingleWsdlTestAsync<PrimitivesService, IPrimitivesService>(new BasicHttpBinding(), _output);
         }
+
+        [Fact]
+        public async Task ComplexTypesWithCollectionsDataContract()
+        {
+            await TestHelper.RunSingleWsdlTestAsync<ComplexTypesWithCollectionsService, IComplexTypesWithCollectionsService>(new BasicHttpBinding(), _output);
+        }
     }
 }

--- a/src/CoreWCF.Metadata/tests/Services/CollectionsService.cs
+++ b/src/CoreWCF.Metadata/tests/Services/CollectionsService.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using ServiceContract;
+
+namespace Services
+{
+    public class CollectionsService : ICollectionsService
+    {
+        public Dictionary<string, string> EchoDictionary(Dictionary<string, string> echo) => throw new NotImplementedException();
+        public IDictionary<string, string> EchoIDictionary(IDictionary<string, string> echo) => throw new NotImplementedException();
+        public string[] EchoStringArray(string[] echo) => throw new NotImplementedException();
+        public IEnumerable<string> EchoStringEnumerable(IEnumerable<string> echo) => throw new NotImplementedException();
+        public List<string> EchoStringList(List<string> echo) => throw new NotImplementedException();
+    }
+}

--- a/src/CoreWCF.Metadata/tests/Services/ComplexTypesWithCollectionsService.cs
+++ b/src/CoreWCF.Metadata/tests/Services/ComplexTypesWithCollectionsService.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using ServiceContract;
+
+namespace Services
+{
+    public class ComplexTypesWithCollectionsService : IComplexTypesWithCollectionsService
+    {
+        public DataContainingArray EchoComplexTypeWithArray(DataContainingArray echo) => throw new NotImplementedException();
+        public DataContainingList EchoComplexTypeWithList(DataContainingList echo) => throw new NotImplementedException();
+    }
+}

--- a/src/CoreWCF.Metadata/tests/Services/PrimitivesService.cs
+++ b/src/CoreWCF.Metadata/tests/Services/PrimitivesService.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using ServiceContract;
+
+namespace Services
+{
+    public class PrimitivesService : IPrimitivesService
+    {
+        public bool EchoBool(bool data) => throw new NotImplementedException();
+        public byte EchoByte(byte data) => throw new NotImplementedException();
+        public char EchoChar(char data) => throw new NotImplementedException();
+        public DateTime EchoDateTime(DateTime data) => throw new NotImplementedException();
+        public decimal EchoDecimal(decimal data) => throw new NotImplementedException();
+        public double EchoDouble(double data) => throw new NotImplementedException();
+        public float EchoFloat(float data) => throw new NotImplementedException();
+        public Guid EchoGuid(Guid data) => throw new NotImplementedException();
+        public int EchoInt(int data) => throw new NotImplementedException();
+        public long EchoLong(long data) => throw new NotImplementedException();
+        public sbyte[] EchoSbyte(sbyte[] data) => throw new NotImplementedException();
+        public short EchoShort(short data) => throw new NotImplementedException();
+        public string EchoString(string data) => throw new NotImplementedException();
+        public TimeSpan EchoTimeSpan(TimeSpan data) => throw new NotImplementedException();
+        public uint EchoUint(uint data) => throw new NotImplementedException();
+        public ulong EchoUlong(ulong data) => throw new NotImplementedException();
+        public Uri EchoUri(Uri data) => throw new NotImplementedException();
+        public ushort EchoUshort(ushort data) => throw new NotImplementedException();
+    }
+}

--- a/src/CoreWCF.Metadata/tests/Wsdls/DataTypesTest.CollectionsDataContract.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/DataTypesTest.CollectionsDataContract.xml
@@ -1,0 +1,250 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="CollectionsService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+      <xs:element name="EchoStringList">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q1:ArrayOfstring" xmlns:q1="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringListResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringListResult" nillable="true" type="q2:ArrayOfstring" xmlns:q2="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringEnumerable">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q3:ArrayOfstring" xmlns:q3="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringEnumerableResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringEnumerableResult" nillable="true" type="q4:ArrayOfstring" xmlns:q4="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringArray">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q5:ArrayOfstring" xmlns:q5="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringArrayResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringArrayResult" nillable="true" type="q6:ArrayOfstring" xmlns:q6="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDictionary">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q7:ArrayOfKeyValueOfstringstring" xmlns:q7="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDictionaryResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoDictionaryResult" nillable="true" type="q8:ArrayOfKeyValueOfstringstring" xmlns:q8="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoIDictionary">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q9:ArrayOfKeyValueOfstringstring" xmlns:q9="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoIDictionaryResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoIDictionaryResult" nillable="true" type="q10:ArrayOfKeyValueOfstringstring" xmlns:q10="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+      <xs:complexType name="ArrayOfstring">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="string" nillable="true" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfstring" nillable="true" type="tns:ArrayOfstring"/>
+      <xs:complexType name="ArrayOfKeyValueOfstringstring">
+        <xs:annotation>
+          <xs:appinfo>
+            <IsDictionary xmlns="http://schemas.microsoft.com/2003/10/Serialization/">true</IsDictionary>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="KeyValueOfstringstring">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="Key" nillable="true" type="xs:string"/>
+                <xs:element name="Value" nillable="true" type="xs:string"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfKeyValueOfstringstring" nillable="true" type="tns:ArrayOfKeyValueOfstringstring"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="CollectionsService_EchoStringList_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringList"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringList_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringListResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringEnumerable_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringEnumerable"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringEnumerable_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringEnumerableResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringArray_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringArray"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringArray_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringArrayResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoDictionary_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDictionary"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoDictionary_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDictionaryResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoIDictionary_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoIDictionary"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoIDictionary_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoIDictionaryResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="CollectionsService">
+    <wsdl:operation name="EchoStringList">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringList" message="tns:CollectionsService_EchoStringList_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringListResponse" message="tns:CollectionsService_EchoStringList_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringEnumerable">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringEnumerable" message="tns:CollectionsService_EchoStringEnumerable_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringEnumerableResponse" message="tns:CollectionsService_EchoStringEnumerable_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringArray">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringArray" message="tns:CollectionsService_EchoStringArray_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringArrayResponse" message="tns:CollectionsService_EchoStringArray_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDictionary">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoDictionary" message="tns:CollectionsService_EchoDictionary_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoDictionaryResponse" message="tns:CollectionsService_EchoDictionary_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoIDictionary">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoIDictionary" message="tns:CollectionsService_EchoIDictionary_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoIDictionaryResponse" message="tns:CollectionsService_EchoIDictionary_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_CollectionsService" type="tns:CollectionsService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoStringList">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringList" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringEnumerable">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringEnumerable" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringArray">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringArray" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDictionary">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoDictionary" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoIDictionary">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoIDictionary" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="CollectionsService">
+    <wsdl:port name="BasicHttpBinding_CollectionsService" binding="tns:BasicHttpBinding_CollectionsService">
+      <soap:address location="http://localhost/TestService/api"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/DataTypesTest.ComplexTypesWithCollectionsDataContract.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/DataTypesTest.ComplexTypesWithCollectionsDataContract.xml
@@ -1,0 +1,148 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="ComplexTypesWithCollectionsService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+      <xs:element name="EchoComplexTypeWithList">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q1:DataContainingList" xmlns:q1="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoComplexTypeWithListResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoComplexTypeWithListResult" nillable="true" type="q2:DataContainingList" xmlns:q2="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoComplexTypeWithArray">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q3:DataContainingArray" xmlns:q3="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoComplexTypeWithArrayResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoComplexTypeWithArrayResult" nillable="true" type="q4:DataContainingArray" xmlns:q4="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.datacontract.org/2004/07/ServiceContract" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.datacontract.org/2004/07/ServiceContract">
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+      <xs:complexType name="DataContainingList">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="StringDataList" nillable="true" type="q1:ArrayOfstring" xmlns:q1="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="DataContainingList" nillable="true" type="tns:DataContainingList"/>
+      <xs:complexType name="DataContainingArray">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="StringDataArray" nillable="true" type="q2:ArrayOfstring" xmlns:q2="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="DataContainingArray" nillable="true" type="tns:DataContainingArray"/>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+      <xs:complexType name="ArrayOfstring">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="string" nillable="true" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfstring" nillable="true" type="tns:ArrayOfstring"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="ComplexTypesWithCollectionsService_EchoComplexTypeWithList_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoComplexTypeWithList"/>
+  </wsdl:message>
+  <wsdl:message name="ComplexTypesWithCollectionsService_EchoComplexTypeWithList_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoComplexTypeWithListResponse"/>
+  </wsdl:message>
+  <wsdl:message name="ComplexTypesWithCollectionsService_EchoComplexTypeWithArray_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoComplexTypeWithArray"/>
+  </wsdl:message>
+  <wsdl:message name="ComplexTypesWithCollectionsService_EchoComplexTypeWithArray_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoComplexTypeWithArrayResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="ComplexTypesWithCollectionsService">
+    <wsdl:operation name="EchoComplexTypeWithList">
+      <wsdl:input wsaw:Action="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithList" message="tns:ComplexTypesWithCollectionsService_EchoComplexTypeWithList_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithListResponse" message="tns:ComplexTypesWithCollectionsService_EchoComplexTypeWithList_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoComplexTypeWithArray">
+      <wsdl:input wsaw:Action="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithArray" message="tns:ComplexTypesWithCollectionsService_EchoComplexTypeWithArray_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithArrayResponse" message="tns:ComplexTypesWithCollectionsService_EchoComplexTypeWithArray_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_ComplexTypesWithCollectionsService" type="tns:ComplexTypesWithCollectionsService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoComplexTypeWithList">
+      <soap:operation soapAction="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithList" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoComplexTypeWithArray">
+      <soap:operation soapAction="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithArray" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="ComplexTypesWithCollectionsService">
+    <wsdl:port name="BasicHttpBinding_ComplexTypesWithCollectionsService" binding="tns:BasicHttpBinding_ComplexTypesWithCollectionsService">
+      <soap:address location="http://localhost/TestService/api"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/DataTypesTest.PrimitivesDataContract.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/DataTypesTest.PrimitivesDataContract.xml
@@ -1,0 +1,662 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="PrimitivesService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/"/>
+      <xs:element name="EchoUri">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" nillable="true" type="xs:anyURI"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUriResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoUriResult" nillable="true" type="xs:anyURI"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoSbyte">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" nillable="true" type="q1:ArrayOfbyte" xmlns:q1="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoSbyteResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoSbyteResult" nillable="true" type="q2:ArrayOfbyte" xmlns:q2="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoBool">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:boolean"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoBoolResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoBoolResult" type="xs:boolean"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDateTime">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:dateTime"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDateTimeResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoDateTimeResult" type="xs:dateTime"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDecimal">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:decimal"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDecimalResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoDecimalResult" type="xs:decimal"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDouble">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:double"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDoubleResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoDoubleResult" type="xs:double"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoFloat">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:float"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoFloatResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoFloatResult" type="xs:float"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoInt">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:int"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoIntResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoIntResult" type="xs:int"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoLong">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:long"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoLongResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoLongResult" type="xs:long"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoShort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:short"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoShortResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoShortResult" type="xs:short"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoByte">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:unsignedByte"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoByteResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoByteResult" type="xs:unsignedByte"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUint">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:unsignedInt"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUintResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoUintResult" type="xs:unsignedInt"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUlong">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:unsignedLong"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUlongResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoUlongResult" type="xs:unsignedLong"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUshort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:unsignedShort"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUshortResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoUshortResult" type="xs:unsignedShort"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoChar">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="q3:char" xmlns:q3="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoCharResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoCharResult" type="q4:char" xmlns:q4="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoTimeSpan">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="q5:duration" xmlns:q5="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoTimeSpanResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoTimeSpanResult" type="q6:duration" xmlns:q6="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoGuid">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="q7:guid" xmlns:q7="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoGuidResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoGuidResult" type="q8:guid" xmlns:q8="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+      <xs:complexType name="ArrayOfbyte">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="byte" type="xs:byte"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfbyte" nillable="true" type="tns:ArrayOfbyte"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="PrimitivesService_EchoUri_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUri"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUri_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUriResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoSbyte_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoSbyte"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoSbyte_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoSbyteResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoBool_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoBool"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoBool_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoBoolResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDateTime_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDateTime"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDateTime_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDateTimeResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDecimal_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDecimal"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDecimal_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDecimalResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDouble_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDouble"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDouble_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDoubleResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoFloat_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoFloat"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoFloat_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoFloatResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoInt_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoInt"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoInt_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoIntResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoLong_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoLong"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoLong_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoLongResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoShort_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoShort"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoShort_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoShortResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoString_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoString_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoByte_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoByte"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoByte_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoByteResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUint_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUint"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUint_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUintResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUlong_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUlong"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUlong_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUlongResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUshort_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUshort"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUshort_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUshortResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoChar_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoChar"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoChar_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoCharResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoTimeSpan_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoTimeSpan"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoTimeSpan_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoTimeSpanResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoGuid_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoGuid"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoGuid_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoGuidResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="PrimitivesService">
+    <wsdl:operation name="EchoUri">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoUri" message="tns:PrimitivesService_EchoUri_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoUriResponse" message="tns:PrimitivesService_EchoUri_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoSbyte">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoSbyte" message="tns:PrimitivesService_EchoSbyte_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoSbyteResponse" message="tns:PrimitivesService_EchoSbyte_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoBool">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoBool" message="tns:PrimitivesService_EchoBool_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoBoolResponse" message="tns:PrimitivesService_EchoBool_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDateTime">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoDateTime" message="tns:PrimitivesService_EchoDateTime_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoDateTimeResponse" message="tns:PrimitivesService_EchoDateTime_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDecimal">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoDecimal" message="tns:PrimitivesService_EchoDecimal_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoDecimalResponse" message="tns:PrimitivesService_EchoDecimal_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDouble">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoDouble" message="tns:PrimitivesService_EchoDouble_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoDoubleResponse" message="tns:PrimitivesService_EchoDouble_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoFloat">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoFloat" message="tns:PrimitivesService_EchoFloat_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoFloatResponse" message="tns:PrimitivesService_EchoFloat_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoInt">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoInt" message="tns:PrimitivesService_EchoInt_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoIntResponse" message="tns:PrimitivesService_EchoInt_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoLong">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoLong" message="tns:PrimitivesService_EchoLong_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoLongResponse" message="tns:PrimitivesService_EchoLong_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoShort">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoShort" message="tns:PrimitivesService_EchoShort_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoShortResponse" message="tns:PrimitivesService_EchoShort_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoString" message="tns:PrimitivesService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoStringResponse" message="tns:PrimitivesService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoByte">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoByte" message="tns:PrimitivesService_EchoByte_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoByteResponse" message="tns:PrimitivesService_EchoByte_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUint">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoUint" message="tns:PrimitivesService_EchoUint_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoUintResponse" message="tns:PrimitivesService_EchoUint_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUlong">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoUlong" message="tns:PrimitivesService_EchoUlong_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoUlongResponse" message="tns:PrimitivesService_EchoUlong_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUshort">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoUshort" message="tns:PrimitivesService_EchoUshort_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoUshortResponse" message="tns:PrimitivesService_EchoUshort_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoChar">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoChar" message="tns:PrimitivesService_EchoChar_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoCharResponse" message="tns:PrimitivesService_EchoChar_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoTimeSpan">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoTimeSpan" message="tns:PrimitivesService_EchoTimeSpan_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoTimeSpanResponse" message="tns:PrimitivesService_EchoTimeSpan_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoGuid">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoGuid" message="tns:PrimitivesService_EchoGuid_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoGuidResponse" message="tns:PrimitivesService_EchoGuid_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_PrimitivesService" type="tns:PrimitivesService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoUri">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoUri" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoSbyte">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoSbyte" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoBool">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoBool" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDateTime">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoDateTime" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDecimal">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoDecimal" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDouble">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoDouble" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoFloat">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoFloat" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoInt">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoInt" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoLong">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoLong" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoShort">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoShort" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoString">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoByte">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoByte" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUint">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoUint" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUlong">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoUlong" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUshort">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoUshort" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoChar">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoChar" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoTimeSpan">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoTimeSpan" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoGuid">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoGuid" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PrimitivesService">
+    <wsdl:port name="BasicHttpBinding_PrimitivesService" binding="tns:BasicHttpBinding_PrimitivesService">
+      <soap:address location="http://localhost/TestService/api"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/WsdlExporter.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/WsdlExporter.cs
@@ -144,48 +144,10 @@ namespace CoreWCF.Description
 
             foreach (XmlSchema schema in GeneratedXmlSchemas.Schemas())
             {
-                RemoveKeyValuePair(schema);
-
-                if (schema.Items.Count > 0)
-                {
-                    set.MetadataSections.Add(MetadataSection.CreateFromSchema(schema));
-                }
+                set.MetadataSections.Add(MetadataSection.CreateFromSchema(schema));
             }
 
             return set;
-        }
-
-        // Workaround for DataContract adding an extra schema entry for KeyValue<K,V>. See GitHub
-        // issue https://github.com/dotnet/runtime/issues/67949 for details.
-        private static void RemoveKeyValuePair(XmlSchema schema)
-        {
-            if (schema.TargetNamespace == "http://schemas.datacontract.org/2004/07/System.Collections.Generic")
-            {
-                var schemaObjectsToRemove = new List<XmlSchemaObject>();
-                foreach (XmlSchemaObject schemaObject in schema.Items)
-                {
-                    if (schemaObject is XmlSchemaElement schemaElement)
-                    {
-                        if (schemaElement.SchemaTypeName.Namespace == "http://schemas.datacontract.org/2004/07/System.Collections.Generic" &&
-                            schemaElement.SchemaTypeName.Name.StartsWith("KeyValuePairOf"))
-                        {
-                            schemaObjectsToRemove.Add(schemaObject);
-                        }
-                    }
-                    else if (schemaObject is XmlSchemaComplexType schemaComplexType)
-                    {
-                        if (schemaComplexType.Name.StartsWith("KeyValuePairOf"))
-                        {
-                            schemaObjectsToRemove.Add(schemaObject);
-                        }
-                    }
-                }
-
-                foreach (var schemaObject in schemaObjectsToRemove)
-                {
-                    schema.Items.Remove(schemaObject);
-                }
-            }
         }
 
         public WsdlNS.ServiceDescriptionCollection GeneratedWsdlDocuments { get; } = new WsdlNS.ServiceDescriptionCollection();

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/WsdlExporter.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/WsdlExporter.cs
@@ -144,10 +144,48 @@ namespace CoreWCF.Description
 
             foreach (XmlSchema schema in GeneratedXmlSchemas.Schemas())
             {
-                set.MetadataSections.Add(MetadataSection.CreateFromSchema(schema));
+                RemoveKeyValuePair(schema);
+
+                if (schema.Items.Count > 0)
+                {
+                    set.MetadataSections.Add(MetadataSection.CreateFromSchema(schema));
+                }
             }
 
             return set;
+        }
+
+        // Workaround for DataContract adding an extra schema entry for KeyValue<K,V>. See GitHub
+        // issue https://github.com/dotnet/runtime/issues/67949 for details.
+        private static void RemoveKeyValuePair(XmlSchema schema)
+        {
+            if (schema.TargetNamespace == "http://schemas.datacontract.org/2004/07/System.Collections.Generic")
+            {
+                var schemaObjectsToRemove = new List<XmlSchemaObject>();
+                foreach (XmlSchemaObject schemaObject in schema.Items)
+                {
+                    if (schemaObject is XmlSchemaElement schemaElement)
+                    {
+                        if (schemaElement.SchemaTypeName.Namespace == "http://schemas.datacontract.org/2004/07/System.Collections.Generic" &&
+                            schemaElement.SchemaTypeName.Name.StartsWith("KeyValuePairOf"))
+                        {
+                            schemaObjectsToRemove.Add(schemaObject);
+                        }
+                    }
+                    else if (schemaObject is XmlSchemaComplexType schemaComplexType)
+                    {
+                        if (schemaComplexType.Name.StartsWith("KeyValuePairOf"))
+                        {
+                            schemaObjectsToRemove.Add(schemaObject);
+                        }
+                    }
+                }
+
+                foreach (var schemaObject in schemaObjectsToRemove)
+                {
+                    schema.Items.Remove(schemaObject);
+                }
+            }
         }
 
         public WsdlNS.ServiceDescriptionCollection GeneratedWsdlDocuments { get; } = new WsdlNS.ServiceDescriptionCollection();

--- a/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/DataContractEx.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/DataContractEx.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Xml;
@@ -13,19 +13,7 @@ namespace CoreWCF.Runtime.Serialization
 {
     internal class DataContractEx
     {
-        private static readonly Dictionary<Type, XmlQualifiedName> s_typeToName = new Dictionary<Type, XmlQualifiedName>
-        {
-            [typeof(sbyte)] = new XmlQualifiedName("byte", XmlSchema.Namespace),
-            [typeof(byte)] = new XmlQualifiedName("unsignedByte", XmlSchema.Namespace),
-            [typeof(short)] = new XmlQualifiedName("short", XmlSchema.Namespace),
-            [typeof(ushort)] = new XmlQualifiedName("unsignedShort", XmlSchema.Namespace),
-            [typeof(int)] = new XmlQualifiedName("int", XmlSchema.Namespace),
-            [typeof(uint)] = new XmlQualifiedName("unsignedInt", XmlSchema.Namespace),
-            [typeof(long)] = new XmlQualifiedName("long", XmlSchema.Namespace),
-            [typeof(ulong)] = new XmlQualifiedName("unsignedLong", XmlSchema.Namespace)
-        };
-
-        private DataContractEx(object dataContract)
+        protected DataContractEx(object dataContract)
         {
             WrappedDataContract = dataContract ?? throw new ArgumentNullException(nameof(dataContract));
             Fx.Assert(DataContractType.IsAssignableFrom(dataContract.GetType()), "Only types derived from DataContract can be wrapped");
@@ -38,44 +26,544 @@ namespace CoreWCF.Runtime.Serialization
         public XmlDictionaryString TopLevelElementName => s_getTopLevelElementName(WrappedDataContract);
         public XmlDictionaryString TopLevelElementNamespace => s_getTopLevelElementNamespace(WrappedDataContract);
         public bool HasRoot => s_getHasRoot(WrappedDataContract);
-        public bool IsXmlDataContract => WrappedDataContract.GetType() == s_xmlDataContractType;
-        public bool XmlDataContractIsAnonymous => s_getXmlDataContractIsAnonymous(WrappedDataContract);
-        public XmlSchemaType XmlDataContractXsdType => s_getXmlDataContractXsdType(WrappedDataContract);
+        public bool IsBuiltInDataContract => s_getIsBuiltInDataContract(WrappedDataContract);
+        public bool IsReference => s_getIsReference(WrappedDataContract);
+        public bool IsISerializable => s_getIsISerializable(WrappedDataContract);
+        public bool IsValueType => s_getIsValueType(WrappedDataContract);
+
+        public sealed override bool Equals(object other)
+        {
+            Fx.Assert(!(other is DataContractEx), "The unwrapped DataContract should be passed to equals");
+            if (WrappedDataContract == other)
+                return true;
+
+            return Equals(other, new Dictionary<DataContractPairKey, object>());
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        internal virtual bool Equals(object other, Dictionary<DataContractPairKey, object> checkedContracts)
+        {
+            DataContractEx dataContract = Wrap(other);
+            if (dataContract != null)
+            {
+                return StableName.Name == dataContract.StableName.Name && StableName.Namespace == dataContract.StableName.Namespace && IsReference == dataContract.IsReference;
+            }
+
+            return false;
+        }
+
+        internal bool IsEqualOrChecked(object other, Dictionary<DataContractPairKey, object> checkedContracts)
+        {
+            if (WrappedDataContract == other)
+                return true;
+
+            if (checkedContracts != null)
+            {
+                DataContractPairKey contractPairKey = new DataContractPairKey(WrappedDataContract, other);
+                if (checkedContracts.ContainsKey(contractPairKey))
+                    return true;
+                checkedContracts.Add(contractPairKey, null);
+            }
+
+            return false;
+        }
 
         internal static Func<Type, DataContractEx> GetDataContract { private set; get; } = GetDataContractStub;
 
         internal static Type DataContractType => typeof(DataContractSerializer).Assembly.GetType("System.Runtime.Serialization.DataContract");
-        private static Type s_xmlDataContractType = typeof(DataContractSerializer).Assembly.GetType("System.Runtime.Serialization.XmlDataContract");
-        private static Type s_enumDataContractType = typeof(DataContractSerializer).Assembly.GetType("System.Runtime.Serialization.EnumDataContract");
-        private static Func<object, Type> s_getUnderlyingType = ReflectionHelper.GetPropertyDelegate<Type>(DataContractType, "UnderlyingType");
-        private static Func<object, XmlQualifiedName> s_getStableName = ReflectionHelper.GetPropertyDelegate<XmlQualifiedName>(DataContractType, "StableName");
-        private static Func<object, XmlDictionaryString> s_getTopLevelElementName = ReflectionHelper.GetPropertyDelegate<XmlDictionaryString>(DataContractType, "TopLevelElementName");
-        private static Func<object, XmlDictionaryString> s_getTopLevelElementNamespace = ReflectionHelper.GetPropertyDelegate<XmlDictionaryString>(DataContractType, "TopLevelElementNamespace");
-        private static Func<object, bool> s_getHasRoot = ReflectionHelper.GetPropertyDelegate<bool>(DataContractType, "HasRoot");
-        private static Func<object, bool> s_getXmlDataContractIsAnonymous = ReflectionHelper.GetPropertyDelegate<bool>(s_xmlDataContractType, "IsAnonymous");
-        private static Func<object, XmlSchemaType> s_getXmlDataContractXsdType = ReflectionHelper.GetPropertyDelegate<XmlSchemaType>(s_xmlDataContractType, "XsdType");
-        private static Action<object, XmlQualifiedName> s_setEnumBaseContractName = ReflectionHelper.SetPropertyDelegate<XmlQualifiedName>(s_enumDataContractType, "BaseContractName");
+        protected static readonly Type ClassDataContractType = typeof(DataContractSerializer).Assembly.GetType("System.Runtime.Serialization.ClassDataContract");
+        protected static readonly Type CollectionDataContractType = typeof(DataContractSerializer).Assembly.GetType("System.Runtime.Serialization.CollectionDataContract");
+        protected static readonly Type EnumDataContractType = typeof(DataContractSerializer).Assembly.GetType("System.Runtime.Serialization.EnumDataContract");
+        protected static readonly Type PrimitiveDataContractType = typeof(DataContractSerializer).Assembly.GetType("System.Runtime.Serialization.PrimitiveDataContract");
+        protected static readonly Type XmlDataContractType = typeof(DataContractSerializer).Assembly.GetType("System.Runtime.Serialization.XmlDataContract");
 
-        internal static void FixupEnumDataContract(object dataContract)
-        {
-            if (dataContract.GetType().Equals(s_enumDataContractType))
-            {
-                var wrapped = new DataContractEx(dataContract);
-                var dataType = wrapped.UnderlyingType; // Type that DataContract is for
-                Fx.Assert(dataType.IsEnum, "EnumDataContract should only be created for an enum type");
-                var underlyingType = Enum.GetUnderlyingType(dataType); // The underlying integer type backing the Enum
-                var baseContractName = s_typeToName[underlyingType];
-                s_setEnumBaseContractName(dataContract, baseContractName);
-            }
-        }
+        private static readonly Func<object, Type> s_getUnderlyingType = ReflectionHelper.GetPropertyDelegate<Type>(DataContractType, "UnderlyingType");
+        private static readonly Func<object, XmlQualifiedName> s_getStableName = ReflectionHelper.GetPropertyDelegate<XmlQualifiedName>(DataContractType, "StableName");
+        private static readonly Func<object, XmlDictionaryString> s_getTopLevelElementName = ReflectionHelper.GetPropertyDelegate<XmlDictionaryString>(DataContractType, "TopLevelElementName");
+        private static readonly Func<object, XmlDictionaryString> s_getTopLevelElementNamespace = ReflectionHelper.GetPropertyDelegate<XmlDictionaryString>(DataContractType, "TopLevelElementNamespace");
+        private static readonly Func<object, bool> s_getHasRoot = ReflectionHelper.GetPropertyDelegate<bool>(DataContractType, "HasRoot");
+        private static readonly Func<object, bool> s_getIsBuiltInDataContract = ReflectionHelper.GetPropertyDelegate<bool>(DataContractType, "IsBuiltInDataContract");
+        private static readonly Func<object, bool> s_getIsReference = ReflectionHelper.GetPropertyDelegate<bool>(DataContractType, "IsReference");
+        private static readonly Func<object, bool> s_getIsISerializable = ReflectionHelper.GetPropertyDelegate<bool>(DataContractType, "IsISerializable");
+        private static readonly Func<object, bool> s_getIsValueType = ReflectionHelper.GetPropertyDelegate<bool>(DataContractType, "IsValueType");
 
         private static DataContractEx GetDataContractStub(Type clrType)
         {
             var methodInfo = DataContractType.GetMethod("GetDataContract", BindingFlags.Static | BindingFlags.NonPublic, null, new Type[] { typeof(Type) }, null);
             var getDataContractDelegate = ReflectionHelper.CreateStaticMethodCallLambda<Type, object>(methodInfo);
-            Func<Type, DataContractEx> wrappingDelegate = (Type type) => new DataContractEx(getDataContractDelegate(type));
+            Func<Type, DataContractEx> wrappingDelegate = (Type type) => Wrap(getDataContractDelegate(type));
             GetDataContract = wrappingDelegate;
             return GetDataContract(clrType);
+        }
+
+        internal static DataContractEx Wrap(object dataContract)
+        {
+            Fx.Assert(!(dataContract is DataContractEx), "Attempting to wrap a DataContractEx");
+
+            var dataContractType = dataContract.GetType();
+            if (ClassDataContractType.Equals(dataContractType))
+            {
+                return new ClassDataContractEx(dataContract);
+            }
+            else if (CollectionDataContractType.Equals(dataContractType))
+            {
+                return new CollectionDataContractEx(dataContract);
+            }
+            else if (EnumDataContractType.Equals(dataContractType))
+            {
+                return new EnumDataContractEx(dataContract);
+            }
+            else if (PrimitiveDataContractType.IsAssignableFrom(dataContractType))
+            {
+                return new PrimitiveDataContractEx(dataContract);
+            }
+            else if (XmlDataContractType.Equals(dataContractType))
+            {
+                return new XmlDataContractEx(dataContract);
+            }
+            else
+            {
+                Fx.Assert($"Unrecognized data contract type {dataContractType}");
+                return null;
+            }
+        }
+    }
+
+    internal class ClassDataContractEx : DataContractEx
+    {
+        private List<DataMemberEx> _wrappedMembersList;
+        private ClassDataContractEx _baseContract;
+
+        public ClassDataContractEx(object dataContract) : base(dataContract)
+        {
+            Fx.Assert(ClassDataContractType.Equals(dataContract.GetType()), "Only ClassDataContract can be wrapped");
+        }
+
+        public ClassDataContractEx BaseContract
+        {
+            get
+            {
+                if (_baseContract == null)
+                {
+                    var baseContract = s_getBaseContract(WrappedDataContract);
+                    if (baseContract != null)
+                    {
+                        _baseContract = new ClassDataContractEx(baseContract);
+                    }
+                }
+
+                return _baseContract;
+            }
+        }
+
+        private List<DataMemberEx> Members
+        {
+            get
+            {
+                if (_wrappedMembersList == null)
+                {
+                    var dataMembersList = s_getMembers(WrappedDataContract);
+                    _wrappedMembersList = new List<DataMemberEx>(dataMembersList.Count);
+                    foreach(var member in dataMembersList)
+                    {
+                        _wrappedMembersList.Add(new DataMemberEx(member));
+                    }
+                }
+
+                return _wrappedMembersList;
+            }
+        }
+
+        internal override bool Equals(object other, Dictionary<DataContractPairKey, object> checkedContracts)
+        {
+            if (IsEqualOrChecked(other, checkedContracts))
+                return true;
+
+            if (base.Equals(other, checkedContracts))
+            {
+                if (ClassDataContractType.Equals(other?.GetType()))
+                {
+                    ClassDataContractEx dataContract = new ClassDataContractEx(other);
+                    if (IsISerializable)
+                    {
+                        if (!dataContract.IsISerializable)
+                            return false;
+                    }
+                    else
+                    {
+                        if (dataContract.IsISerializable)
+                            return false;
+
+                        if (Members == null)
+                        {
+                            if (dataContract.Members != null)
+                            {
+                                // check that all the datamembers in dataContract.Members are optional
+                                if (!IsEveryDataMemberOptional(dataContract.Members))
+                                    return false;
+                            }
+                        }
+                        else if (dataContract.Members == null)
+                        {
+                            // check that all the datamembers in Members are optional
+                            if (!IsEveryDataMemberOptional(Members))
+                                return false;
+                        }
+                        else
+                        {
+                            Dictionary<string, DataMemberEx> membersDictionary = new Dictionary<string, DataMemberEx>(Members.Count);
+                            List<DataMemberEx> dataContractMembersList = new List<DataMemberEx>();
+                            for (int i = 0; i < Members.Count; i++)
+                            {
+                                membersDictionary.Add(Members[i].Name, Members[i]);
+                            }
+
+                            for (int i = 0; i < dataContract.Members.Count; i++)
+                            {
+                                // check that all datamembers common to both datacontracts match
+                                DataMemberEx dataMember;
+                                if (membersDictionary.TryGetValue(dataContract.Members[i].Name, out dataMember))
+                                {
+                                    if (dataMember.Equals(dataContract.Members[i], checkedContracts))
+                                    {
+                                        membersDictionary.Remove(dataMember.Name);
+                                    }
+                                    else
+                                    {
+                                        return false;
+                                    }
+                                }
+                                // otherwise save the non-matching datamembers for later verification 
+                                else
+                                {
+                                    dataContractMembersList.Add(dataContract.Members[i]);
+                                }
+                            }
+
+                            // check that datamembers left over from either datacontract are optional
+                            if (!IsEveryDataMemberOptional(membersDictionary.Values))
+                                return false;
+                            if (!IsEveryDataMemberOptional(dataContractMembersList))
+                                return false;
+
+                        }
+                    }
+
+                    if (BaseContract == null)
+                        return (dataContract.BaseContract == null);
+                    else if (dataContract.BaseContract == null)
+                        return false;
+                    else
+                        return BaseContract.Equals(dataContract.BaseContract.WrappedDataContract, checkedContracts);
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsEveryDataMemberOptional(IEnumerable<DataMemberEx> dataMembers)
+        {
+            foreach (var dataMember in dataMembers)
+            {
+                if (dataMember.IsRequired)
+                    return false;
+            }
+            return true;
+        }
+
+        private static readonly Func<object, IList> s_getMembers = ReflectionHelper.GetPropertyDelegate<IList>(ClassDataContractType, "Members");
+        private static readonly Func<object, object> s_getBaseContract = ReflectionHelper.GetPropertyDelegate<object>(ClassDataContractType, "BaseContract");
+    }
+
+    internal class CollectionDataContractEx : DataContractEx
+    {
+        private DataContractEx _itemContract;
+
+        public CollectionDataContractEx(object dataContract) : base(dataContract)
+        {
+            Fx.Assert(CollectionDataContractType.Equals(dataContract.GetType()), "Only CollectionDataContract can be wrapped");
+        }
+
+        public DataContractEx ItemContract
+        {
+            get
+            {
+                if (_itemContract == null)
+                {
+                    var itemContract = s_getItemContract(WrappedDataContract);
+                    if (itemContract != null)
+                    {
+                        _itemContract = Wrap(itemContract);
+                    }
+                }
+
+                return _itemContract;
+            }
+        }
+
+        public string ItemName => s_getItemName(WrappedDataContract);
+        public bool IsItemTypeNullable => s_getIsItemTypeNullable(WrappedDataContract);
+
+        internal override bool Equals(object other, Dictionary<DataContractPairKey, object> checkedContracts)
+        {
+            if (IsEqualOrChecked(other, checkedContracts))
+                return true;
+
+            if (base.Equals(other, checkedContracts))
+            {
+                if (CollectionDataContractType.Equals(other?.GetType()))
+                {
+                    CollectionDataContractEx dataContract = new CollectionDataContractEx(other);
+                    bool thisItemTypeIsNullable = (ItemContract == null) ? false : !ItemContract.IsValueType;
+                    bool otherItemTypeIsNullable = (dataContract.ItemContract == null) ? false : !dataContract.ItemContract.IsValueType;
+                    return ItemName == dataContract.ItemName &&
+                        (IsItemTypeNullable || thisItemTypeIsNullable) == (dataContract.IsItemTypeNullable || otherItemTypeIsNullable) &&
+                        ItemContract.Equals(dataContract.ItemContract.WrappedDataContract, checkedContracts);
+                }
+            }
+            return false;
+        }
+
+        private static readonly Func<object, object> s_getItemContract = ReflectionHelper.GetPropertyDelegate<object>(CollectionDataContractType, "ItemContract");
+        private static readonly Func<object, string> s_getItemName = ReflectionHelper.GetPropertyDelegate<string>(CollectionDataContractType, "ItemName");
+        private static readonly Func<object, bool> s_getIsItemTypeNullable = ReflectionHelper.GetPropertyDelegate<bool>(CollectionDataContractType, "IsItemTypeNullable");
+    }
+
+    internal class EnumDataContractEx : DataContractEx
+    {
+        private List<DataMemberEx> _wrappedMembersList;
+
+        public EnumDataContractEx(object dataContract) : base(dataContract)
+        {
+            Fx.Assert(EnumDataContractType.Equals(dataContract.GetType()), "Only EnumDataContract can be wrapped");
+            var dataType = UnderlyingType; // Type that DataContract is for
+            Fx.Assert(dataType.IsEnum, "EnumDataContract should only be created for an enum type");
+            var underlyingType = Enum.GetUnderlyingType(dataType); // The underlying integer type backing the Enum
+            Fx.Assert(s_typeToName.ContainsKey(underlyingType), $"Enum underlying type {underlyingType} is missing from map");
+            BaseContractName = s_typeToName[underlyingType];
+        }
+
+        public XmlQualifiedName BaseContractName
+        {
+            set => s_setBaseContractName(WrappedDataContract, value);
+        }
+
+        public List<DataMemberEx> Members
+        {
+            get
+            {
+                if (_wrappedMembersList == null)
+                {
+                    var dataMembersList = s_getMembers(WrappedDataContract);
+                    _wrappedMembersList = new List<DataMemberEx>(dataMembersList.Count);
+                    foreach (var member in dataMembersList)
+                    {
+                        _wrappedMembersList.Add(new DataMemberEx(member));
+                    }
+                }
+
+                return _wrappedMembersList;
+            }
+        }
+
+        public List<long> Values => s_getValues(WrappedDataContract);
+        public bool IsFlags => s_getIsFlags(WrappedDataContract);
+
+        internal override bool Equals(object other, Dictionary<DataContractPairKey, object> checkedContracts)
+        {
+            if (IsEqualOrChecked(other, checkedContracts))
+                return true;
+
+            if (base.Equals(other, null))
+            {
+                if (EnumDataContractType.Equals(other?.GetType()))
+                {
+                    EnumDataContractEx dataContract = new EnumDataContractEx(other);
+                    if (Members.Count != dataContract.Members.Count || Values.Count != dataContract.Values.Count)
+                        return false;
+                    string[] memberNames1 = new string[Members.Count], memberNames2 = new string[Members.Count];
+                    for (int i = 0; i < Members.Count; i++)
+                    {
+                        memberNames1[i] = Members[i].Name;
+                        memberNames2[i] = dataContract.Members[i].Name;
+                    }
+                    Array.Sort(memberNames1);
+                    Array.Sort(memberNames2);
+                    for (int i = 0; i < Members.Count; i++)
+                    {
+                        if (memberNames1[i] != memberNames2[i])
+                            return false;
+                    }
+
+                    return IsFlags == dataContract.IsFlags;
+                }
+            }
+            return false;
+        }
+
+        private static readonly Func<object, IList> s_getMembers = ReflectionHelper.GetPropertyDelegate<IList>(EnumDataContractType, "Members");
+        private static readonly Func<object, List<long>> s_getValues = ReflectionHelper.GetPropertyDelegate<List<long>>(EnumDataContractType, "Values");
+        private static readonly Func<object, bool> s_getIsFlags = ReflectionHelper.GetPropertyDelegate <bool>(EnumDataContractType, "IsFlags");
+        private static readonly Action<object, XmlQualifiedName> s_setBaseContractName = ReflectionHelper.SetPropertyDelegate<XmlQualifiedName>(EnumDataContractType, "BaseContractName");
+
+        private static readonly Dictionary<Type, XmlQualifiedName> s_typeToName = new Dictionary<Type, XmlQualifiedName>
+        {
+            [typeof(sbyte)] = new XmlQualifiedName("byte", XmlSchema.Namespace),
+            [typeof(byte)] = new XmlQualifiedName("unsignedByte", XmlSchema.Namespace),
+            [typeof(short)] = new XmlQualifiedName("short", XmlSchema.Namespace),
+            [typeof(ushort)] = new XmlQualifiedName("unsignedShort", XmlSchema.Namespace),
+            [typeof(int)] = new XmlQualifiedName("int", XmlSchema.Namespace),
+            [typeof(uint)] = new XmlQualifiedName("unsignedInt", XmlSchema.Namespace),
+            [typeof(long)] = new XmlQualifiedName("long", XmlSchema.Namespace),
+            [typeof(ulong)] = new XmlQualifiedName("unsignedLong", XmlSchema.Namespace)
+        };
+    }
+
+    internal class PrimitiveDataContractEx : DataContractEx
+    {
+        public PrimitiveDataContractEx(object dataContract) : base(dataContract)
+        {
+            Fx.Assert(PrimitiveDataContractType.IsAssignableFrom(dataContract.GetType()), "Only PrimitiveDataContract or derived type can be wrapped");
+        }
+
+        internal override bool Equals(object other, Dictionary<DataContractPairKey, object> checkedContracts)
+        {
+            if (PrimitiveDataContractType.IsAssignableFrom(other?.GetType()))
+            {
+                Type thisType = WrappedDataContract.GetType();
+                Type otherType = other.GetType();
+                return (thisType.Equals(otherType) || thisType.IsSubclassOf(otherType) || otherType.IsSubclassOf(thisType));
+            }
+            return false;
+        }
+    }
+
+    internal class XmlDataContractEx : DataContractEx
+    {
+        public XmlDataContractEx(object dataContract) : base(dataContract)
+        {
+            Fx.Assert(XmlDataContractType.Equals(dataContract.GetType()), "Only XmlDataContract can be wrapped");
+        }
+
+        public bool IsAnonymous => s_getIsAnonymous(WrappedDataContract);
+        public XmlSchemaType XsdType => s_getXsdType(WrappedDataContract);
+
+        internal override bool Equals(object other, Dictionary<DataContractPairKey, object> checkedContracts)
+        {
+            if (IsEqualOrChecked(other, checkedContracts))
+                return true;
+
+            if (XmlDataContractType.Equals(other?.GetType()))
+            {
+                XmlDataContractEx dataContract = new XmlDataContractEx(other);
+                if (HasRoot != dataContract.HasRoot)
+                    return false;
+
+                if (IsAnonymous)
+                {
+                    return dataContract.IsAnonymous;
+                }
+                else
+                {
+                    return StableName.Name == dataContract.StableName.Name && StableName.Namespace == dataContract.StableName.Namespace;
+                }
+            }
+            return false;
+        }
+
+        private static readonly Func<object, bool> s_getIsAnonymous = ReflectionHelper.GetPropertyDelegate<bool>(XmlDataContractType, "IsAnonymous");
+        private static readonly Func<object, XmlSchemaType> s_getXsdType = ReflectionHelper.GetPropertyDelegate<XmlSchemaType>(XmlDataContractType, "XsdType");
+    }
+
+    internal class DataMemberEx
+    {
+        private DataContractEx _memberTypeContract;
+
+        public DataMemberEx(object dataMember)
+        {
+            WrappedDataMember = dataMember ?? throw new ArgumentNullException(nameof(dataMember));
+            Fx.Assert(s_dataMemberType.Equals(dataMember.GetType()), "Only DataMember can be wrapped");
+        }
+
+        private object WrappedDataMember { get; }
+
+        public bool EmitDefaultValue => s_getEmitDefaultValue(WrappedDataMember);
+        public bool IsNullable => s_getIsNullable(WrappedDataMember);
+        public bool IsRequired => s_getIsRequired(WrappedDataMember);
+        public string Name => s_getName(WrappedDataMember);
+
+        public DataContractEx MemberTypeContract
+        {
+            get
+            {
+                if (_memberTypeContract == null)
+                {
+                    var memberTypeContract = s_getMemberTypeContract(WrappedDataMember);
+                    if (memberTypeContract != null)
+                    {
+                        _memberTypeContract = DataContractEx.Wrap(memberTypeContract);
+                    }
+                }
+
+                return _memberTypeContract;
+            }
+        }
+
+        internal bool Equals(object other, Dictionary<DataContractPairKey, object> checkedContracts)
+        {
+            if (this == other)
+                return true;
+
+            DataMemberEx dataMember = other as DataMemberEx;
+            if (dataMember != null)
+            {
+                // Note: comparison does not use Order hint since it influences element order but does not specify exact order
+                bool thisIsNullable = (MemberTypeContract == null) ? false : !MemberTypeContract.IsValueType;
+                bool dataMemberIsNullable = (dataMember.MemberTypeContract == null) ? false : !dataMember.MemberTypeContract.IsValueType;
+                return Name == dataMember.Name
+                       && (IsNullable || thisIsNullable) == (dataMember.IsNullable || dataMemberIsNullable)
+                       && IsRequired == dataMember.IsRequired
+                       && EmitDefaultValue == dataMember.EmitDefaultValue
+                       && MemberTypeContract.Equals(dataMember.MemberTypeContract.WrappedDataContract, checkedContracts);
+            }
+            return false;
+        }
+
+        private static readonly Type s_dataMemberType = typeof(DataContractSerializer).Assembly.GetType("System.Runtime.Serialization.DataMember");
+
+        private static readonly Func<object, bool> s_getEmitDefaultValue = ReflectionHelper.GetPropertyDelegate<bool>(s_dataMemberType, "EmitDefaultValue");
+        private static readonly Func<object, bool> s_getIsRequired = ReflectionHelper.GetPropertyDelegate<bool>(s_dataMemberType, "IsRequired");
+        private static readonly Func<object, bool> s_getIsNullable = ReflectionHelper.GetPropertyDelegate<bool>(s_dataMemberType, "IsNullable");
+        private static readonly Func<object, string> s_getName = ReflectionHelper.GetPropertyDelegate<string>(s_dataMemberType, "Name");
+        private static readonly Func<object, object> s_getMemberTypeContract = ReflectionHelper.GetPropertyDelegate<object>(s_dataMemberType, "MemberTypeContract");
+    }
+
+    internal class DataContractPairKey
+    {
+        private readonly object _object1;
+        private readonly object _object2;
+
+        public DataContractPairKey(object object1, object object2)
+        {
+            _object1 = object1;
+            _object2 = object2;
+        }
+
+        public override bool Equals(object other)
+        {
+            DataContractPairKey otherKey = other as DataContractPairKey;
+            if (otherKey == null)
+                return false;
+            return (otherKey._object1 == _object1 && otherKey._object2 == _object2) || (otherKey._object1 == _object2 && otherKey._object2 == _object1);
+        }
+
+        public override int GetHashCode()
+        {
+            return _object1.GetHashCode() ^ _object2.GetHashCode();
         }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/ReflectionHelper.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/ReflectionHelper.cs
@@ -38,8 +38,7 @@ namespace CoreWCF.Runtime.Serialization
         internal static Func<TParam, TReturn> CreateStaticMethodCallLambda<TParam, TReturn>(MethodInfo methodInfo)
         {
             var paramExpression = Expression.Parameter(typeof(TParam), "param");
-            // Passing null as instance expression as static method call
-            Expression callExpr = Expression.Call(null, methodInfo, paramExpression);
+            Expression callExpr = Expression.Call(methodInfo, paramExpression);
             if (typeof(TReturn) != typeof(object))
             {
                 callExpr = Expression.Convert(callExpr, typeof(TReturn));

--- a/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/XsdDataContractExporterEx.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/XsdDataContractExporterEx.cs
@@ -11,8 +11,8 @@ namespace CoreWCF.Runtime.Serialization
 {
     internal class XsdDataContractExporterEx
     {
-        XmlSchemaSet _schemas;
-        DataContractSetEx _dataContractSet;
+        private XmlSchemaSet _schemas;
+        private DataContractSetEx _dataContractSet;
 
         public XsdDataContractExporterEx()
         {
@@ -23,7 +23,7 @@ namespace CoreWCF.Runtime.Serialization
             _schemas = schemas;
         }
 
-        XmlSchemaSet GetSchemaSet()
+        private XmlSchemaSet GetSchemaSet()
         {
             if (_schemas == null)
             {
@@ -33,7 +33,7 @@ namespace CoreWCF.Runtime.Serialization
             return _schemas;
         }
 
-        DataContractSetEx DataContractSet
+        private DataContractSetEx DataContractSet
         {
             get
             {
@@ -76,7 +76,8 @@ namespace CoreWCF.Runtime.Serialization
             type = GetSurrogatedType(type);
             DataContractEx dataContract = DataContractEx.GetDataContract(type);
             DataContractSetEx.EnsureTypeNotGeneric(dataContract.UnderlyingType);
-            if (dataContract.IsXmlDataContract && dataContract.XmlDataContractIsAnonymous)
+            XmlDataContractEx xmlDataContract = dataContract as XmlDataContractEx;
+            if (xmlDataContract != null && xmlDataContract.IsAnonymous)
                 return XmlQualifiedName.Empty;
             return dataContract.StableName;
         }
@@ -89,8 +90,9 @@ namespace CoreWCF.Runtime.Serialization
             type = GetSurrogatedType(type);
             DataContractEx dataContract = DataContractEx.GetDataContract(type);
             DataContractSetEx.EnsureTypeNotGeneric(dataContract.UnderlyingType);
-            if (dataContract.IsXmlDataContract && dataContract.XmlDataContractIsAnonymous)
-                return dataContract.XmlDataContractXsdType;
+            XmlDataContractEx xmlDataContract = dataContract as XmlDataContractEx;
+            if (xmlDataContract != null && xmlDataContract.IsAnonymous)
+                return xmlDataContract.XsdType;
             return null;
         }
 
@@ -112,7 +114,7 @@ namespace CoreWCF.Runtime.Serialization
             }
         }
 
-        Type GetSurrogatedType(Type type)
+        private Type GetSurrogatedType(Type type)
         {
             //IDataContractSurrogate dataContractSurrogate;
             //if (options != null && (dataContractSurrogate = Options.GetSurrogate()) != null)
@@ -120,12 +122,12 @@ namespace CoreWCF.Runtime.Serialization
             return type;
         }
 
-        void AddType(Type type)
+        private void AddType(Type type)
         {
             DataContractSet.Add(type);
         }
 
-        void Export()
+        private void Export()
         {
             DataContractSet.FixupEnumDataContracts();
             var schemaExporterType = typeof(DataContractSerializer).Assembly.GetType("System.Runtime.Serialization.SchemaExporter");


### PR DESCRIPTION
Worked around issue where equivalent data contracts were failing to add. E.g. `IEnumerable<string>` and `List<string>`
Also worked around issue where adding `Dictionary<K,V>` was adding spurious extra schema `KeyValuePair<K,V>`.