### PR TITLE
Fix streamed mode multiple services

### DIFF
--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/ConnectionOrientedTransportReplyChannel.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/ConnectionOrientedTransportReplyChannel.cs
@@ -51,6 +51,17 @@ namespace CoreWCF.Channels
             }
 
             await base.OnCloseAsync(token);
+
+            if (_serviceProvider is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else if (_serviceProvider is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+
+            _serviceProvider = null;
         }
 
         public override T GetProperty<T>()

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/ConnectionOrientedTransportReplyChannel.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/ConnectionOrientedTransportReplyChannel.cs
@@ -12,7 +12,7 @@ namespace CoreWCF.Channels
     internal class ConnectionOrientedTransportReplyChannel : ReplyChannel
     {
         private StreamUpgradeProvider _upgrade;
-        private readonly IServiceProvider _serviceProvider;
+        private IServiceProvider _serviceProvider;
 
         public ConnectionOrientedTransportReplyChannel(ITransportFactorySettings settings, EndpointAddress localAddress, IServiceProvider serviceProvider)
             : base(settings, localAddress)

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/ServerSessionConnectionReaderMiddleware.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/Framing/ServerSessionConnectionReaderMiddleware.cs
@@ -37,6 +37,7 @@ namespace CoreWCF.Channels.Framing
             {
                 lock (_lock)
                 {
+                    // Double locked checking not necessary as there's no functional harm to having multiple instances
                     BindingElementCollection be = connection.ServiceDispatcher.Binding.CreateBindingElements();
                     TransportBindingElement tbe = be.Find<TransportBindingElement>();
                     settings = new NetFramingTransportSettings

--- a/src/CoreWCF.NetTcp/tests/Contract/IEchoService.cs
+++ b/src/CoreWCF.NetTcp/tests/Contract/IEchoService.cs
@@ -21,36 +21,5 @@ namespace Contract
         [System.ServiceModel.OperationContract(Name = "Echo", Action = Constants.OPERATION_BASE + "Echo",
             ReplyAction = Constants.OPERATION_BASE + "EchoResponse")]
         string EchoString(string echo);
-
-        [CoreWCF.OperationContract(Name = "WaitForSecondRequest", Action = Constants.OPERATION_BASE + "WaitForSecondRequest",
-            ReplyAction = Constants.OPERATION_BASE + "WaitForSecondRequestResponse")]
-        [System.ServiceModel.OperationContract(Name = "WaitForSecondRequest", Action = Constants.OPERATION_BASE + "WaitForSecondRequest",
-            ReplyAction = Constants.OPERATION_BASE + "WaitForSecondRequestResponse")]
-        bool WaitForSecondRequest();
-
-        [CoreWCF.OperationContract(Name = "WaitForSecondRequest", Action = Constants.OPERATION_BASE + "WaitForSecondRequest",
-            ReplyAction = Constants.OPERATION_BASE + "WaitForSecondRequestResponse")]
-        [System.ServiceModel.OperationContract(Name = "WaitForSecondRequest", Action = Constants.OPERATION_BASE + "WaitForSecondRequest",
-            ReplyAction = Constants.OPERATION_BASE + "WaitForSecondRequestResponse")]
-        Task<bool> WaitForSecondRequestAsync();
-
-
-        [CoreWCF.OperationContract(Name = "SecondRequest", Action = Constants.OPERATION_BASE + "SecondRequest",
-            ReplyAction = Constants.OPERATION_BASE + "SecondRequestResponse")]
-        [System.ServiceModel.OperationContract(Name = "SecondRequest", Action = Constants.OPERATION_BASE + "SecondRequest",
-            ReplyAction = Constants.OPERATION_BASE + "SecondRequestResponse")]
-        void SecondRequest();
-
-        [CoreWCF.OperationContract(Name = "GetClientIpEndpoint", Action = Constants.OPERATION_BASE + "GetClientIpEndpoint",
-            ReplyAction = Constants.OPERATION_BASE + "GetClientIpEndpointResponse")]
-        [System.ServiceModel.OperationContract(Name = "GetClientIpEndpoint", Action = Constants.OPERATION_BASE + "GetClientIpEndpoint",
-            ReplyAction = Constants.OPERATION_BASE + "GetClientIpEndpointResponse")]
-        string GetClientIpEndpoint();
-
-        [CoreWCF.OperationContract(Name = "TestMessageContract", Action = Constants.OPERATION_BASE + "TestMessageContract",
-            ReplyAction = Constants.OPERATION_BASE + "TestMessageContractResponse")]
-        [System.ServiceModel.OperationContract(Name = "TestMessageContract", Action = Constants.OPERATION_BASE + "TestMessageContract",
-            ReplyAction = Constants.OPERATION_BASE + "TestMessageContractResponse")]
-        TestMessage TestMessageContract(TestMessage testMessage);
     }
 }

--- a/src/CoreWCF.NetTcp/tests/Services/EchoService.cs
+++ b/src/CoreWCF.NetTcp/tests/Services/EchoService.cs
@@ -1,14 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using Contract;
 using CoreWCF;
-using CoreWCF.Channels;
 
 namespace Services
 {
@@ -21,42 +15,10 @@ namespace Services
         {
             return echo;
         }
+    }
 
-        public bool WaitForSecondRequest()
-        {
-            _mre.Reset();
-            return _mre.WaitOne(TimeSpan.FromSeconds(10));
-        }
-
-        public void SecondRequest()
-        {
-            _mre.Set();
-        }
-
-        public string GetClientIpEndpoint()
-        {
-            if (OperationContext.Current.IncomingMessageProperties.TryGetValue(RemoteEndpointMessageProperty.Name, out object remoteEndpointObj))
-            {
-                var remoteEndpoint = remoteEndpointObj as RemoteEndpointMessageProperty;
-                return remoteEndpoint.Address.ToString() + ":" + remoteEndpoint.Port.ToString();
-            }
-
-            throw new Exception("Remote endpoint message property not found");
-        }
-
-        public TestMessage TestMessageContract(TestMessage testMessage)
-        {
-            string text = new StreamReader(testMessage.Body, Encoding.UTF8).ReadToEnd();
-            return new TestMessage()
-            {
-                Header = testMessage.Header + " from server",
-                Body = new MemoryStream(Encoding.UTF8.GetBytes(text + " from server"))
-            };
-        }
-
-        public Task<bool> WaitForSecondRequestAsync()
-        {
-            return Task.FromResult(WaitForSecondRequest());
-        }
+    public class EchoService2 : EchoService
+    {
+        // Duplicate identical service, need a different type for multi-service test
     }
 }


### PR DESCRIPTION
Fixes #782 
In WCF, a single channel instance is created for dispatching streamed mode requests for NetTcp, but that's scoped to a single ServiceHost. In CoreWCF, multiple services use the same single middleware instance which meant that the single channel instance was being used for multiple services. One the channel had been created for a request for the first service, when a request came in for the second service, the EndpointDispatcher didn't match. The fix is to cache the channel per IServiceDispatcher. I'm doing this with a HashTable (no lock needed for read, only for writing), but it might be worth creating a property bag on IServiceDispatcher to help with these sorts of situations. But that's a future issue to consider.