### PR TITLE
Implement IOThreadScheduler fix seen in WCF client

### DIFF
--- a/src/Common/src/CoreWCF/Runtime/ServiceModelSynchronizationContext.cs
+++ b/src/Common/src/CoreWCF/Runtime/ServiceModelSynchronizationContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace CoreWCF.Runtime
 {
@@ -11,8 +12,7 @@ namespace CoreWCF.Runtime
 
         public override void Post(SendOrPostCallback d, object state)
         {
-            IOThreadScheduler.ScheduleCallbackNoFlow(
-                (s) => { d(s); }, state);
+            Task.Factory.StartNew((s) => d(s), state, default, TaskCreationOptions.RunContinuationsAsynchronously, IOThreadScheduler.IOTaskScheduler);
         }
     }
 }

--- a/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
+++ b/src/Common/src/CoreWCF/Runtime/TaskHelpers.cs
@@ -194,6 +194,9 @@ namespace CoreWCF.Runtime
         // then use the NoSpin variant.
         public static void WaitForCompletion(this Task task)
         {
+            Fx.Assert(task.IsCompleted || !IOThreadScheduler.IsRunningOnIOThread, "Waiting on an IO Thread might cause problems");
+            // Waiting on an IO Thread can cause performance problems as we might block the IOThreadScheduler
+            // dequeuing loop.
             task.GetAwaiter().GetResult();
         }
 
@@ -205,6 +208,9 @@ namespace CoreWCF.Runtime
         {
             if (!task.IsCompleted)
             {
+                Fx.Assert(!IOThreadScheduler.IsRunningOnIOThread, "Waiting on an IO Thread might cause problems");
+                // Waiting on an IO Thread can cause performance problems as we might block the IOThreadScheduler
+                // dequeuing loop.
                 ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
             }
 
@@ -214,6 +220,9 @@ namespace CoreWCF.Runtime
 
         public static TResult WaitForCompletion<TResult>(this Task<TResult> task)
         {
+            Fx.Assert(task.IsCompleted || !IOThreadScheduler.IsRunningOnIOThread, "Waiting on an IO Thread might cause problems");
+            // Waiting on an IO Thread can cause performance problems as we might block the IOThreadScheduler
+            // dequeuing loop.
             return task.GetAwaiter().GetResult();
         }
 
@@ -221,6 +230,9 @@ namespace CoreWCF.Runtime
         {
             if (!task.IsCompleted)
             {
+                Fx.Assert(!IOThreadScheduler.IsRunningOnIOThread, "Waiting on an IO Thread might cause problems");
+                // Waiting on an IO Thread can cause performance problems as we might block the IOThreadScheduler
+                // dequeuing loop.
                 ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
             }
 
@@ -238,6 +250,9 @@ namespace CoreWCF.Runtime
             bool completed = true;
             if (!task.IsCompleted)
             {
+                Fx.Assert(!IOThreadScheduler.IsRunningOnIOThread, "Waiting on an IO Thread might cause problems");
+                // Waiting on an IO Thread can cause performance problems as we might block the IOThreadScheduler
+                // dequeuing loop.
                 completed = ((IAsyncResult)task).AsyncWaitHandle.WaitOne(timeout);
             }
 
@@ -309,16 +324,25 @@ namespace CoreWCF.Runtime
             return new SyncContextScope();
         }
 
-        // Calls the given Action asynchronously.
+        // Calls the given Action asynchronously on the ThreadPool.
         public static async Task CallActionAsync<TArg>(Action<TArg> action, TArg argument)
         {
-            using (IDisposable scope = RunTaskContinuationsOnOurThreads())
+            // Make sure any async tasks started from the action have their continuation
+            // execute on the IOThreadScheduler, but make sure the action itself is running
+            // on the thread pool.
+            if (!Thread.CurrentThread.IsThreadPoolThread)
             {
-                if (scope != null)  // No need to change threads if already off of thread pool
-                {
-                    await Task.Yield(); // Move synchronous method off of thread pool
-                }
+                // Switch to a thread pool thread to run passed action
+                SynchronizationContext.SetSynchronizationContext(null);
+                await Task.Yield();
+            }
 
+            // Now we're running on the ThreadPool, we reset the SynchronizationContext to
+            // our sync context which posts to the IOThreadScheduler. We're not hopping threads
+            // so any synchronous blocking will occur on the current thread pool thread.
+            Fx.Assert(Thread.CurrentThread.IsThreadPoolThread, "We should be running on the thread pool");
+            using (var scope = RunTaskContinuationsOnOurThreads())
+            {
                 action(argument);
             }
         }


### PR DESCRIPTION
### Description

This PR implements the same fix for the IOThreadScheduler seen here: https://github.com/dotnet/wcf/pull/4862
The expected results for this fix: 
* Better performance on Linux since it lacks IO thread optimizations
* Linux performance should match performance of benchmarks where a temp fix was used to handle task continuation 

---

### Testing

* Unit tests passed locally 
* The performance benchmarks below were taken. Note that the performance for receiving payloads has 

| | Echo1 | Echo100 | Echo1000 | Send1 | Send100 | Send1000 | Receive1 | Receive100 | Receive1000
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | 
WCF - Windows (RPS) | 15764 | 4519 | 634 | 16434 | 6695 | 1007 | 16360 | 7075 | 1116
CoreWCF - Windows (RPS) | 22861 | 4996 | 576 | 24100 | 7242 | 921 | 23816 | 9189 | 1002
**CoreWCF - Windows (RPS, IOThreadScheduler fix)** | **22247** | **5217** | **554** | **23514** | **7258** | **984** | **23539** | **9136** | **938**
CoreWCF - Linux (RPS, original) | 23046 | 4770 | 480 | 23433 | 6431 | 816 | 23411 | 2073 | 211
CoreWCF - Linux (RPS, temp fix for task continuation) | 22919 | 4586 | 518 | 24173 | 6394 | 780 | 24611 | 7471 | 800
**CoreWCF - Linux (RPS, IOThreadScheduler fix)** | **22823** | **4839** | **511** | **23863** | **6705** | **810** | **23966** | **7450** | **811**