### PR TITLE
Enable GZip and Deflate compression for binary messages over TCP

### DIFF
--- a/src/CoreWCF.Http/tests/ClientContract/IServiceWithMessageBodyAndHeader.cs
+++ b/src/CoreWCF.Http/tests/ClientContract/IServiceWithMessageBodyAndHeader.cs
@@ -23,6 +23,9 @@ namespace ClientContract
 
         [MessageHeader]
         public string APIKey { get; set; }
+
+        [MessageHeaderArray]
+        public string[] HeaderArrayValues { get; set; }
     }
 
 
@@ -34,5 +37,8 @@ namespace ClientContract
 
         [MessageHeader]
         public string SayHi { get; set; }
+
+        [MessageHeaderArray]
+        public string[] HeaderArrayValues { get; set; }
     }
 }

--- a/src/CoreWCF.Http/tests/ServiceWithMessageBodyAndHeaderTest.cs
+++ b/src/CoreWCF.Http/tests/ServiceWithMessageBodyAndHeaderTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.ServiceModel.Channels;
 using System.Text;
 using ClientContract;
@@ -38,9 +39,13 @@ namespace BasicHttp
                     new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/Service.svc")));
                 IServiceWithMessageBodyAndHeader channel = factory.CreateChannel();
 
-
-                CoreEchoMessageResponse result = channel.EchoWithMessageContract(new CoreEchoMessageRequest() { Text = "Message Hello", APIKey = "DEVKEYTOTEST" });
+                var request = new CoreEchoMessageRequest() { Text = "Message Hello", APIKey = "DEVKEYTOTEST", HeaderArrayValues = new[] { "One", "Two", "Three" } };
+                CoreEchoMessageResponse result = channel.EchoWithMessageContract(request);
                 Assert.NotNull(result);
+                Assert.Equal("Saying Hello " + request.Text, result.SayHello);
+                Assert.Equal("Saying Hi " + request.Text, result.SayHi);
+                Assert.Equal(request.HeaderArrayValues.Length, result.HeaderArrayValues.Length);
+                Assert.Equal(request.HeaderArrayValues, result.HeaderArrayValues);
                 ((IChannel)channel).Close();
             }
         }

--- a/src/CoreWCF.Http/tests/Services/ServiceWithMessageBodyAndHeader.cs
+++ b/src/CoreWCF.Http/tests/Services/ServiceWithMessageBodyAndHeader.cs
@@ -20,7 +20,8 @@ namespace Services
             CoreEchoMessageResponse echoMessageResponse = new CoreEchoMessageResponse
             {
                 SayHello = "Saying Hello " + request.Text,
-                SayHi = "Saying Hi " + request.Text
+                SayHi = "Saying Hi " + request.Text,
+                HeaderArrayValues = request.HeaderArrayValues,
             };
             return echoMessageResponse;
         }
@@ -45,6 +46,9 @@ namespace Services
 
         [MessageHeader]
         public string APIKey { get; set; }
+
+        [MessageHeaderArray]
+        public string[] HeaderArrayValues { get; set; }
     }
 
 
@@ -56,5 +60,8 @@ namespace Services
 
         [MessageHeader]
         public string SayHi { get; set; }
+
+        [MessageHeaderArray]
+        public string[] HeaderArrayValues { get; set; }
     }
 }

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingDecoder.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingDecoder.cs
@@ -386,6 +386,14 @@ namespace CoreWCF.Channels.Framing
                     return FramingEncodingString.Binary;
                 case FramingEncodingType.BinarySession:
                     return FramingEncodingString.BinarySession;
