### PR TITLE
Update the use of System.Net.NTAuthentication from NegotiateInternalState

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/INTAuthenticationFacade.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/INTAuthenticationFacade.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace CoreWCF.Security.NegotiateInternal
+{
+    internal interface INTAuthenticationFacade
+    {
+        object Instance { get; }
+
+        bool IsCompleted { get; }
+
+        string Protocol { get; }
+
+        bool IsValidContext { get; }
+
+        byte[] GetOutgoingBlob(byte[] incomingBlob, bool throwOnError, out object statusCode);
+
+        int Encrypt(byte[] input, ref byte[] output);
+
+        void CloseContext();
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthentication.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthentication.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Reflection;
+using System.Security.Authentication;
+using System;
+using System.Linq;
+
+namespace CoreWCF.Security.NegotiateInternal
+{
+    internal class NTAuthentication : INTAuthenticationFacade
+    {
+        protected static readonly Type s_ntAuthenticationType;
+        protected static readonly ConstructorInfo s_constructor;
+        protected static readonly MethodInfo s_getOutgoingBlob;
+        protected static readonly MethodInfo s_isCompleted;
+        protected static readonly MethodInfo s_isValidContext;
+        protected static readonly MethodInfo s_protocol;
+        protected static readonly MethodInfo s_closeContext;
+        protected static readonly MethodInfo s_encrypt;
+
+        public object Instance { get; }
+
+        public bool IsCompleted => (bool)s_isCompleted.Invoke(Instance, Array.Empty<object>());
+
+        public string Protocol => (string)s_protocol.Invoke(Instance, Array.Empty<object>());
+
+        public bool IsValidContext => (bool)s_isValidContext.Invoke(Instance, Array.Empty<object>());
+
+        internal NTAuthentication() => Instance = CreateInstance();
+
+        static NTAuthentication()
+        {
+            Assembly secAssembly = typeof(AuthenticationException).Assembly;
+            s_ntAuthenticationType = secAssembly.GetType("System.Net.NTAuthentication", throwOnError: true);
+
+            s_constructor = s_ntAuthenticationType.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).First();
+            s_getOutgoingBlob = s_ntAuthenticationType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
+                info.Name.Equals("GetOutgoingBlob") && info.GetParameters().Count() == 3).Single();
+            s_isCompleted = s_ntAuthenticationType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
+                info.Name.Equals("get_IsCompleted")).Single();
+            s_protocol = s_ntAuthenticationType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
+                info.Name.Equals("get_ProtocolName")).Single();
+            s_closeContext = s_ntAuthenticationType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
+                info.Name.Equals("CloseContext")).Single();
+            s_encrypt = s_ntAuthenticationType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
+                info.Name.Equals("Encrypt")).Single();
+            s_isValidContext = s_ntAuthenticationType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
+            info.Name.Equals("get_IsValidContext")).Single();
+        }
+
+        protected static object CreateInstance()
+        {
+            ICredentials credential = CredentialCache.DefaultCredentials;
+            return s_constructor.Invoke(new object[] { true, "Negotiate", credential, null, 0, null });
+        }
+
+        public virtual byte[] GetOutgoingBlob(byte[] incomingBlob, bool throwOnError, out object statusCode)
+        {
+            // byte[] GetOutgoingBlob(byte[] incomingBlob, bool throwOnError, out SecurityStatusPal statusCode)
+            object[] parameters = new object[] { incomingBlob, throwOnError, null };
+            byte[] blob = (byte[])s_getOutgoingBlob.Invoke(Instance, parameters);
+            statusCode = parameters[2];
+            return blob;
+        }
+
+        public virtual void CloseContext()
+        {
+            s_closeContext.Invoke(Instance, Array.Empty<object>());
+        }
+
+        public virtual int Encrypt(byte[] input, ref byte[] output)
+        {
+            /*
+             * internal int Encrypt(
+             *     byte[] buffer,
+             *     int offset,
+             *     int count,
+             *     ref byte[] output,
+             *     uint sequenceNumber)
+             */
+            object[] parameters = new object[] { input, 0, input.Length, output, 0U };
+            int totalBytes = (int)s_encrypt.Invoke(Instance, parameters);
+            output = (byte[])parameters[3];
+            return totalBytes;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationFacade.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationFacade.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Authentication;
+
+namespace CoreWCF.Security.NegotiateInternal
+{
+    internal static class NTAuthenticationFacade
+    {
+        private static readonly int s_AssemblyMajorVersion = typeof(AuthenticationException).Assembly.GetName().Version.Major;
+
+        internal static INTAuthenticationFacade Build() =>
+            s_AssemblyMajorVersion switch
+            {
+                >= 5 => new NTAuthenticationNet5(),
+                _ => new NTAuthenticationLegacy()
+            };
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationFacade.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationFacade.cs
@@ -12,6 +12,7 @@ namespace CoreWCF.Security.NegotiateInternal
         internal static INTAuthenticationFacade Build() =>
             s_AssemblyMajorVersion switch
             {
+                >= 7 => new NTAuthenticationNet7(),
                 >= 5 => new NTAuthenticationNet5(),
                 _ => new NTAuthenticationLegacy()
             };

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationLegacy.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationLegacy.cs
@@ -37,7 +37,7 @@ namespace CoreWCF.Security.NegotiateInternal
 
             s_constructor = s_ntAuthenticationType.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).First();
             s_getOutgoingBlob = s_ntAuthenticationType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
-                info.Name.Equals("GetOutgoingBlob") && info.GetParameters().Count() == 3).Single();
+                info.Name.Equals("GetOutgoingBlob") && info.ToString().Equals("Byte[] GetOutgoingBlob(Byte[], Boolean, System.Net.SecurityStatusPal ByRef)")).Single();
             s_isCompleted = s_ntAuthenticationType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
                 info.Name.Equals("get_IsCompleted")).Single();
             s_protocol = s_ntAuthenticationType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationLegacy.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationLegacy.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace CoreWCF.Security.NegotiateInternal
 {
-    internal class NTAuthentication : INTAuthenticationFacade
+    internal class NTAuthenticationLegacy : INTAuthenticationFacade
     {
         protected static readonly Type s_ntAuthenticationType;
         protected static readonly ConstructorInfo s_constructor;
@@ -28,9 +28,9 @@ namespace CoreWCF.Security.NegotiateInternal
 
         public bool IsValidContext => (bool)s_isValidContext.Invoke(Instance, Array.Empty<object>());
 
-        internal NTAuthentication() => Instance = CreateInstance();
+        internal NTAuthenticationLegacy() => Instance = CreateInstance();
 
-        static NTAuthentication()
+        static NTAuthenticationLegacy()
         {
             Assembly secAssembly = typeof(AuthenticationException).Assembly;
             s_ntAuthenticationType = secAssembly.GetType("System.Net.NTAuthentication", throwOnError: true);

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationLegacy.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationLegacy.cs
@@ -11,7 +11,7 @@ namespace CoreWCF.Security.NegotiateInternal
 {
     internal class NTAuthenticationLegacy : INTAuthenticationFacade
     {
-        protected static readonly Type s_ntAuthenticationType;
+        protected static readonly Type s_ntAuthenticationType = typeof(AuthenticationException).Assembly.GetType("System.Net.NTAuthentication", throwOnError: true);
         protected static readonly ConstructorInfo s_constructor;
         protected static readonly MethodInfo s_getOutgoingBlob;
         protected static readonly MethodInfo s_isCompleted;
@@ -32,9 +32,6 @@ namespace CoreWCF.Security.NegotiateInternal
 
         static NTAuthenticationLegacy()
         {
-            Assembly secAssembly = typeof(AuthenticationException).Assembly;
-            s_ntAuthenticationType = secAssembly.GetType("System.Net.NTAuthentication", throwOnError: true);
-
             s_constructor = s_ntAuthenticationType.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).First();
             s_getOutgoingBlob = s_ntAuthenticationType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
                 info.Name.Equals("GetOutgoingBlob") && info.ToString().Equals("Byte[] GetOutgoingBlob(Byte[], Boolean, System.Net.SecurityStatusPal ByRef)")).Single();

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationNet5.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationNet5.cs
@@ -18,7 +18,7 @@ namespace CoreWCF.Security.NegotiateInternal
          *     [NotNull] ref byte[]? output, 
          *     uint sequenceNumber)
          */
-        private static readonly Lazy<EncryptInvoker> s_encryptInvoker = new Lazy<EncryptInvoker>(() => BuildEncrypt(Expression.Constant(0U)));
+        private static readonly EncryptInvoker s_encryptInvoker = BuildEncrypt(Expression.Constant(0U));
 
         protected static EncryptInvoker BuildEncrypt(params Expression[] otherParameters)
         {
@@ -54,6 +54,6 @@ namespace CoreWCF.Security.NegotiateInternal
             return expression.Compile();
         }
 
-        public override int Encrypt(byte[] input, ref byte[] output) => s_encryptInvoker.Value(Instance, input, ref output);
+        public override int Encrypt(byte[] input, ref byte[] output) => s_encryptInvoker(Instance, input, ref output);
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationNet5.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationNet5.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq.Expressions;
+using System.Linq;
+using System.Reflection;
+
+namespace CoreWCF.Security.NegotiateInternal
+{
+    internal class NTAuthenticationNet5 : NTAuthenticationLegacy
+    {
+        protected delegate int EncryptInvoker(object instance, byte[] buffer, ref byte[] output);
+
+        /*
+         * int Encrypt(
+         *     ReadOnlySpan<byte> buffer, 
+         *     [NotNull] ref byte[]? output, 
+         *     uint sequenceNumber)
+         */
+        private static readonly Lazy<EncryptInvoker> s_encryptInvoker = new Lazy<EncryptInvoker>(() => BuildEncrypt(Expression.Constant(0U)));
+
+        protected static EncryptInvoker BuildEncrypt(params Expression[] otherParameters)
+        {
+            /* This method build a function equivalent to:
+             * 
+             * (object instance, byte[] buffer, ref byte[] output) => 
+             *     ((NTAuthentication) instance).Encrypt((ReadOnlySpan<byte>) buffer.AsSpan(), output, ...*otherParameters*)
+             *                                                                                          
+             */
+            ParameterExpression instanceParameter = Expression.Parameter(typeof(object));
+            ParameterExpression bufferParameter = Expression.Parameter(typeof(byte[]));
+            ParameterExpression outputParameter = Expression.Parameter(typeof(byte[]).MakeByRefType());
+
+            UnaryExpression typedInstance = Expression.TypeAs(instanceParameter, s_ntAuthenticationType);
+
+            MethodInfo asSpan = typeof(MemoryExtensions)
+                .GetMethods()
+                .Single(m => m.Name == "AsSpan" && m.ToString() == "System.Span`1[T] AsSpan[T](T[])").
+                MakeGenericMethod(typeof(byte));
+
+
+            UnaryExpression bufferSpan = Expression.Convert(
+                Expression.Call(asSpan, bufferParameter),
+                typeof(ReadOnlySpan<byte>));
+
+            MethodCallExpression call = Expression.Call(
+                typedInstance,
+                s_encrypt,
+                Enumerable.Concat(new Expression[] { bufferSpan, outputParameter }, otherParameters));
+
+            var expression = Expression.Lambda<EncryptInvoker>(call, instanceParameter, bufferParameter, outputParameter);
+
+            return expression.Compile();
+        }
+
+        public override int Encrypt(byte[] input, ref byte[] output) => s_encryptInvoker.Value(Instance, input, ref output);
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationNet7.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationNet7.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace CoreWCF.Security.NegotiateInternal
+{
+    internal class NTAuthenticationNet7 : NTAuthenticationNet5
+    {
+        /*
+         * int Encrypt(
+         *     ReadOnlySpan<byte> buffer,
+         *     [NotNull] ref byte[]? output)
+         */
+        private static readonly Lazy<EncryptInvoker> s_encryptInvoker = new Lazy<EncryptInvoker>(() => BuildEncrypt());
+
+        public override int Encrypt(byte[] input, ref byte[] output) => s_encryptInvoker.Value(Instance, input, ref output);
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationNet7.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NTAuthenticationNet7.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace CoreWCF.Security.NegotiateInternal
 {
     internal class NTAuthenticationNet7 : NTAuthenticationNet5
@@ -12,8 +10,8 @@ namespace CoreWCF.Security.NegotiateInternal
          *     ReadOnlySpan<byte> buffer,
          *     [NotNull] ref byte[]? output)
          */
-        private static readonly Lazy<EncryptInvoker> s_encryptInvoker = new Lazy<EncryptInvoker>(() => BuildEncrypt());
+        private static readonly EncryptInvoker s_encryptInvoker = BuildEncrypt();
 
-        public override int Encrypt(byte[] input, ref byte[] output) => s_encryptInvoker.Value(Instance, input, ref output);
+        public override int Encrypt(byte[] input, ref byte[] output) => s_encryptInvoker(Instance, input, ref output);
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NegotiateInternalState.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NegotiateInternalState.cs
@@ -52,7 +52,7 @@ namespace CoreWCF.Security.NegotiateInternal
 
         public NegotiateInternalState()
         {
-            _ntAuthentication = new NTAuthentication();
+            _ntAuthentication = NTAuthenticationFacade.Build();
         }
 
         // Copied rather than reflected to remove the IsCompleted -> CloseContext check.

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NegotiateInternalState.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/NegotiateInternal/NegotiateInternalState.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
@@ -17,46 +16,18 @@ namespace CoreWCF.Security.NegotiateInternal
         // https://www.gnu.org/software/gss/reference/gss.pdf
         private const uint GSS_S_NO_CRED = 7 << 16;
 
-        private static readonly ConstructorInfo s_constructor;
-        private static readonly MethodInfo s_getOutgoingBlob;
-        private static readonly MethodInfo s_isCompleted;
-        private static readonly MethodInfo s_isValidContext;
-
-        private static readonly MethodInfo s_protocol;
         private static readonly MethodInfo s_getIdentity;
-        private static readonly MethodInfo s_closeContext;
-        //private static readonly MethodInfo _getContext;
-        private static readonly MethodInfo s_encrypt;
 
         private static readonly FieldInfo s_statusCode;
         private static readonly FieldInfo s_statusException;
         private static readonly FieldInfo s_gssMinorStatus;
         private static readonly Type s_gssExceptionType;
 
-        private readonly object _instance;
+        private readonly INTAuthenticationFacade _ntAuthentication;
 
         static NegotiateInternalState()
         {
             Assembly secAssembly = typeof(AuthenticationException).Assembly;
-            Type ntAuthType = secAssembly.GetType("System.Net.NTAuthentication", throwOnError: true);
-            s_constructor = ntAuthType.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).First();
-            s_getOutgoingBlob = ntAuthType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
-                info.Name.Equals("GetOutgoingBlob") && info.GetParameters().Count() == 3).Single();
-            s_isCompleted = ntAuthType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
-                info.Name.Equals("get_IsCompleted")).Single();
-            s_protocol = ntAuthType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
-                info.Name.Equals("get_ProtocolName")).Single();
-            s_closeContext = ntAuthType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
-                info.Name.Equals("CloseContext")).Single();
-
-            //Added these 2 new call
-            //   _getContext = ntAuthType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
-            //       info.Name.Equals("GetContext")).Single();
-            s_encrypt = ntAuthType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
-                info.Name.Equals("Encrypt")).Single();
-            s_isValidContext = ntAuthType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(info =>
-            info.Name.Equals("get_IsValidContext")).Single();
-            //end 
 
             //TODO this fails in framework
             Type securityStatusType = secAssembly.GetType("System.Net.SecurityStatusPal", throwOnError: true);
@@ -81,9 +52,7 @@ namespace CoreWCF.Security.NegotiateInternal
 
         public NegotiateInternalState()
         {
-
-            ICredentials credential = CredentialCache.DefaultCredentials;
-            _instance = s_constructor.Invoke(new object[] { true, "Negotiate", credential, null, 0, null });
+            _ntAuthentication = new NTAuthentication();
         }
 
         // Copied rather than reflected to remove the IsCompleted -> CloseContext check.
@@ -113,11 +82,8 @@ namespace CoreWCF.Security.NegotiateInternal
         {
             try
             {
-                // byte[] GetOutgoingBlob(byte[] incomingBlob, bool throwOnError, out SecurityStatusPal statusCode)
-                object[] parameters = new object[] { incomingBlob, false, null };
-                byte[] blob = (byte[])s_getOutgoingBlob.Invoke(_instance, parameters);
+                byte[] blob = _ntAuthentication.GetOutgoingBlob(incomingBlob, false, out object securityStatus);
 
-                object securityStatus = parameters[2];
                 // TODO: Update after corefx changes
                 error = (Exception)(s_statusException.GetValue(securityStatus)
                     ?? GetException.Invoke(null, new[] { securityStatus }));
@@ -170,41 +136,31 @@ namespace CoreWCF.Security.NegotiateInternal
             }
         }
 
-        public bool IsCompleted => (bool)s_isCompleted.Invoke(_instance, Array.Empty<object>());
+        public bool IsCompleted => _ntAuthentication.IsCompleted;
 
-        public string Protocol => (string)s_protocol.Invoke(_instance, Array.Empty<object>());
+        public string Protocol => _ntAuthentication.Protocol;
 
-        public bool IsValidContext => (bool)s_isValidContext.Invoke(_instance, Array.Empty<object>());
+        public bool IsValidContext => _ntAuthentication.IsValidContext;
 
         public static MethodInfo GetException { get; private set; }
 
-        public IIdentity GetIdentity() => (IIdentity)s_getIdentity.Invoke(obj: null, parameters: new object[] { _instance });
+        public IIdentity GetIdentity() => (IIdentity)s_getIdentity.Invoke(obj: null, parameters: new object[] { _ntAuthentication.Instance });
 
         public byte[] Encrypt(byte[] input)
         {
-
-            /*
-             *     internal int Encrypt(
-      byte[] buffer,
-      int offset,
-      int count,
-      ref byte[] output,
-      uint sequenceNumber)
-             */
             if (input == null)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull(nameof(input));
             }
 
             byte[] _writeBuffer = new byte[4];
-            object[] parameters = new object[] { input, 0, input.Length, _writeBuffer, 0U };
-            int totalBytes = (int)s_encrypt.Invoke(_instance, parameters);
+            int totalBytes = _ntAuthentication.Encrypt(input, ref _writeBuffer);
             byte[] result = new byte[totalBytes - 4];
-            Buffer.BlockCopy((byte[])parameters[3], 4, result, 0, result.Length);
+            Buffer.BlockCopy(_writeBuffer, 4, result, 0, result.Length);
             return result;
         }
 
-        public void Dispose() => s_closeContext.Invoke(_instance, Array.Empty<object>());
+        public void Dispose() => _ntAuthentication.CloseContext();
 
         private bool IsCredentialError(NegotiateInternalSecurityStatusErrorCode error) => error == NegotiateInternalSecurityStatusErrorCode.LogonDenied ||
                 error == NegotiateInternalSecurityStatusErrorCode.UnknownCredentials ||


### PR DESCRIPTION
Update the calls to System.Net.NTAuthentication to be compatible with net5.0, net6.0 and net7.0
 - Move the reflection code to a specific class
 - Invoke NTAuthentication.Encrypt() with the new signatures
 - Update GetOutgoingBlob search condition since there are new overloads in net7.0

#916  