### PR TITLE
Do not close WebSocket twice

### DIFF
--- a/src/CoreWCF.Http/src/CoreWCF/Channels/WebSocketTransportDuplexSessionChannel.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/WebSocketTransportDuplexSessionChannel.cs
@@ -278,6 +278,9 @@ namespace CoreWCF.Channels
         {
             try
             {
+                if (WebSocket.State == WebSocketState.Closed || WebSocket.State == WebSocketState.Aborted)
+                    return Task.CompletedTask;
+
                 return WebSocket.CloseAsync(_webSocketCloseDetails.OutputCloseStatus, _webSocketCloseDetails.OutputCloseStatusDescription, token);
             }
             catch (Exception e)


### PR DESCRIPTION
When a WebSocketTransportDuplexSessionChannel gets closed, it will always throw an exception because the underlaying WebSocket gets closed twice.
Fixes #708