+                case FramingEncodingType.ExtendedBinaryGZip:
+                    return FramingEncodingString.ExtendedBinaryGZip;
+                case FramingEncodingType.ExtendedBinarySessionGZip:
+                    return FramingEncodingString.ExtendedBinarySessionGZip;
+                case FramingEncodingType.ExtendedBinaryDeflate:
+                    return FramingEncodingString.ExtendedBinaryDeflate;
+                case FramingEncodingType.ExtendedBinarySessionDeflate:
+                    return FramingEncodingString.ExtendedBinarySessionDeflate;
                 default:
                     return "unknown" + ((int)type).ToString(CultureInfo.InvariantCulture);
             }

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingEncoder.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingEncoder.cs
@@ -130,7 +130,23 @@ namespace CoreWCF.Channels.Framing
 
         public static EncodedContentType Create(string contentType)
         {
-            if (contentType == FramingEncodingString.BinarySession)
+            if (contentType == FramingEncodingString.ExtendedBinarySessionDeflate)
+            {
+                return new EncodedContentType(FramingEncodingType.ExtendedBinarySessionDeflate);
+            }
+            else if (contentType == FramingEncodingString.ExtendedBinaryDeflate)
+            {
+                return new EncodedContentType(FramingEncodingType.ExtendedBinaryDeflate);
+            }
+            else if (contentType == FramingEncodingString.ExtendedBinarySessionGZip)
+            {
+                return new EncodedContentType(FramingEncodingType.ExtendedBinarySessionGZip);
+            }
+            else if (contentType == FramingEncodingString.ExtendedBinaryGZip)
+            {
+                return new EncodedContentType(FramingEncodingType.ExtendedBinaryGZip);
+            }
+            else if(contentType == FramingEncodingString.BinarySession)
             {
                 return new EncodedContentType(FramingEncodingType.BinarySession);
             }

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingFormat.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingFormat.cs
@@ -119,6 +119,10 @@ namespace CoreWCF.Channels.Framing
         MTOM = 0x6,
         Binary = 0x7,
         BinarySession = 0x8,
+        ExtendedBinaryGZip = 0x9,
+        ExtendedBinarySessionGZip = 0xA,
+        ExtendedBinaryDeflate = 0xB,
+        ExtendedBinarySessionDeflate = 0xC
     }
 
     internal static class FramingEncodingString

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/NetMessageFramingConnectionHandler.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/NetMessageFramingConnectionHandler.cs
@@ -90,7 +90,7 @@ namespace CoreWCF.Channels.Framing
                     }
 
                     IServiceDispatcher _serviceDispatcher = null;
-                    var _customBinding = new CustomBinding(dispatcher.Binding);
+                    var _customBinding = dispatcher.Binding as CustomBinding ?? new CustomBinding(dispatcher.Binding);
                     if (_customBinding.Elements.Find<ConnectionOrientedTransportBindingElement>() != null)
                     {
                         var parameters = new BindingParameterCollection();
@@ -99,7 +99,7 @@ namespace CoreWCF.Channels.Framing
                             _serviceDispatcher = _customBinding.BuildServiceDispatcher<IDuplexSessionChannel>(parameters, dispatcher);
                         }
                     }
-                    _serviceDispatcher = _serviceDispatcher ?? dispatcher;
+                    _serviceDispatcher ??= dispatcher;
                     HandshakeDelegate handshake = BuildHandshakeDelegateForDispatcher(_serviceDispatcher);
 
                     logger.LogDebug($"Registering URI {dispatcher.BaseAddress} with NetMessageFramingConnectionHandler");

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/TcpTransportBindingElement.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/TcpTransportBindingElement.cs
@@ -97,11 +97,10 @@ namespace CoreWCF.Channels
             {
                 return (T)(object)ExtendedProtectionPolicy;
             }
