### PR TITLE
Enable compression over NetTcp

### DIFF
--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingDecoder.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingDecoder.cs
@@ -386,6 +386,14 @@ namespace CoreWCF.Channels.Framing
                     return FramingEncodingString.Binary;
                 case FramingEncodingType.BinarySession:
                     return FramingEncodingString.BinarySession;
+                case FramingEncodingType.ExtendedBinaryGZip:
+                    return FramingEncodingString.ExtendedBinaryGZip;
+                case FramingEncodingType.ExtendedBinarySessionGZip:
+                    return FramingEncodingString.ExtendedBinarySessionGZip;
+                case FramingEncodingType.ExtendedBinaryDeflate:
+                    return FramingEncodingString.ExtendedBinaryDeflate;
+                case FramingEncodingType.ExtendedBinarySessionDeflate:
+                    return FramingEncodingString.ExtendedBinarySessionDeflate;
                 default:
                     return "unknown" + ((int)type).ToString(CultureInfo.InvariantCulture);
             }

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingEncoder.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingEncoder.cs
@@ -130,7 +130,23 @@ namespace CoreWCF.Channels.Framing
 
         public static EncodedContentType Create(string contentType)
         {
-            if (contentType == FramingEncodingString.BinarySession)
+            if (contentType == FramingEncodingString.ExtendedBinarySessionDeflate)
+            {
+                return new EncodedContentType(FramingEncodingType.ExtendedBinarySessionDeflate);
+            }
+            else if (contentType == FramingEncodingString.ExtendedBinaryDeflate)
+            {
+                return new EncodedContentType(FramingEncodingType.ExtendedBinaryDeflate);
+            }
+            else if (contentType == FramingEncodingString.ExtendedBinarySessionGZip)
+            {
+                return new EncodedContentType(FramingEncodingType.ExtendedBinarySessionGZip);
+            }
+            else if (contentType == FramingEncodingString.ExtendedBinaryGZip)
+            {
+                return new EncodedContentType(FramingEncodingType.ExtendedBinaryGZip);
+            }
+            else if(contentType == FramingEncodingString.BinarySession)
             {
                 return new EncodedContentType(FramingEncodingType.BinarySession);
             }

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingFormat.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingFormat.cs
@@ -119,6 +119,10 @@ namespace CoreWCF.Channels.Framing
         MTOM = 0x6,
         Binary = 0x7,
         BinarySession = 0x8,
+        ExtendedBinaryGZip = 0x9,
+        ExtendedBinarySessionGZip = 0xA,
+        ExtendedBinaryDeflate = 0xB,
+        ExtendedBinarySessionDeflate = 0xC
     }
 
     internal static class FramingEncodingString

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/NetMessageFramingConnectionHandler.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/NetMessageFramingConnectionHandler.cs
@@ -90,7 +90,7 @@ namespace CoreWCF.Channels.Framing
                     }
 
                     IServiceDispatcher _serviceDispatcher = null;
-                    var _customBinding = new CustomBinding(dispatcher.Binding);
+                    var _customBinding = dispatcher.Binding as CustomBinding ?? new CustomBinding(dispatcher.Binding);
                     if (_customBinding.Elements.Find<ConnectionOrientedTransportBindingElement>() != null)
                     {
                         var parameters = new BindingParameterCollection();
@@ -99,7 +99,7 @@ namespace CoreWCF.Channels.Framing
                             _serviceDispatcher = _customBinding.BuildServiceDispatcher<IDuplexSessionChannel>(parameters, dispatcher);
                         }
                     }
-                    _serviceDispatcher = _serviceDispatcher ?? dispatcher;
+                    _serviceDispatcher ??= dispatcher;
                     HandshakeDelegate handshake = BuildHandshakeDelegateForDispatcher(_serviceDispatcher);
 
                     logger.LogDebug($"Registering URI {dispatcher.BaseAddress} with NetMessageFramingConnectionHandler");

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/TcpTransportBindingElement.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/TcpTransportBindingElement.cs
@@ -97,11 +97,10 @@ namespace CoreWCF.Channels
             {
                 return (T)(object)ExtendedProtectionPolicy;
             }
