### PR TITLE
Fix HttpSys HTTPS tests running in Azure DevOps

### DIFF
--- a/src/CoreWCF.Http/tests/SimpleWSHTTPTest.cs
+++ b/src/CoreWCF.Http/tests/SimpleWSHTTPTest.cs
@@ -230,8 +230,8 @@ namespace WSHttp
         }
 #endif
 
-        [Fact(Skip="Temporarily failing in Azure Devops due to corrupted IIS Express dev certificate in test environment image."),
-            Description("transport-security-with-windows-authentication-httpsys")]
+        [Fact]
+        [Description("transport-security-with-windows-authentication-httpsys")]
         [Trait("Category", "WindowsOnly")]  // HttpSys not supported on Linux
 #if NET5_0_OR_GREATER
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
@@ -284,8 +284,8 @@ namespace WSHttp
             }
         }
 
-        [Fact(Skip = "Failing in Azure Devops due to corrupted IIS Express dev certificate"),
-            Description("no-security-with-an-anonymous-client-using-impersonation-httpsys")]
+        [Fact]
+        [Description("no-security-with-an-anonymous-client-using-impersonation-httpsys")]
         [Trait("Category", "WindowsOnly")]  // HttpSys not supported on Linux
 #if NET5_0_OR_GREATER
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]


### PR DESCRIPTION
I discovered an undocumented command in IisExpressAdminCmd which resets the certificate and bindings for the IIS dev certificate. Adding it to the pipeline and reenabling the tests.