### PR TITLE
Do not retrieve inherited MessageContract attributes

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageContractHelper.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageContractHelper.cs
@@ -12,7 +12,7 @@ namespace CoreWCF.Description
     {
         internal static bool IsMessageContract(Type type)
         {
-            foreach (Attribute attr in type.GetCustomAttributes())
+            foreach (Attribute attr in type.GetCustomAttributes(inherit: false))
             {
                 if (attr.GetType() == typeof(MessageContractAttribute)
                 || (string.Compare(attr.GetType().FullName, ServiceReflector.SMMessageContractAttributeFullName, true) == 0))

--- a/src/CoreWCF.Primitives/tests/ContractDescriptionTests.cs
+++ b/src/CoreWCF.Primitives/tests/ContractDescriptionTests.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+using CoreWCF.Description;
+using Xunit;
+
+namespace CoreWCF.Primitives.Tests
+{
+    public class ContractDescriptionTests
+    {
+        [Fact]
+        public void ValidateContractCanBeConstructed()
+        {
+            ContractDescription.GetContract<MessagePropertyService>(typeof(IMessagePropertyService));
+        }
+
+        public class MessagePropertyService : IMessagePropertyService
+        {
+            public SimpleResponse Request(SimpleRequest request)
+            {
+                return new SimpleResponse
+                {
+                    stringParam = request.stringParam,
+                    stringProperty = request.stringParam
+                };
+            }
+        }
+
+        [System.ServiceModel.ServiceContract]
+        internal interface IMessagePropertyService
+        {
+            [System.ServiceModel.OperationContract]
+            SimpleResponse Request(SimpleRequest request);
+        }
+
+        [DataContract]
+        public class SimpleRequest : BaseRequest
+        {
+        }
+
+        [System.ServiceModel.MessageContract(WrapperName = "MPRequest", WrapperNamespace = "http://tempuri.org")]
+        public class BaseRequest
+        {
+            [System.ServiceModel.MessageBodyMember]
+            public string stringParam;
+        }
+
+        [DataContract]
+        public class SimpleResponse : BaseResponse
+        {
+        }
+
+        [System.ServiceModel.MessageContract(WrapperName = "MPResponse", WrapperNamespace = "http://tempuri.org")]
+        public abstract class BaseResponse
+        {
+            public const string PropertyName = "MPMessageProperty";
+            [System.ServiceModel.MessageBodyMember]
+            public string stringParam;
+            [System.ServiceModel.MessageProperty(Name = PropertyName)]
+            public string stringProperty;
+        }
+    }
+}


### PR DESCRIPTION
MessageContractHelper includes MessageContract attributes from base types, which leads to a Null Reference Exception later when CreateTypedMessageDescription attemptes to retrieve the same attribute from the message type.
- Do not retrieve inherited MessageContract attributes

#824