-            // TODO: Support ITransportCompressionSupport
-            //else if (typeof(T) == typeof(ITransportCompressionSupport))
-            //{
-            //    return (T)(object)new TransportCompressionSupportHelper();
-            //}
+            else if (typeof(T) == typeof(ITransportCompressionSupport))
+            {
+                return (T)(object)new TransportCompressionSupportHelper();
+            }
             else if (typeof(T) == typeof(IConnectionReuseHandler))
             {
                 return (T)(object)new ConnectionReuseHandler(new TcpTransportBindingElement(this));

--- a/src/CoreWCF.NetTcp/tests/CompressionFormatTests.cs
+++ b/src/CoreWCF.NetTcp/tests/CompressionFormatTests.cs
@@ -1,0 +1,132 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using CoreWCF.Channels;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.NetTcp.Tests
+{
+    public class CompressionFormatTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public CompressionFormatTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestVariations))]
+        public void CompressionFormatTest(
+            MessageVersion messageVersion,
+            System.ServiceModel.Channels.MessageVersion clientMessageVersion,
+            CompressionFormat compressionFormat,
+            System.ServiceModel.Channels.CompressionFormat clientCompressionFormat,
+            TransferMode transferMode,
+            System.ServiceModel.TransferMode clientTransferMode)
+        {
+            string testString = new string('a', 8000);
+            var webHostBuilder = ServiceHelper.CreateWebHostBuilder<Tests.Startup>(_output);
+            webHostBuilder.ConfigureServices(services => services.AddServiceModelServices());
+            webHostBuilder.Configure(app =>
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.TestService>();
+                    builder.AddServiceEndpoint<Services.TestService, ServiceContract.ITestService>(GetServerBinding(messageVersion, compressionFormat, transferMode), "/MessageVersionTest.svc");
+                });
+            });
+            var host = webHostBuilder.Build();
+            using (host)
+            {
+                host.Start();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(GetClientBinding(clientMessageVersion, clientCompressionFormat, clientTransferMode),
+                    new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + "/MessageVersionTest.svc"));
+                ClientContract.ITestService channel = factory.CreateChannel();
+                var result = channel.EchoString(testString);
+                Assert.Equal(testString, result);
+                ((System.ServiceModel.IClientChannel)channel).Close();
+            }
+        }
+
+        public static IEnumerable<object[]> GetTestVariations()
+        {
+            foreach (CompressionFormat compression in Enum.GetValues(typeof(CompressionFormat)))
+            {
+                foreach (TransferMode transferMode in Enum.GetValues(typeof(TransferMode)))
+                {
+                    yield return new object[]
+                    {
+                        MessageVersion.Soap12WSAddressing10,
+                        System.ServiceModel.Channels.MessageVersion.CreateVersion(System.ServiceModel.EnvelopeVersion.Soap12, System.ServiceModel.Channels.AddressingVersion.WSAddressing10),
+                        compression,
+                        (System.ServiceModel.Channels.CompressionFormat)compression,
+                        transferMode,
+                        (System.ServiceModel.TransferMode)transferMode
+                    };
+                    yield return new object[]
+                    {
+                        MessageVersion.Soap12WSAddressingAugust2004,
+                        System.ServiceModel.Channels.MessageVersion.Soap12WSAddressingAugust2004,
+                        compression,
+                        (System.ServiceModel.Channels.CompressionFormat)compression,
+                        transferMode,
+                        (System.ServiceModel.TransferMode)transferMode
+                    };
+                }
+            }
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app) { }
+        }
+
+        internal static Binding GetServerBinding(
+            MessageVersion messageVersion,
+            CompressionFormat compressionFormat,
+            TransferMode transferMode)
+        {
+            var netTcpBinding = new NetTcpBinding();
+            netTcpBinding.Security.Mode = SecurityMode.None;
+            netTcpBinding.TransferMode = transferMode;
+
+            var customBinding = new CustomBinding(netTcpBinding);
+            var binaryEncoding = customBinding.Elements.Find<BinaryMessageEncodingBindingElement>();
+            binaryEncoding.MessageVersion = messageVersion;
+            binaryEncoding.CompressionFormat = compressionFormat;
+
+            return customBinding;
+        }
+
+        internal static System.ServiceModel.Channels.Binding GetClientBinding(
+            System.ServiceModel.Channels.MessageVersion clientMessageVersion,
+            System.ServiceModel.Channels.CompressionFormat compressionFormat,
+            System.ServiceModel.TransferMode transferMode)
+        {
+            var netTcpBinding = new System.ServiceModel.NetTcpBinding();
+            netTcpBinding.Security.Mode = System.ServiceModel.SecurityMode.None;
+            netTcpBinding.TransferMode = transferMode;
+
+            var customBinding = new System.ServiceModel.Channels.CustomBinding(netTcpBinding);
+            var binaryEncoding = customBinding.Elements.Find<System.ServiceModel.Channels.BinaryMessageEncodingBindingElement>();
+            binaryEncoding.MessageVersion = clientMessageVersion;
+            binaryEncoding.CompressionFormat = compressionFormat;
+
+            return customBinding;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/ITransportCompressionSupport.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/ITransportCompressionSupport.cs
@@ -3,7 +3,7 @@
 
 namespace CoreWCF.Channels
 {
-    internal interface ITransportCompressionSupport
+    public interface ITransportCompressionSupport
     {
         bool IsCompressionFormatSupported(CompressionFormat compressionFormat);
     }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/TransportCompressionSupportHelper.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/TransportCompressionSupportHelper.cs
@@ -3,7 +3,7 @@
 
 namespace CoreWCF.Channels
 {
-    internal class TransportCompressionSupportHelper : ITransportCompressionSupport
+    public class TransportCompressionSupportHelper : ITransportCompressionSupport
     {
         public bool IsCompressionFormatSupported(CompressionFormat compressionFormat)
         {

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/FaultDescriptionCollection.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/FaultDescriptionCollection.cs
@@ -1,10 +1,35 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.ObjectModel;
+
 namespace CoreWCF.Description
 {
-    public class FaultDescriptionCollection : System.Collections.ObjectModel.Collection<FaultDescription>
+    public class FaultDescriptionCollection : Collection<FaultDescription>
     {
         internal FaultDescriptionCollection() { }
+
+        public FaultDescription Find(string action)
+        {
+            foreach (FaultDescription description in this)
+            {
+                if (description != null && action == description.Action)
+                    return description;
+            }
+
+            return null;
+        }
+
+        public Collection<FaultDescription> FindAll(string action)
+        {
+            Collection<FaultDescription> descriptions = new Collection<FaultDescription>();
+            foreach (FaultDescription description in this)
+            {
+                if (description != null && action == description.Action)
+                    descriptions.Add(description);
+            }
+
+            return descriptions;
+        }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageContractHelper.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageContractHelper.cs
@@ -23,21 +23,23 @@ namespace CoreWCF.Description
             return false;
         }
 
+        private static HashSet<string> s_eligibleMessageList = new HashSet<string>()
+            {
+                ServiceReflector.CWCFMessageHeaderAttribute,
+                ServiceReflector.CWCFMessageHeaderArrayAttribute,
+                ServiceReflector.CWCFMessageBodyMemberAttribute,
+                ServiceReflector.CWCFMessagePropertyAttribute,
+                ServiceReflector.SMMessageHeaderAttributeFullName,
+                ServiceReflector.SMMessageHeaderArrayAttributeFullName,
+                ServiceReflector.SMMessageBodyMemberAttributeFullName,
+                ServiceReflector.SMMessagePropertyAttributeFullName
+            };
+
         internal static bool IsEligibleMember(MemberInfo memberInfo)
         {
-            HashSet<string> eligibleMessageList = new HashSet<string>()
-            {
-                 ServiceReflector.CWCFMesssageHeaderAttribute
-                , ServiceReflector.CWCFMesssageHeaderArrayAttribute
-                ,ServiceReflector.CWCFMesssageBodyMemberAttribute
-                ,ServiceReflector.CWCFMesssagePropertyAttribute
-                ,ServiceReflector.SMMessageBodyMemberAttributeFullName
-                , ServiceReflector.SMMessageContractAttributeFullName
-                ,ServiceReflector.SMMessageHeaderAttributeFullName
-            };
             foreach (Attribute attr in memberInfo.GetCustomAttributes())
             {
-                if (eligibleMessageList.Contains(attr.GetType().FullName))
+                if (s_eligibleMessageList.Contains(attr.GetType().FullName))
                 {
                     return true;
                 }
@@ -52,6 +54,7 @@ namespace CoreWCF.Description
                 if ((attr.GetType() == typeof(MessageHeaderAttribute))
                     || (attr.GetType() == typeof(MessageHeaderArrayAttribute))
                     || (string.Compare(attr.GetType().FullName, ServiceReflector.SMMessageHeaderAttributeFullName, true) == 0)
+                    || (string.Compare(attr.GetType().FullName, ServiceReflector.SMMessageHeaderArrayAttributeFullName, true) == 0)
                     )
                 {
                     return true;

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageDescription.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageDescription.cs
@@ -42,7 +42,6 @@ namespace CoreWCF.Description
             }
             MessageName = other.MessageName;
             MessageType = other.MessageType;
-
         }
 
         public MessageDescription Clone()

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageDescriptionCollection.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageDescriptionCollection.cs
@@ -1,12 +1,35 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.ObjectModel;
+
 namespace CoreWCF.Description
 {
-    public class MessageDescriptionCollection : System.Collections.ObjectModel.Collection<MessageDescription>
+    public class MessageDescriptionCollection : Collection<MessageDescription>
     {
         internal MessageDescriptionCollection() { }
-        public MessageDescription Find(string action) { return default; }
-        public System.Collections.ObjectModel.Collection<MessageDescription> FindAll(string action) { return default; }
+
+        public MessageDescription Find(string action)
+        {
+            foreach (MessageDescription description in this)
+            {
+                if (description != null && action == description.Action)
+                    return description;
+            }
+
+            return null;
+        }
+
+        public Collection<MessageDescription> FindAll(string action)
+        {
+            Collection<MessageDescription> descriptions = new Collection<MessageDescription>();
+            foreach (MessageDescription description in this)
+            {
+                if (description != null && action == description.Action)
+                    descriptions.Add(description);
+            }
+
+            return descriptions;
+        }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageHeaderDescriptionCollection.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageHeaderDescriptionCollection.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Xml;
+
 namespace CoreWCF.Description
 {
-    public class MessageHeaderDescriptionCollection : System.Collections.ObjectModel.KeyedCollection<System.Xml.XmlQualifiedName, MessageHeaderDescription>
+    public class MessageHeaderDescriptionCollection : System.Collections.ObjectModel.KeyedCollection<XmlQualifiedName, MessageHeaderDescription>
     {
         internal MessageHeaderDescriptionCollection() { }
-        protected override System.Xml.XmlQualifiedName GetKeyForItem(MessageHeaderDescription item) { return default; }
+        protected override XmlQualifiedName GetKeyForItem(MessageHeaderDescription item) => new XmlQualifiedName(item.Name, item.Namespace);
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MessagePartDescriptionCollection.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MessagePartDescriptionCollection.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Xml;
+
 namespace CoreWCF.Description
 {
-    public class MessagePartDescriptionCollection : System.Collections.ObjectModel.KeyedCollection<System.Xml.XmlQualifiedName, MessagePartDescription>
+    public class MessagePartDescriptionCollection : System.Collections.ObjectModel.KeyedCollection<XmlQualifiedName, MessagePartDescription>
     {
         internal MessagePartDescriptionCollection() { }
-        protected override System.Xml.XmlQualifiedName GetKeyForItem(MessagePartDescription item) { return default; }
+        protected override XmlQualifiedName GetKeyForItem(MessagePartDescription item) => new XmlQualifiedName(item.Name, item.Namespace);
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MessagePropertyAttribute.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MessagePropertyAttribute.cs
@@ -5,9 +5,8 @@ using System;
 
 namespace CoreWCF.Description
 {
-    // TODO: Make public and add to contract
     [AttributeUsage(CoreWCFAttributeTargets.MessageMember, Inherited = false)]
-    internal sealed class MessagePropertyAttribute : Attribute
+    public sealed class MessagePropertyAttribute : Attribute
     {
         private string _name;
 
@@ -27,6 +26,7 @@ namespace CoreWCF.Description
                 _name = value;
             }
         }
+
         internal bool IsNameSetExplicit { get; private set; }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MessagePropertyDescription.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MessagePropertyDescription.cs
@@ -5,6 +5,13 @@ namespace CoreWCF.Description
 {
     public class MessagePropertyDescription : MessagePartDescription
     {
-        public MessagePropertyDescription(string name) : base(default, default) { }
+        public MessagePropertyDescription(string name) : base(name, "") { }
+
+        internal MessagePropertyDescription(MessagePropertyDescription other) : base(other) { }
+
+        public override MessagePartDescription Clone()
+        {
+            return new MessagePropertyDescription(this);
+        }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MessagePropertyDescriptionCollection.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MessagePropertyDescriptionCollection.cs
@@ -6,6 +6,6 @@ namespace CoreWCF.Description
     public class MessagePropertyDescriptionCollection : System.Collections.ObjectModel.KeyedCollection<string, MessagePropertyDescription>
     {
         internal MessagePropertyDescriptionCollection() { }
-        protected override string GetKeyForItem(MessagePropertyDescription item) { return default; }
+        protected override string GetKeyForItem(MessagePropertyDescription item) => item.Name;
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/PolicyAssertionCollection.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/PolicyAssertionCollection.cs
@@ -9,9 +9,7 @@ namespace CoreWCF.Description
 {
     public class PolicyAssertionCollection : Collection<XmlElement>
     {
-        public PolicyAssertionCollection()
-        {
-        }
+        public PolicyAssertionCollection() { }
 
         public PolicyAssertionCollection(IEnumerable<XmlElement> elements)
         {
@@ -65,7 +63,7 @@ namespace CoreWCF.Description
             return Find(localName, namespaceUri, true);
         }
 
-        XmlElement Find(string localName, string namespaceUri, bool remove)
+        private XmlElement Find(string localName, string namespaceUri, bool remove)
         {
             if (localName == null)
             {
@@ -103,7 +101,7 @@ namespace CoreWCF.Description
             return FindAll(localName, namespaceUri, true);
         }
 
-        Collection<XmlElement> FindAll(string localName, string namespaceUri, bool remove)
+        private Collection<XmlElement> FindAll(string localName, string namespaceUri, bool remove)
         {
             if (localName == null)
             {

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceReflector.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceReflector.cs
@@ -365,8 +365,8 @@ namespace CoreWCF.Description
         internal const BindingFlags ServiceModelBindingFlags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance;
         internal const string BeginMethodNamePrefix = "Begin";
         internal const string EndMethodNamePrefix = "End";
-        internal static readonly Type VoidType = typeof(void);
         internal const string AsyncMethodNameSuffix = "Async";
+        internal static readonly Type VoidType = typeof(void);
         internal static readonly Type taskType = typeof(Task);
         internal static readonly Type taskTResultType = typeof(Task<>);
         internal static readonly Type CancellationTokenType = typeof(CancellationToken);
@@ -379,6 +379,7 @@ namespace CoreWCF.Description
         internal const string SMOperationContractAttributeFullName = "System.ServiceModel.OperationContractAttribute";
         internal const string SMMessageContractAttributeFullName = "System.ServiceModel.MessageContractAttribute";
         internal const string SMMessageHeaderAttributeFullName = "System.ServiceModel.MessageHeaderAttribute";
+        internal const string SMMessageHeaderArrayAttributeFullName = "System.ServiceModel.MessageHeaderArrayAttribute";
         internal const string SMMessagePropertyAttributeFullName = "System.ServiceModel.MessagePropertyAttribute";
         internal const string SMMessageBodyMemberAttributeFullName = "System.ServiceModel.MessageBodyMemberAttribute";
         internal const string SMMessageParameterAttributeFullName = "System.ServiceModel.MessageParameterAttribute";
@@ -386,11 +387,10 @@ namespace CoreWCF.Description
         internal const string SMFaultContractAttributeFullName = "System.ServiceModel.FaultContractAttribute";
         internal const string SMServiceKnownTypeAttributeFullName = "System.ServiceModel.ServiceKnownTypeAttribute";
 
-        internal static readonly string CWCFMesssageHeaderAttribute = "CoreWCF.MessageHeaderAttribute";
-        internal static readonly string CWCFMesssageHeaderArrayAttribute = "CoreWCF.MessageHeaderArrayAttribute";
-        internal static readonly string CWCFMesssageBodyMemberAttribute = "CoreWCF.MessageBodyMemberAttribute";
-        internal static readonly string CWCFMesssagePropertyAttribute = "CoreWCF.MessagePropertyAttribute";
-        internal static readonly string CWCFMesssageContractAttribute = "CoreWCF.MessageContractAttribute";
+        internal const string CWCFMessageHeaderAttribute = "CoreWCF.MessageHeaderAttribute";
+        internal const string CWCFMessageHeaderArrayAttribute = "CoreWCF.MessageHeaderArrayAttribute";
+        internal const string CWCFMessageBodyMemberAttribute = "CoreWCF.MessageBodyMemberAttribute";
+        internal const string CWCFMessagePropertyAttribute = "CoreWCF.MessagePropertyAttribute";
 
         internal static Type GetOperationContractProviderType(MethodInfo method)
         {

--- a/src/CoreWCF.Primitives/src/CoreWCF/MessageHeaderArrayAttribute.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/MessageHeaderArrayAttribute.cs
@@ -6,7 +6,7 @@ using System;
 namespace CoreWCF
 {
     [AttributeUsage(CoreWCFAttributeTargets.MessageMember, AllowMultiple = false, Inherited = false)]
-    internal sealed class MessageHeaderArrayAttribute : MessageHeaderAttribute
+    public sealed class MessageHeaderArrayAttribute : MessageHeaderAttribute
     {
     }
 }

--- a/src/CoreWCF.Primitives/tests/MessagePropertyAttributeTests.cs
+++ b/src/CoreWCF.Primitives/tests/MessagePropertyAttributeTests.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using CoreWCF;
+using CoreWCF.Channels;
+using CoreWCF.Description;
+using CoreWCF.Dispatcher;
+using Extensibility;
+using Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Primitives.Tests
+{
+    public class MessagePropertyAttributeTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public MessagePropertyAttributeTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void ValidateMessagePropertyPopulated()
+        {
+            var inspector = new PropertyCheckingDispatchMessageInspector(SimpleResponse.PropertyName);
+            var behavior = new TestServiceBehavior { DispatchMessageInspector = inspector };
+            System.ServiceModel.ChannelFactory<IMessagePropertyService> factory = ExtensibilityHelper.CreateChannelFactory<MessagePropertyService, IMessagePropertyService>(behavior);
+            factory.Open();
+            IMessagePropertyService channel = factory.CreateChannel();
+            var testString = Guid.NewGuid().ToString();
+            var response = channel.Request(new SimpleRequest { stringParam = testString });
+            Assert.Equal(testString, response.stringParam);
+            Assert.Null(response.stringProperty);
+            Assert.NotNull(inspector.MessagePropertyValue);
+            Assert.IsType<string>(inspector.MessagePropertyValue);
+            Assert.Equal(testString, inspector.MessagePropertyValue as string);
+            ((System.ServiceModel.Channels.IChannel)channel).Close();
+            factory.Close();
+            TestHelper.CloseServiceModelObjects((System.ServiceModel.Channels.IChannel)channel, factory);
+        }
+
+        public class MessagePropertyService : IMessagePropertyService
+        {
+            public SimpleResponse Request(SimpleRequest request)
+            {
+                return new SimpleResponse
+                {
+                    stringParam = request.stringParam,
+                    stringProperty = request.stringParam
+                };
+            }
+        }
+
+        [System.ServiceModel.ServiceContract]
+        internal interface IMessagePropertyService
+        {
+            [System.ServiceModel.OperationContract]
+            SimpleResponse Request(SimpleRequest request);
+        }
+
+        [System.ServiceModel.MessageContract(WrapperName = "MPRequest", WrapperNamespace = "http://tempuri.org")]
+        public class SimpleRequest
+        {
+            [System.ServiceModel.MessageBodyMember]
+            public string stringParam;
+        }
+
+        [System.ServiceModel.MessageContract(WrapperName = "MPResponse", WrapperNamespace = "http://tempuri.org")]
+        public class SimpleResponse
+        {
+            public const string PropertyName = "MPMessageProperty";
+            [System.ServiceModel.MessageBodyMember]
+            public string stringParam;
+            [System.ServiceModel.MessageProperty(Name = PropertyName)]
+            public string stringProperty;
+        }
+
+        internal class PropertyCheckingDispatchMessageInspector : IDispatchMessageInspector
+        {
+            private string _propertyName;
+
+            public PropertyCheckingDispatchMessageInspector(string propertyName)
+            {
+                _propertyName = propertyName;
+            }
+
+            public object MessagePropertyValue { get; private set; }
+
+            public object AfterReceiveRequest(ref Message request, IClientChannel channel, InstanceContext instanceContext)
+            {
+                return null;
+            }
+
+            public void BeforeSendReply(ref Message reply, object correlationState)
+            {
+                if (reply.Properties.ContainsKey(_propertyName))
+                {
+                    MessagePropertyValue = reply.Properties[_propertyName];
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
Closes: #595 

This PR allows server bindings to be configured for GZip and Deflate compression formats for binary messages over TCP.

---

### Testing
* Unit tests show end-to-end communication works as expected
* Manual inspection of network activity showed the messages sent in the unit tests were in fact compressed:
Uncompressed message: `new string('a', 10000)  // string of length 10,000`

Compression | Message size
--- | --- 
Uncompressed | 10198 bytes
GZip |  233 bytes
Deflate | 216 bytes

---

### Concerns/Follow-up questions:
* ~This PR only enables recognition of GZip and Deflate compression formats if the content type is `application/soap+msbinsession1`. It was the only content type I was able to figure out how to test so the content type of `application/soap+msbin1` was left out. Are there any concerns leaving this content type unsupported? If so, what is the best way to test this case?~

