### PR TITLE
Fix WSDL for multiple services

### DIFF
--- a/src/CoreWCF.Metadata/tests/Helpers/TestHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/TestHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using CoreWCF.Channels;
@@ -24,10 +25,10 @@ namespace CoreWCF.Metadata.Tests.Helpers
                 EndpointRelativePath,
                 output)
                 .Build();
-            string wsdlAddress = "http://localhost:8080/endpointAddress.svc";
+            string wsdlAddress = "http://localhost:8080" + EndpointRelativePath;
             if ("https".Equals(binding.Scheme, StringComparison.OrdinalIgnoreCase))
             {
-                wsdlAddress = "https://localhost:8443/endpointAddress.svc";
+                wsdlAddress = "https://localhost:8443" + EndpointRelativePath;
             }
             using (host)
             {
@@ -36,6 +37,37 @@ namespace CoreWCF.Metadata.Tests.Helpers
                 await WsdlHelper.ValidateSingleWsdl(wsdlAddress, endpointAddress, callerMethodName, sourceFilePath);
             }
         }
+
+        internal static async Task RunMultipleWsdlTestAsync<TService1, TService2, TContract1, TContract2>(Binding binding1, Binding binding2, ITestOutputHelper output,
+        [System.Runtime.CompilerServices.CallerMemberName] string callerMethodName = "",
+        [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "") where TService1 : class  where TService2 : class
+        {
+            IWebHost host = ServiceHelper.CreateHttpWebHostBuilderWithMetadata<TService1, TService2, TContract1, TContract2>(
+                binding1,
+                binding2,
+                EndpointRelativePath,
+                output)
+                .Build();
+            string wsdl1Address = "http://localhost:8080/1" + EndpointRelativePath;
+            if ("https".Equals(binding1.Scheme, StringComparison.OrdinalIgnoreCase))
+            {
+                wsdl1Address = "https://localhost:8443/1" + EndpointRelativePath;
+            }
+            string wsdl2Address = "http://localhost:8080/2" + EndpointRelativePath;
+            if ("https".Equals(binding1.Scheme, StringComparison.OrdinalIgnoreCase))
+            {
+                wsdl2Address = "https://localhost:8443/2" + EndpointRelativePath;
+            }
+            using (host)
+            {
+                await host.StartAsync();
+                var endpoint1Address = $"{ServiceHelper.GetEndpointBaseAddress(host, binding1)}/1{EndpointRelativePath}/{binding1.Scheme}";
+                var endpoint2Address = $"{ServiceHelper.GetEndpointBaseAddress(host, binding2)}/2{EndpointRelativePath}/{binding2.Scheme}";
+                await WsdlHelper.ValidateSingleWsdl(wsdl1Address, endpoint1Address, callerMethodName + "_1", sourceFilePath);
+                await WsdlHelper.ValidateSingleWsdl(wsdl2Address, endpoint2Address, callerMethodName + "_2", sourceFilePath);
+            }
+        }
+
 
         internal static async Task RunSingleWsdlTestAsync<TService, TContract>(IDictionary<string, Binding> bindingEndpointMap, Uri[] baseAddresses, ITestOutputHelper output,
                 [System.Runtime.CompilerServices.CallerMemberName] string callerMethodName = "",

--- a/src/CoreWCF.Metadata/tests/MultipleServicesTest.cs
+++ b/src/CoreWCF.Metadata/tests/MultipleServicesTest.cs
@@ -10,11 +10,11 @@ using Xunit.Abstractions;
 
 namespace CoreWCF.Metadata.Tests
 {
-    public class BasicHttpSimpleServiceTest
+    public class MultipleServicesTest
     {
         private readonly ITestOutputHelper _output;
 
-        public BasicHttpSimpleServiceTest(ITestOutputHelper output)
+        public MultipleServicesTest(ITestOutputHelper output)
         {
             _output = output;
         }
@@ -22,7 +22,8 @@ namespace CoreWCF.Metadata.Tests
         [Fact]
         public async Task BasicHttpRequestReplyEchoString()
         {
-            await TestHelper.RunSingleWsdlTestAsync<SimpleEchoService, IEchoService>(new BasicHttpBinding(), _output);
+            await TestHelper.RunMultipleWsdlTestAsync<SimpleEchoService, CollectionsService, IEchoService, ICollectionsService>(
+                new BasicHttpBinding(), new BasicHttpBinding(), _output);
         }
     }
 }

--- a/src/CoreWCF.Metadata/tests/Wsdls/MultipleServicesTest.BasicHttpRequestReplyEchoString_1.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/MultipleServicesTest.BasicHttpRequestReplyEchoString_1.xml
@@ -1,0 +1,229 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SimpleEchoService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q1:StreamBody" xmlns:q1="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamResult" type="q2:StreamBody" xmlns:q2="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringAsyncResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q3:StreamBody" xmlns:q3="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamAsyncResult" type="q4:StreamBody" xmlns:q4="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoToFailResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/Message" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString" message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse" message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream" message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse" message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync" message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse" message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync" message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse" message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail" message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse" message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_IEchoService" type="tns:IEchoService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="BasicHttpBinding_IEchoService" binding="tns:BasicHttpBinding_IEchoService">
+      <soap:address location="http://localhost/TestService/1/http"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/MultipleServicesTest.BasicHttpRequestReplyEchoString_2.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/MultipleServicesTest.BasicHttpRequestReplyEchoString_2.xml
@@ -1,0 +1,250 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="CollectionsService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+      <xs:element name="EchoStringList">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q1:ArrayOfstring" xmlns:q1="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringListResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringListResult" nillable="true" type="q2:ArrayOfstring" xmlns:q2="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringEnumerable">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q3:ArrayOfstring" xmlns:q3="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringEnumerableResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringEnumerableResult" nillable="true" type="q4:ArrayOfstring" xmlns:q4="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringArray">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q5:ArrayOfstring" xmlns:q5="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringArrayResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringArrayResult" nillable="true" type="q6:ArrayOfstring" xmlns:q6="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDictionary">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q7:ArrayOfKeyValueOfstringstring" xmlns:q7="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDictionaryResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoDictionaryResult" nillable="true" type="q8:ArrayOfKeyValueOfstringstring" xmlns:q8="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoIDictionary">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q9:ArrayOfKeyValueOfstringstring" xmlns:q9="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoIDictionaryResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoIDictionaryResult" nillable="true" type="q10:ArrayOfKeyValueOfstringstring" xmlns:q10="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+      <xs:complexType name="ArrayOfstring">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="string" nillable="true" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfstring" nillable="true" type="tns:ArrayOfstring"/>
+      <xs:complexType name="ArrayOfKeyValueOfstringstring">
+        <xs:annotation>
+          <xs:appinfo>
+            <IsDictionary xmlns="http://schemas.microsoft.com/2003/10/Serialization/">true</IsDictionary>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="KeyValueOfstringstring">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="Key" nillable="true" type="xs:string"/>
+                <xs:element name="Value" nillable="true" type="xs:string"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfKeyValueOfstringstring" nillable="true" type="tns:ArrayOfKeyValueOfstringstring"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="CollectionsService_EchoStringList_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringList"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringList_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringListResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringEnumerable_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringEnumerable"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringEnumerable_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringEnumerableResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringArray_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringArray"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringArray_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringArrayResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoDictionary_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDictionary"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoDictionary_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDictionaryResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoIDictionary_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoIDictionary"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoIDictionary_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoIDictionaryResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="CollectionsService">
+    <wsdl:operation name="EchoStringList">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringList" message="tns:CollectionsService_EchoStringList_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringListResponse" message="tns:CollectionsService_EchoStringList_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringEnumerable">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringEnumerable" message="tns:CollectionsService_EchoStringEnumerable_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringEnumerableResponse" message="tns:CollectionsService_EchoStringEnumerable_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringArray">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringArray" message="tns:CollectionsService_EchoStringArray_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringArrayResponse" message="tns:CollectionsService_EchoStringArray_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDictionary">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoDictionary" message="tns:CollectionsService_EchoDictionary_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoDictionaryResponse" message="tns:CollectionsService_EchoDictionary_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoIDictionary">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoIDictionary" message="tns:CollectionsService_EchoIDictionary_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoIDictionaryResponse" message="tns:CollectionsService_EchoIDictionary_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_CollectionsService" type="tns:CollectionsService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoStringList">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringList" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringEnumerable">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringEnumerable" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringArray">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringArray" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDictionary">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoDictionary" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoIDictionary">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoIDictionary" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="CollectionsService">
+    <wsdl:port name="BasicHttpBinding_CollectionsService" binding="tns:BasicHttpBinding_CollectionsService">
+      <soap:address location="http://localhost/TestService/2/http"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceMetadataBehavior.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceMetadataBehavior.cs
@@ -368,6 +368,12 @@ namespace CoreWCF.Description
 
                         if (exporter is WsdlExporter wsdlExporter)
                         {
+                            // Fix issue with shared exporter. Need to do comparison of Type objects as "is" will return true if it's a derived type
+                            if (exporter.GetType() == typeof(WsdlExporter))
+                            {
+                                exporter = wsdlExporter = wsdlExporter.Clone();
+                            }
+
                             // Pass the BindingParameterCollection into the ExportEndpoints method so that the binding parameters can be using to export WSDL correctly.
                             // The binding parameters are used in BuildChannelListener, during which they can modify the configuration of the channel in ways that might have to
                             // be communicated in the WSDL. For example, in the case of Multi-Auth, the AuthenticationSchemesBindingParameter is used during BuildChannelListener

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/WsdlExporter.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/WsdlExporter.cs
@@ -22,9 +22,35 @@ namespace CoreWCF.Description
         internal const string DefaultServiceName = "service";
         private static XmlDocument s_xmlDocument;
         private bool _isFaulted = false;
-        private readonly Dictionary<ContractDescription, WsdlContractConversionContext> _exportedContracts = new Dictionary<ContractDescription, WsdlContractConversionContext>();
-        private readonly Dictionary<BindingDictionaryKey, WsdlEndpointConversionContext> _exportedBindings = new Dictionary<BindingDictionaryKey, WsdlEndpointConversionContext>();
-        private readonly Dictionary<EndpointDictionaryKey, ServiceEndpoint> _exportedEndpoints = new Dictionary<EndpointDictionaryKey, ServiceEndpoint>();
+        private Dictionary<ContractDescription, WsdlContractConversionContext> _exportedContracts = new Dictionary<ContractDescription, WsdlContractConversionContext>();
+        private Dictionary<BindingDictionaryKey, WsdlEndpointConversionContext> _exportedBindings = new Dictionary<BindingDictionaryKey, WsdlEndpointConversionContext>();
+        private Dictionary<EndpointDictionaryKey, ServiceEndpoint> _exportedEndpoints = new Dictionary<EndpointDictionaryKey, ServiceEndpoint>();
+
+        internal WsdlExporter Clone()
+        {
+            WsdlExporter exporter = new WsdlExporter();
+
+            if (_exportedContracts.Count > 0)
+                exporter._exportedContracts = new Dictionary<ContractDescription, WsdlContractConversionContext>(_exportedContracts);
+
+            if (_exportedBindings.Count > 0)
+                exporter._exportedBindings = new Dictionary<BindingDictionaryKey, WsdlEndpointConversionContext>(_exportedBindings);
+
+            if (_exportedEndpoints.Count > 0)
+                exporter._exportedEndpoints = new Dictionary<EndpointDictionaryKey, ServiceEndpoint>(_exportedEndpoints);
+
+            exporter._isFaulted = _isFaulted;
+
+            // Base class clone
+            exporter.PolicyVersion = PolicyVersion;
+            foreach (var error in Errors)
+                exporter.Errors.Add(error);
+
+            foreach(var stateItem in State)
+                exporter.State.Add(stateItem.Key, stateItem.Value);
+
+            return exporter;
+        }
 
         public override void ExportContract(ContractDescription contract)
         {


### PR DESCRIPTION
Fixes #653 
Fixes #645 

The problem is caused by a single common ServiceMetadataBehavior in DI. The ServiceMetadataBehavior provides the MetadataExporter instance as a Singleton. This means multiple services will end up using the same MetadataExporter instance. If you have two services, ServiceA and Service B, after you fetch the WSDL for ServiceA, the MetadataExporter will be populated for ServiceA. Then when you fetch the WSDL for ServiceB, the MetadataExporter will contain metadata for both services. There's also a risk of concurrent modification if the two wsdl's are retrieved at the same time.  

This change clones the MetadataExporter returned from the ServiceMetadataBehavior. Cloning is needed as someone could add some metadata to the instance in the behavior before starting the service. The cloning maintains any potential changes that were made.  