-            // TODO: Support ITransportCompressionSupport
-            //else if (typeof(T) == typeof(ITransportCompressionSupport))
-            //{
-            //    return (T)(object)new TransportCompressionSupportHelper();
-            //}
+            else if (typeof(T) == typeof(ITransportCompressionSupport))
+            {
+                return (T)(object)new TransportCompressionSupportHelper();
+            }
             else if (typeof(T) == typeof(IConnectionReuseHandler))
             {
                 return (T)(object)new ConnectionReuseHandler(new TcpTransportBindingElement(this));

--- a/src/CoreWCF.NetTcp/tests/CompressionFormatTests.cs
+++ b/src/CoreWCF.NetTcp/tests/CompressionFormatTests.cs
@@ -1,0 +1,134 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using CoreWCF.Channels;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.NetTcp.Tests
+{
+    public class CompressionFormatTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public CompressionFormatTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestVariations))]
+        public void CompressionFormatTest(
+            MessageVersion messageVersion,
+            System.ServiceModel.Channels.MessageVersion clientMessageVersion,
+            CompressionFormat compressionFormat,
+            System.ServiceModel.Channels.CompressionFormat clientCompressionFormat,
+            TransferMode transferMode,
+            System.ServiceModel.TransferMode clientTransferMode)
+        {
+            string testString = new string('a', 8000);
+            var webHostBuilder = ServiceHelper.CreateWebHostBuilder<Tests.Startup>(_output);
+            webHostBuilder.ConfigureServices(services => services.AddServiceModelServices());
+            webHostBuilder.Configure(app =>
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.TestService>();
+                    builder.AddServiceEndpoint<Services.TestService, ServiceContract.ITestService>(GetServerBinding(messageVersion, compressionFormat, transferMode), "/MessageVersionTest.svc");
+                });
+            });
+            var host = webHostBuilder.Build();
+            using (host)
+            {
+                host.Start();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(GetClientBinding(clientMessageVersion, clientCompressionFormat, clientTransferMode),
+                    new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + "/MessageVersionTest.svc"));
+                ClientContract.ITestService channel = factory.CreateChannel();
+                var result = channel.EchoString(testString);
+                Assert.Equal(testString, result);
+                ((System.ServiceModel.IClientChannel)channel).Close();
+            }
+        }
+
+        public static IEnumerable<object[]> GetTestVariations()
+        {
+            foreach (CompressionFormat compression in Enum.GetValues(typeof(CompressionFormat)))
+            {
+                foreach (TransferMode transferMode in Enum.GetValues(typeof(TransferMode)))
+                {
+                    yield return new object[]
+                    {
+                        MessageVersion.Soap12WSAddressing10,
+                        System.ServiceModel.Channels.MessageVersion.CreateVersion(System.ServiceModel.EnvelopeVersion.Soap12, System.ServiceModel.Channels.AddressingVersion.WSAddressing10),
+                        compression,
+                        (System.ServiceModel.Channels.CompressionFormat)compression,
+                        transferMode,
+                        (System.ServiceModel.TransferMode)transferMode
+                    };
+                    yield return new object[]
+                    {
+                        MessageVersion.Soap12WSAddressingAugust2004,
+                        System.ServiceModel.Channels.MessageVersion.Soap12WSAddressingAugust2004,
+                        compression,
+                        (System.ServiceModel.Channels.CompressionFormat)compression,
+                        transferMode,
+                        (System.ServiceModel.TransferMode)transferMode
+                    };
+                }
+            }
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app) { }
+        }
+
+        internal static Binding GetServerBinding(
+            MessageVersion messageVersion,
+            CompressionFormat compressionFormat,
+            TransferMode transferMode)
+        {
+            var netTcpBinding = new NetTcpBinding();
+            netTcpBinding.Security.Mode = SecurityMode.None;
+            netTcpBinding.TransferMode = transferMode;
+
+            var customBinding = new CustomBinding(netTcpBinding);
+            var binaryEncoding = customBinding.Elements.Find<BinaryMessageEncodingBindingElement>();
+            binaryEncoding.CompressionFormat = CompressionFormat.GZip;
+            binaryEncoding.MessageVersion = messageVersion;
+            binaryEncoding.CompressionFormat = compressionFormat;
+
+            return customBinding;
+        }
+
+        internal static System.ServiceModel.Channels.Binding GetClientBinding(
+            System.ServiceModel.Channels.MessageVersion clientMessageVersion,
+            System.ServiceModel.Channels.CompressionFormat compressionFormat,
+            System.ServiceModel.TransferMode transferMode)
+        {
+            var netTcpBinding = new System.ServiceModel.NetTcpBinding();
+            netTcpBinding.Security.Mode = System.ServiceModel.SecurityMode.None;
+            netTcpBinding.TransferMode = transferMode;
+
+            var customBinding = new System.ServiceModel.Channels.CustomBinding(netTcpBinding);
+            var binaryEncoding = customBinding.Elements.Find<System.ServiceModel.Channels.BinaryMessageEncodingBindingElement>();
+            binaryEncoding.CompressionFormat = System.ServiceModel.Channels.CompressionFormat.GZip;
+            binaryEncoding.MessageVersion = clientMessageVersion;
+            binaryEncoding.CompressionFormat = compressionFormat;
+
+            return customBinding;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/ITransportCompressionSupport.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/ITransportCompressionSupport.cs
@@ -3,7 +3,7 @@
 
 namespace CoreWCF.Channels
 {
-    internal interface ITransportCompressionSupport
+    public interface ITransportCompressionSupport
     {
         bool IsCompressionFormatSupported(CompressionFormat compressionFormat);
     }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/TransportCompressionSupportHelper.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/TransportCompressionSupportHelper.cs
@@ -3,7 +3,7 @@
 
 namespace CoreWCF.Channels
 {
-    internal class TransportCompressionSupportHelper : ITransportCompressionSupport
+    public class TransportCompressionSupportHelper : ITransportCompressionSupport
     {
         public bool IsCompressionFormatSupported(CompressionFormat compressionFormat)
         {


### PR DESCRIPTION
Duplicate of #622 but with proper rebase and squashing.

Original PR description below:

---

### Description
Closes: #595 

This PR allows server bindings to be configured for GZip and Deflate compression formats for binary messages over TCP.

---

### Testing
* Unit tests show end-to-end communication works as expected
* Manual inspection of network activity showed the messages sent in the unit tests were in fact compressed:
Uncompressed message: `new string('a', 10000)  // string of length 10,000`

Compression | Message size
--- | --- 
Uncompressed | 10198 bytes
GZip |  233 bytes
Deflate | 216 bytes

---

### Concerns/Follow-up questions:
* ~This PR only enables recognition of GZip and Deflate compression formats if the content type is `application/soap+msbinsession1`. It was the only content type I was able to figure out how to test so the content type of `application/soap+msbin1` was left out. Are there any concerns leaving this content type unsupported? If so, what is the best way to test this case?~


