### PR TITLE
Fix multiple WSDL issues

### DIFF
--- a/src/CoreWCF.Metadata/tests/DataTypesTest.cs
+++ b/src/CoreWCF.Metadata/tests/DataTypesTest.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Threading.Tasks;
 using CoreWCF.Metadata.Tests.Helpers;
 using ServiceContract;
@@ -22,7 +23,9 @@ namespace CoreWCF.Metadata.Tests
         [Fact]
         public async Task CollectionsDataContract()
         {
+            AppContext.SetSwitch("CoreWCF.RemoveKeyValuePairFromWsdl", true);
             await TestHelper.RunSingleWsdlTestAsync<CollectionsService, ICollectionsService>(new BasicHttpBinding(), _output);
+            AppContext.SetSwitch("CoreWCF.RemoveKeyValuePairFromWsdl", false);
         }
 
         [Fact]

--- a/src/CoreWCF.Metadata/tests/Helpers/WsdlHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/WsdlHelper.cs
@@ -17,6 +17,7 @@ namespace CoreWCF.Metadata.Tests.Helpers
 {
     internal static class WsdlHelper
     {
+        private const string XmlDeclaration = "<?xml version=\"1.0\" encoding=\"utf-8\"?>";
         public static async Task ValidateSingleWsdl(string serviceMetadataPath, string endpointAddress,
                 string callerMethodName, string sourceFilePath)
         {
@@ -33,6 +34,7 @@ namespace CoreWCF.Metadata.Tests.Helpers
                 generatedWsdlTxt = await response.Content.ReadAsStringAsync();
             }
 
+            Assert.StartsWith(XmlDeclaration, generatedWsdlTxt);
             var xmlFileName = Path.Combine("Wsdls", Path.GetFileNameWithoutExtension(sourceFilePath) + "." + callerMethodName + ".xml");
             if (!File.Exists(xmlFileName))
             {

--- a/src/CoreWCF.Metadata/tests/MultipleServicesTest.cs
+++ b/src/CoreWCF.Metadata/tests/MultipleServicesTest.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Threading.Tasks;
 using CoreWCF.Metadata.Tests.Helpers;
 using ServiceContract;
@@ -22,8 +23,10 @@ namespace CoreWCF.Metadata.Tests
         [Fact]
         public async Task BasicHttpRequestReplyEchoString()
         {
+            AppContext.SetSwitch("CoreWCF.RemoveKeyValuePairFromWsdl", true);
             await TestHelper.RunMultipleWsdlTestAsync<SimpleEchoService, CollectionsService, IEchoService, ICollectionsService>(
                 new BasicHttpBinding(), new BasicHttpBinding(), _output);
+            AppContext.SetSwitch("CoreWCF.RemoveKeyValuePairFromWsdl", false);
         }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceMetadataExtension.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceMetadataExtension.cs
@@ -1509,9 +1509,11 @@ SR.SFxDocExt_NoMetadataSection5        ));
                         var utf8NoBomEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
                         using (var textWriter = new StreamWriter(memoryStream, encoding: utf8NoBomEncoding, bufferSize: 1024, leaveOpen: true))
                         {
-                            using (var xmlTextWriter = XmlWriter.Create(textWriter, new XmlWriterSettings { Indent = false, OmitXmlDeclaration = true }))
+                            using (var xmlTextWriter = XmlWriter.Create(textWriter, new XmlWriterSettings { Indent = false, OmitXmlDeclaration = false }))
                             {
+                                xmlTextWriter.WriteStartDocument();
                                 Write(xmlTextWriter);
+                                xmlTextWriter.WriteEndDocument();
                             }
                         }
                         memoryStream.Position = 0;


### PR DESCRIPTION
Fixes #654 (Add xml declaration to WSDL document)
Also changed default behavior to leave KeyValuePairOfXXXX in the wsdl as some people actually use KeyValuePair\<K,V\> in their contracts and removing this broke their WSDL. It should be harmless in the output if it isn't needed, but in case it does cause problems, I've added an AppContext switch to turn the behavior back on. This won't be a problem for .NET 7 as they fixed the issue there.