### PR TITLE
Add support for custom tokens and credentials by exposing internal methods

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceCredentials.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceCredentials.cs
@@ -109,7 +109,7 @@ namespace CoreWCF.Description
             return new ServiceCredentials();
         }
 
-        internal override SecurityTokenManager CreateSecurityTokenManager()
+        public override SecurityTokenManager CreateSecurityTokenManager()
         {
             if (UseIdentityConfiguration)
             {

--- a/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Selectors/SecurityTokenManager.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Selectors/SecurityTokenManager.cs
@@ -6,7 +6,7 @@ namespace CoreWCF.IdentityModel.Selectors
     public abstract class SecurityTokenManager
     {
         public abstract SecurityTokenProvider CreateSecurityTokenProvider(SecurityTokenRequirement tokenRequirement);
-        internal abstract SecurityTokenSerializer CreateSecurityTokenSerializer(SecurityTokenVersion version);
+        public abstract SecurityTokenSerializer CreateSecurityTokenSerializer(SecurityTokenVersion version);
         public abstract SecurityTokenAuthenticator CreateSecurityTokenAuthenticator(SecurityTokenRequirement tokenRequirement, out SecurityTokenResolver outOfBandTokenResolver);
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/FederatedSecurityTokenManager.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/FederatedSecurityTokenManager.cs
@@ -319,7 +319,7 @@ namespace CoreWCF.Security
         /// <param name="version">SecurityTokenVersion of the serializer to be created.</param>
         /// <returns>Instance of SecurityTokenSerializer.</returns>
         /// <exception cref="ArgumentNullException">Input parameter is null.</exception>
-        internal override SecurityTokenSerializer CreateSecurityTokenSerializer(SecurityTokenVersion version)
+        public override SecurityTokenSerializer CreateSecurityTokenSerializer(SecurityTokenVersion version)
         {
             if (version == null)
             {

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/SecurityCredentialsManager.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/SecurityCredentialsManager.cs
@@ -10,6 +10,6 @@ namespace CoreWCF.Security
         protected SecurityCredentialsManager() { }
 
         // TODO: Resolve solution to SecurityTokenManager which lives in System.IdentityModel.Selectors not existing on .Net standard
-        internal abstract SecurityTokenManager CreateSecurityTokenManager();
+        public abstract SecurityTokenManager CreateSecurityTokenManager();
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/SecuritySessionSecurityTokenAuthenticator.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/SecuritySessionSecurityTokenAuthenticator.cs
@@ -1286,7 +1286,7 @@ namespace CoreWCF.Security
                 return _innerTokenManager.CreateSecurityTokenProvider(requirement);
             }
 
-            internal override SecurityTokenSerializer CreateSecurityTokenSerializer(SecurityTokenVersion version)
+            public override SecurityTokenSerializer CreateSecurityTokenSerializer(SecurityTokenVersion version)
             {
                 return _innerTokenManager.CreateSecurityTokenSerializer(version);
             }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/ServiceCredentialsSecurityTokenManager.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/ServiceCredentialsSecurityTokenManager.cs
@@ -24,7 +24,7 @@ namespace CoreWCF.Security
 
         public ServiceCredentials ServiceCredentials { get; }
 
-        internal override SecurityTokenSerializer CreateSecurityTokenSerializer(SecurityTokenVersion version)
+        public override SecurityTokenSerializer CreateSecurityTokenSerializer(SecurityTokenVersion version)
         {
             if (version == null)
             {


### PR DESCRIPTION
Add support for custom tokens and credentials by exposing internal methods
 - Change ServiceCredentials.CreateSecurityTokenManager from internal to public to allow custom credential types
 - Change SecurityTokenManager.CreateSecurityTokenSerializer from internal to public to allow custom serializers.
 - Adjust derived classes to match.

No functionality changes in this PR. 

#621 

