### PR TITLE
Fix startup race condition which can cause service startup failure

### DIFF
--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingModeHandshakeMiddleware.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/FramingModeHandshakeMiddleware.cs
@@ -4,7 +4,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using CoreWCF.Configuration;
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace CoreWCF.Channels.Framing
 {

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/ServerSessionConnectionReaderMiddleware.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/ServerSessionConnectionReaderMiddleware.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using CoreWCF.Configuration;
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CoreWCF.Channels.Framing

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/ServerFramingDuplexSessionChannel.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/ServerFramingDuplexSessionChannel.cs
@@ -10,9 +10,8 @@ using System.Xml;
 using CoreWCF.Channels.Framing;
 using CoreWCF.Runtime;
 using CoreWCF.Security;
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace CoreWCF.Channels
 {

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilder.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CoreWCF.Channels;
 using CoreWCF.Description;
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CoreWCF.Configuration

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilder.cs
@@ -30,6 +30,7 @@ namespace CoreWCF.Configuration
                     _ = OpenAsync();
                 }
             });
+            Opened += OpenedCallback;
         }
 
         public ICollection<IServiceConfiguration> ServiceConfigurations => _services.Values;
@@ -222,10 +223,15 @@ namespace CoreWCF.Configuration
             return Task.CompletedTask;
         }
 
-        protected override Task OnOpenAsync(CancellationToken token)
+        protected override Task OnOpenAsync(CancellationToken token) => Task.CompletedTask;
+
+        private void OpenedCallback(object sender, EventArgs e)
         {
+            // Using a callback to complete the TCS means the state will have transitioned to Opened before completing the TCS
+            // which means if another thread is waiting on this TCS, ServiceBuilder is in the expected state when it continues.
+            // This callback needs to run before any other event handlers as they can (and the HTTP middleware indirectly does) depend on
+            // the TCS being completed before they run.
             _openingCompletedTcs.TrySetResult(null);
-            return Task.CompletedTask;
         }
 
         protected override void OnFaulted()

--- a/src/CoreWCF.Primitives/tests/Helpers/TestHelper.cs
+++ b/src/CoreWCF.Primitives/tests/Helpers/TestHelper.cs
@@ -212,7 +212,7 @@ namespace Helpers
                 provider.GetRequiredService<Microsoft.Extensions.Hosting.IHostApplicationLifetime>() as Microsoft.Extensions.Hosting.IApplicationLifetime);
 #pragma warning restore CS0618 // Type or member is obsolete
 #else
-            services.AddSingleton<Microsoft.AspNetCore.Hosting.IApplicationLifetime, Microsoft.AspNetCore.Hosting.Internal.ApplicationLifetime>();
+            services.AddSingleton<Microsoft.Extensions.Hosting.IApplicationLifetime, Microsoft.AspNetCore.Hosting.Internal.ApplicationLifetime>();
 #endif
 
         }


### PR DESCRIPTION
When ServiceBuilder.OpenAsync was called, it would complete a TaskCompletionSource before the state moved to Opened. ServiceHostObjectModel calls a method on ServiceBuilder waiting on the Task from TaskCompletionSource which would complete when ServiceBuilder was in the Opening state. It then called ThrowIfDisposedOrNotOpen. Usually it had transitioned to the Opened state, but sometimes it was still in the Opening state causing an exception to be thrown and the service to not start.

This now includes a second fix to switch from using `Microsoft.AspNetCore.Hosting.IApplicationLifetime` to `Microsoft.Extensions.Hosting..IApplicationLifetime`. They are equivalent and do the same thing, but the ApplicationInsights Azure extensions incorrectly hijacks the first type and prevents our initialization code from executing fully, blocking startup when hosted in Azure.