### PR TITLE
Test pipeline to problem installed ssl certs for Http.SYS tests

### DIFF
--- a/templates/TestStage.yml
+++ b/templates/TestStage.yml
@@ -71,6 +71,10 @@ stages:
         installationPath: $(Agent.ToolsDirectory)/dotnet
       condition: not(eq(variables.additionalDotNetCoreSdk, ''))
 
+    - pwsh: |
+        . "$env:windir\system32\netsh" http show sslcert
+      displayName: Get Bound SSL Certificates
+
     - task: DotNetCoreCLI@2
       displayName: Restore packages
       inputs:


### PR DESCRIPTION
This is not intended to be merged. I've added an extra pipeline step to the test stage to try and discover what SSL certs are bound. We're expecting as IIS Express is installed that the IIS Express test certificate is installed and bound to ports 44300 to 44399. This PR is intended to help diagnose PR failures in #647.