### PR TITLE
Set max buffer pool size based on TransportBindingElement setting

### DIFF
--- a/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
@@ -119,27 +119,29 @@ namespace CoreWCF.Channels
                 throw new InvalidOperationException("Channel Dispatcher can't be null");
             }
 
-            var requestContext = HttpRequestContext.CreateContext(_httpSettings, context);
-            await requestContext.ProcessAuthenticationAsync();
-            
-            HttpInput httpInput = requestContext.GetHttpInput(true);
-            (Message requestMessage, Exception requestException) = await httpInput.ParseIncomingMessageAsync();
-            if ((requestMessage == null) && (requestException == null))
+            using (var requestContext = HttpRequestContext.CreateContext(_httpSettings, context))
             {
-                throw Fx.Exception.AsError(
+                await requestContext.ProcessAuthenticationAsync();
+
+                HttpInput httpInput = requestContext.GetHttpInput(true);
+                (Message requestMessage, Exception requestException) = await httpInput.ParseIncomingMessageAsync();
+                if ((requestMessage == null) && (requestException == null))
+                {
+                    throw Fx.Exception.AsError(
                         new ProtocolException(
                             SR.MessageXmlProtocolError,
                             new XmlException(SR.MessageIsEmpty)));
-            }
+                }
 
-            requestContext.SetMessage(requestMessage, requestException);
-            if (requestMessage != null)
-            {
-                requestMessage.Properties.Add("Microsoft.AspNetCore.Http.HttpContext", context);
-            }
+                requestContext.SetMessage(requestMessage, requestException);
+                if (requestMessage != null)
+                {
+                    requestMessage.Properties.Add("Microsoft.AspNetCore.Http.HttpContext", context);
+                }
 
-            await ChannelDispatcher.DispatchAsync(requestContext);
-            await requestContext.ReplySent;
+                await ChannelDispatcher.DispatchAsync(requestContext);
+                await requestContext.ReplySent;
+            }
         }
     }
 }

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/RequestDelegateHandler.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/RequestDelegateHandler.cs
@@ -56,7 +56,7 @@ namespace CoreWCF.Channels
 
             var httpSettings = new HttpTransportSettings
             {
-                BufferManager = BufferManager.CreateBufferManager(DefaultMaxBufferPoolSize, tbe.MaxBufferSize),
+                BufferManager = BufferManager.CreateBufferManager(tbe.MaxBufferPoolSize, tbe.MaxBufferSize),
                 OpenTimeout = _serviceDispatcher.Binding.OpenTimeout,
                 ReceiveTimeout = _serviceDispatcher.Binding.ReceiveTimeout,
                 SendTimeout = _serviceDispatcher.Binding.SendTimeout,


### PR DESCRIPTION
Currently, the max buffer pool size is set to a default value of 512 KB. This causes the the buffer pool to become full prematurely when processing numerous large messages, resulting in excess memory allocations.

This change sets the max buffer pool based on the TransportBindingElement setting rather than a static, default value.