### PR TITLE
Backport net7 support to 1.1

### DIFF
--- a/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn3.11.Tests.csproj
+++ b/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn3.11.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn4.0.Tests.csproj
+++ b/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn4.0.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/CoreWCF.ConfigurationManager/tests/CoreWCF.ConfigurationManager.Tests.csproj
+++ b/src/CoreWCF.ConfigurationManager/tests/CoreWCF.ConfigurationManager.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
@@ -34,13 +34,23 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.17" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0-rc.2.22476.2" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />
-    <ProjectReference Include="..\src\CoreWCF.ConfigurationManager.csproj" />     
+    <ProjectReference Include="..\src\CoreWCF.ConfigurationManager.csproj" />
   </ItemGroup>
 </Project>

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    
+
     <!-- Required for multi-framework support for in-memory integration testing-->
     <OutputType>Exe</OutputType>
     <GenerateProgramFile>false</GenerateProgramFile>
@@ -52,6 +52,12 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="7.0.0-rc.2.22476.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
+++ b/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
@@ -42,6 +42,11 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0-rc.2.22476.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageContractExporter.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/MessageContractExporter.cs
@@ -259,18 +259,18 @@ namespace CoreWCF.Description
             return elementName;
         }
 
-        protected XsdDataContractExporterEx DataContractExporter
+        protected IXsdDataContractExporter DataContractExporter
         {
             get
             {
                 object dataContractExporter;
-                if (!_exporter.State.TryGetValue(typeof(XsdDataContractExporterEx), out dataContractExporter))
+                if (!_exporter.State.TryGetValue(typeof(IXsdDataContractExporter), out dataContractExporter))
                 {
-                    dataContractExporter = new XsdDataContractExporterEx(_exporter.GeneratedXmlSchemas);
-                    _exporter.State.Add(typeof(XsdDataContractExporterEx), dataContractExporter);
+                    dataContractExporter = XsdDataContractExporterFactory.Create(_exporter.GeneratedXmlSchemas);
+                    _exporter.State.Add(typeof(IXsdDataContractExporter), dataContractExporter);
                 }
 
-                return (XsdDataContractExporterEx)dataContractExporter;
+                return (IXsdDataContractExporter)dataContractExporter;
             }
         }
 

