### PR TITLE
Enable VS 2022 builtin docker support and wording for https in templates

### DIFF
--- a/src/CoreWCF.Templates/src/templates/CoreWCFService/.template.config/ide.host.json
+++ b/src/CoreWCF.Templates/src/templates/CoreWCFService/.template.config/ide.host.json
@@ -2,14 +2,9 @@
     "$schema": "http://json.schemastore.org/ide.host",
     "order": 150,
     "icon": "ide/Empty.png",
+    "disableHttpsSymbol": "NoHttps",
+    "supportsDocker": true,
     "symbolInfo": [
-      {
-        "id": "NoHttps",
-        "name": {
-          "text": "Turn off HTTPS feature."
-        },
-        "isVisible": true
-      },
       {
         "id": "NoWsdl",
         "name": {
@@ -20,7 +15,7 @@
       {
         "id": "UseProgramMain",
         "name": {
-          "text": "Turn off minimal ASP.NET Core hosting model. (Only applies to .NET 6 projects)"
+          "text": "Turn off minimal ASP.NET Core hosting model."
         },
         "isVisible": true
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/681739/205479855-7aa47548-1ec6-4333-8ae7-f8bcc8317fa8.png)
