### PR TITLE
Async global exception logging missing user-code stacktrace

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/TaskMethodInvoker.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/TaskMethodInvoker.cs
@@ -244,25 +244,15 @@ namespace CoreWCF.Dispatcher
 
         private Exception ConvertExceptionForFaultedTask(Task task)
         {
-            Exception exception = task.Exception.InnerException;
-            //bool callFaulted;
-            if (exception is SecurityException)
+            if (task.Exception?.InnerException is SecurityException innerException)
             {
-                DiagnosticUtility.TraceHandledException(exception, TraceEventType.Warning);
-                exception = DiagnosticUtility.ExceptionUtility.ThrowHelperError(AuthorizationBehavior.CreateAccessDeniedFaultException());
+                DiagnosticUtility.TraceHandledException(innerException, TraceEventType.Warning);
+                return DiagnosticUtility.ExceptionUtility.ThrowHelperError(AuthorizationBehavior.CreateAccessDeniedFaultException());
             }
-            else if (exception is FaultException)
-            {
-                //callFaulted = true;
-            }
-            else
-            {
-                TraceUtility.TraceUserCodeException(exception, TaskMethod);
-            }
-            //AsyncMethodInvoker.StopOperationInvokeTrace(true, callFaulted, TaskMethod.Name);
-            //AsyncMethodInvoker.StopOperationInvokePerformanceCounters(true, callFaulted, TaskMethod.Name);
 
-            return exception;
+            TraceUtility.TraceUserCodeException(task.Exception, TaskMethod);
+
+            return task.Exception;
         }
 
         private void EnsureIsInitialized()


### PR DESCRIPTION
Currently when an async task throws an exception after an await, the stack trace of the original exception is lost so that it is not possible to see where in user-code the exception was thrown from (since only the corewcf specific code is included).

This change makes it so that information regarding the original exception location is included in the exception message
when it arrives to ErrorHandler code.