--- a/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/IXsdDataContractExporter.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/IXsdDataContractExporter.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Xml;
+using System.Xml.Schema;
+
+namespace CoreWCF.Runtime.Serialization
+{
+    internal interface IXsdDataContractExporter
+    {
+        void Export(Type type);
+        XmlQualifiedName GetRootElementName(Type type);
+        XmlSchemaType GetSchemaType(Type type);
+        XmlQualifiedName GetSchemaTypeName(Type type);
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/XsdDataContractExporterExWrapper.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/XsdDataContractExporterExWrapper.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Xml;
+using System.Xml.Schema;
+
+namespace CoreWCF.Runtime.Serialization
+{
+    internal class XsdDataContractExporterExWrapper : IXsdDataContractExporter
+    {
+        private readonly XsdDataContractExporterEx _xsdDataContractExporter;
+
+        public XsdDataContractExporterExWrapper()
+        {
+            _xsdDataContractExporter = new XsdDataContractExporterEx();
+        }
+
+        public XsdDataContractExporterExWrapper(XmlSchemaSet xmlSchemaSet)
+        {
+            _xsdDataContractExporter = new XsdDataContractExporterEx(xmlSchemaSet);
+        }
+
+        public void Export(Type type) => _xsdDataContractExporter.Export(type);
+        public XmlQualifiedName GetRootElementName(Type type) => _xsdDataContractExporter.GetRootElementName(type);
+        public XmlSchemaType GetSchemaType(Type type) => _xsdDataContractExporter.GetSchemaType(type);
+        public XmlQualifiedName GetSchemaTypeName(Type type) => _xsdDataContractExporter.GetSchemaTypeName(type);
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/XsdDataContractExporterFactory.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/XsdDataContractExporterFactory.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Xml.Schema;
+
+namespace CoreWCF.Runtime.Serialization
+{
+    internal static class XsdDataContractExporterFactory
+    {
+        public static IXsdDataContractExporter Create() => Environment.Version.Major < 7
+            ? new XsdDataContractExporterExWrapper()
+            : new XsdDataContractExporterWrapper();
+
+        public static IXsdDataContractExporter Create(XmlSchemaSet xmlSchemaSet) => Environment.Version.Major < 7
+            ? new XsdDataContractExporterExWrapper(xmlSchemaSet)
+            : new XsdDataContractExporterWrapper(xmlSchemaSet);
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/XsdDataContractExporterWrapper.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Runtime/Serialization/XsdDataContractExporterWrapper.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.Serialization;
+using System.Xml;
+using System.Xml.Schema;
+
+namespace CoreWCF.Runtime.Serialization
+{
+    internal class XsdDataContractExporterWrapper : IXsdDataContractExporter
+    {
+        private readonly XsdDataContractExporter _xsdDataContractExporter;
+
+        public XsdDataContractExporterWrapper()
+        {
+            _xsdDataContractExporter = new XsdDataContractExporter();
+        }
+
+        public XsdDataContractExporterWrapper(XmlSchemaSet xmlSchemaSet)
+        {
+            _xsdDataContractExporter = new XsdDataContractExporter(xmlSchemaSet);
+        }
+
+        public void Export(Type type) => _xsdDataContractExporter.Export(type);
+
+        public XmlQualifiedName GetRootElementName(Type type) => _xsdDataContractExporter.GetRootElementName(type);
+
+        public XmlSchemaType GetSchemaType(Type type) => _xsdDataContractExporter.GetSchemaType(type);
+
+        public XmlQualifiedName GetSchemaTypeName(Type type) => _xsdDataContractExporter.GetSchemaTypeName(type);
+    }
+}

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/CoreWCF.WebHttp/tests/CoreWCF.WebHttp.Tests.csproj
+++ b/src/CoreWCF.WebHttp/tests/CoreWCF.WebHttp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -26,15 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/templates/CodeAnalysis.yml
+++ b/templates/CodeAnalysis.yml
@@ -17,11 +17,12 @@ stages:
     steps:
 
     - task: UseDotNet@2
-      displayName: 'Use .NET Core 6 sdk'
+      displayName: 'Use .NET Core 7 sdk'
       inputs:
         packageType: sdk
-        version: '6.0.x'
+        version: '7.0.x'
         installationPath: $(Agent.ToolsDirectory)/dotnet
+        includePreviewVersions: true
 
     - task: DotNetCoreCLI@2
       displayName: Restore packages
@@ -55,7 +56,7 @@ stages:
       inputs:
         command: test
         projects: ${{ parameters.testProjects}}
-        arguments: '--no-restore --no-build -c Release -f net6.0 --filter Category!=WindowsOnly --collect:"XPlat Code Coverage" --settings coverlet.runsettings'
+        arguments: '--no-restore --no-build -c Release -f net7.0 --filter Category!=WindowsOnly --collect:"XPlat Code Coverage" --settings coverlet.runsettings'
 
     - task: PublishCodeCoverageResults@1
       displayName: Publish Code Coverage report

--- a/templates/TestStage.yml
+++ b/templates/TestStage.yml
@@ -24,7 +24,12 @@ stages:
           imageName: 'windows-latest'
           targetFramework: 'net6.0'
           testArgs: ''
-          additionalDotNetCoreSdk: ''
+          additionalDotNetCoreSdk: '6.0.x'
+        Windows_net7.0:
+          imageName: 'windows-latest'
+          targetFramework: 'net7.0'
+          testArgs: ''
+          additionalDotNetCoreSdk: ''          
         Windows_netfx:
           imageName: 'windows-latest'
           targetFramework: 'net472'
@@ -44,7 +49,12 @@ stages:
           imageName: 'ubuntu-latest'
           targetFramework: 'net6.0'
           testArgs: '--filter Category!=WindowsOnly'
-          additionalDotNetCoreSdk: ''
+          additionalDotNetCoreSdk: '6.0.x'
+        Linux_net7.0:
+          imageName: 'ubuntu-latest'
+          targetFramework: 'net7.0'
+          testArgs: '--filter Category!=WindowsOnly'
+          additionalDotNetCoreSdk: ''          
     displayName: Test Release
     pool:
       vmImage: $(imageName)
@@ -57,11 +67,12 @@ stages:
         path: $(System.DefaultWorkingDirectory)/bin
 
     - task: UseDotNet@2
-      displayName: 'Use .NET Core 6 sdk'
+      displayName: 'Use .NET 7.0 sdk'
       inputs:
         packageType: sdk
-        version: '6.0.x'
+        version: '7.0.x'
         installationPath: $(Agent.ToolsDirectory)/dotnet
+        includePreviewVersions: true
 
     - task: UseDotNet@2
       displayName: 'Use additional .NET Core sdk'
@@ -111,7 +122,12 @@ stages:
           imageName: 'windows-latest'
           targetFramework: 'net6.0'
           testArgs: ''
-          additionalDotNetCoreSdk: ''
+          additionalDotNetCoreSdk: '6.0.x'
+        Windows_net7.0:
+          imageName: 'windows-latest'
+          targetFramework: 'net7.0'
+          testArgs: ''
+          additionalDotNetCoreSdk: ''          
         Windows_netfx:
           imageName: 'windows-latest'
           targetFramework: 'net472'
@@ -131,7 +147,12 @@ stages:
           imageName: 'ubuntu-latest'
           targetFramework: 'net6.0'
           testArgs: '--filter Category!=WindowsOnly'
-          additionalDotNetCoreSdk: ''
+          additionalDotNetCoreSdk: '6.0.x'
+        Linux_net7.0:
+          imageName: 'ubuntu-latest'
+          targetFramework: 'net7.0'
+          testArgs: '--filter Category!=WindowsOnly'
+          additionalDotNetCoreSdk: ''          
     displayName: Test Debug
     pool:
       vmImage: $(imageName)
@@ -144,11 +165,12 @@ stages:
         path: $(System.DefaultWorkingDirectory)/bin
 
     - task: UseDotNet@2
-      displayName: 'Use .NET Core 6 sdk'
+      displayName: 'Use .NET 7.0 sdk'
       inputs:
         packageType: sdk
-        version: '6.0.x'
+        version: '7.0.x'
         installationPath: $(Agent.ToolsDirectory)/dotnet
+        includePreviewVersions: true
 
     - task: UseDotNet@2
       displayName: 'Use additional .NET Core sdk'

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
1.1 is still in support so backporting changes needed for the WSDL feature to work in .NET 7.