### PR TITLE
Reduce the number of scenarios where AllowSynchronousIO is needed

### DIFF
--- a/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs
@@ -252,6 +252,8 @@ namespace CoreWCF.Channels
             }
         }
 
+        protected abstract Task CheckForContentAsync();
+
         // makes sure that appropriate HTTP level headers are included in the received Message
         private Exception ProcessHttpAddressing(Message message)
         {
@@ -387,6 +389,7 @@ namespace CoreWCF.Channels
             bool throwing = true;
             try
             {
+                await CheckForContentAsync();
                 ValidateContentType();
 
                 Message message;

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/HttpRequestContext.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/HttpRequestContext.cs
@@ -415,18 +415,22 @@ namespace CoreWCF.Channels
             {
                 private readonly AspNetCoreHttpContext _aspNetCoreHttpContext;
                 private string _cachedContentType; // accessing the header in System.Net involves a native transition
-                private readonly byte[] _preReadBuffer;
+                private byte[] _preReadBuffer;
 
                 // TODO: ChannelBindingSupport
                 public AspNetCoreHttpInput(AspNetCoreHttpContext aspNetCoreHttpContext)
                     : base(aspNetCoreHttpContext.HttpTransportSettings, true, false /* ChannelBindingSupportEnabled */)
                 {
                     _aspNetCoreHttpContext = aspNetCoreHttpContext;
+                }
+
+                protected override async Task CheckForContentAsync()
+                {
                     if (!_aspNetCoreHttpContext._aspNetContext.Request.ContentLength.HasValue)
                     {
-                        // TODO: Look into useing PipeReader with look-ahead
                         _preReadBuffer = new byte[1];
-                        if (_aspNetCoreHttpContext._aspNetContext.Request.Body.Read(_preReadBuffer, 0, 1) == 0)
+                        // TODO: Look into useing PipeReader with look-ahead
+                        if (await _aspNetCoreHttpContext._aspNetContext.Request.Body.ReadAsync(_preReadBuffer, 0, 1) == 0)
                         {
                             _preReadBuffer = null;
                         }

--- a/src/CoreWCF.Http/tests/Helpers/IntegrationTest.cs
+++ b/src/CoreWCF.Http/tests/Helpers/IntegrationTest.cs
@@ -29,9 +29,6 @@ namespace CoreWCF.Http.Tests.Helpers
             features.Set<IServerAddressesFeature>(addresses); 
 
             var server = new TestServer(builder, features);
-#if NETCOREAPP3_1
-            server.AllowSynchronousIO = true;
-#endif
             return server;
         }
 

--- a/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.Http/tests/Helpers/ServiceHelper.cs
@@ -100,7 +100,6 @@ namespace Helpers
             {
                 options.Authentication.Schemes = Microsoft.AspNetCore.Server.HttpSys.AuthenticationSchemes.None;
                 options.Authentication.AllowAnonymous = true;
-                options.AllowSynchronousIO = true;
                 options.UrlPrefixes.Add("http://+:80/Temporary_Listen_Addresses/CoreWCFTestServices");
                 options.UrlPrefixes.Add("http://+:80/Temporary_Listen_Addresses/CoreWCFTestServices/MorePath");
             })
@@ -120,7 +119,6 @@ namespace Helpers
 #endif // DEBUG
             .UseKestrel(options =>
             {
-                    options.AllowSynchronousIO = true;
                     options.Listen(IPAddress.Loopback, 8080, listenOptions =>
                     {
                         if (Debugger.IsAttached)
@@ -144,7 +142,6 @@ namespace Helpers
 #endif // DEBUG
             .UseKestrel(options =>
             {
-                options.AllowSynchronousIO = true;
                 options.Listen(IPAddress.Loopback, 8080, listenOptions =>
                 {
                     if (Debugger.IsAttached)

--- a/src/CoreWCF.Http/tests/RequestReplyTests.cs
+++ b/src/CoreWCF.Http/tests/RequestReplyTests.cs
@@ -8,6 +8,7 @@ using CoreWCF.Configuration;
 using Helpers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Services;
 using Xunit;
@@ -31,7 +32,16 @@ namespace CoreWCF.Http.Tests
         public void RequestReplyStreaming(string binding)
         {
             Startup.binding = binding;
-            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            var hostBuilder = ServiceHelper.CreateWebHostBuilder<Startup>(_output);
+            hostBuilder.ConfigureServices(services =>
+            {
+                services.Configure<KestrelServerOptions>(options =>
+                {
+                    options.AllowSynchronousIO = true;
+                });
+            });
+
+            IWebHost host = hostBuilder.Build();
             using (host)
             {
                 host.Start();

--- a/src/CoreWCF.Metadata/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/ServiceHelper.cs
@@ -145,38 +145,35 @@ namespace Helpers
 #endif // DEBUG
             host.UseKestrel(options =>
             {
-                options.AllowSynchronousIO = true;
+                // Always listen on http
+                options.ListenLocalhost(HttpListenPort, listenOptions =>
                 {
-                    // Always listen on http
-                    options.ListenLocalhost(HttpListenPort, listenOptions =>
+                    if (Debugger.IsAttached)
                     {
+                        listenOptions.UseConnectionLogging();
+                    }
+                });
+                // Optionally listen on https port
+                bool useHttps = schemesCollection.Contains(Uri.UriSchemeHttps);
+                if (useHttps)
+                {
+                    options.ListenLocalhost(HttpsListenPort, listenOptions =>
+                    {
+                        if (useHttps)
+                        {
+                            listenOptions.UseHttps(httpsOptions =>
+                            {
+#if NET472
+                                    httpsOptions.SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
+#endif // NET472
+                                });
+                        }
+
                         if (Debugger.IsAttached)
                         {
                             listenOptions.UseConnectionLogging();
                         }
                     });
-                    // Optionally listen on https port
-                    bool useHttps = schemesCollection.Contains(Uri.UriSchemeHttps);
-                    if (useHttps)
-                    {
-                        options.ListenLocalhost(HttpsListenPort, listenOptions =>
-                        {
-                            if (useHttps)
-                            {
-                                listenOptions.UseHttps(httpsOptions =>
-                                {
-#if NET472
-                                    httpsOptions.SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
-#endif // NET472
-                                });
-                            }
-
-                            if (Debugger.IsAttached)
-                            {
-                                listenOptions.UseConnectionLogging();
-                            }
-                        });
-                    }
                 }
             });
 

--- a/src/CoreWCF.WebHttp/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.WebHttp/tests/Helpers/ServiceHelper.cs
@@ -27,7 +27,6 @@ namespace Helpers
 #endif // DEBUG
             .UseKestrel(options =>
             {
-                options.AllowSynchronousIO = true;
                 options.Listen(IPAddress.Loopback, 8080, listenOptions =>
                 {
                     if (Debugger.IsAttached)
@@ -36,7 +35,7 @@ namespace Helpers
                     }
                 });
             })
-    .UseStartup<TStartup>();
+            .UseStartup<TStartup>();
 
         public static IWebHostBuilder CreateWebHostBuilderWithSsl<TStartup>(ITestOutputHelper outputHelper = default) where TStartup : class =>
     WebHost.CreateDefaultBuilder(Array.Empty<string>())
@@ -52,7 +51,6 @@ namespace Helpers
 #endif // DEBUG
             .UseKestrel(options =>
             {
-                options.AllowSynchronousIO = true;
                 options.Listen(IPAddress.Loopback, 8080, listenOptions =>
                 {
                     if (Debugger.IsAttached)
@@ -70,6 +68,6 @@ namespace Helpers
                     }
                 });
             })
-.UseStartup<TStartup>();
+            .UseStartup<TStartup>();
     }
 }


### PR DESCRIPTION
After this change, the only time synchronous IO should be needed is if you are using streamed transfer mode.