### PR TITLE
Update package versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,7 +50,7 @@
   </PropertyGroup>
   <ItemGroup Condition="!($(IsTestProject) OR $(IsSampleProject))">
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.5.109</Version>
+      <Version>3.5.119</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <!-- Include license file in packages -->

--- a/Documentation/release-guide.md
+++ b/Documentation/release-guide.md
@@ -66,6 +66,23 @@ Security issues should be reported via email to security@corewcf.net as describe
 Here are the steps to release a new version:
 
 1. Update to the latest patch version of nuget dependencies
+
+   ```dos
+       dotnet tool install --global dotnet-outdated-tool
+       dotnet outdated -u -vl Minor -inc Microsoft.AspNetCore CoreWCF.sln
+       dotnet outdated -u -vl Minor -inc Microsoft.CodeAnalysis CoreWCF.sln
+       dotnet outdated -u -inc Microsoft.NET CoreWCF.sln
+       dotnet outdated -u -exc Microsoft -exc Nerdbank.GitVersioning CoreWCF.sln
+   ```
+
+   Check and manually update the version of `Nerdbank.GitVersioning` if needed. The version is specified in [Directory.Build.props](/Directory.Build.props).
+
+   ```dos
+       dotnet outdated -inc Nerdbank.GitVersioning CoreWCF.sln
+   ```
+
+   Check the pending changes to make sure the package version updated have been applied correctly.
+
 2. Update the CoreWCF.BuildTools AnalyzerReleases markdown documents if new analyzer rules have been created. Instructions for what changes may need to be made are located [here](https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md).
 3. If any changes were made in steps 1 & 2, create a branch, commit the changes, push to your fork, create a PR and merge the changes. Update your local main branch after the PR has been merged.
 4. Install Nerdbank.GitVersioning
@@ -86,5 +103,11 @@ Here are the steps to release a new version:
 7. Stabilization occurs in the release branch.
 8. Commits should be made in the main branch and are cherry-picked into release/vX.Y if needed.
 9. Build release packages and tag vX.Y.Z from the release/vX.Y branch.
+
+   ```dos
+       git tag -a -m "CoreWCF vX.Y.Z" vX.Y.Z
+       git push upstream tag vX.Y.Z
+   ```
+
 10. Push package and symbol package to NuGet.
 11. Delete the release/vX.Y branch.

--- a/src/CoreWCF.BuildTools/src/AnalyzerReleases.Shipped.md
+++ b/src/CoreWCF.BuildTools/src/AnalyzerReleases.Shipped.md
@@ -23,3 +23,13 @@ COREWCF_0101 | OperationParameterInjectionGenerator | Error | COREWCF_0101_Opera
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
 COREWCF_0102 | OperationParameterInjectionGenerator | Error | COREWCF_0102_OperationParameterInjectionGenerator
+
+## Release 1.3.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+COREWCF_0200 | AuthorizationAttributesAnalyzer | Warning  | COREWCF_0200_DiagnosticDescriptors
+COREWCF_0201 | AuthorizationAttributesAnalyzer | Warning  | COREWCF_0202_DiagnosticDescriptors
+COREWCF_0202 | AuthorizationAttributesAnalyzer | Warning  | COREWCF_0203_DiagnosticDescriptors

--- a/src/CoreWCF.BuildTools/src/AnalyzerReleases.Unshipped.md
+++ b/src/CoreWCF.BuildTools/src/AnalyzerReleases.Unshipped.md
@@ -1,7 +1,1 @@
-﻿### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-COREWCF_0200 | AuthorizationAttributesAnalyzer | Warning  | COREWCF_0200_DiagnosticDescriptors
-COREWCF_0201 | AuthorizationAttributesAnalyzer | Warning  | COREWCF_0202_DiagnosticDescriptors
-COREWCF_0202 | AuthorizationAttributesAnalyzer | Warning  | COREWCF_0203_DiagnosticDescriptors
+﻿

--- a/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn3.11.Tests.csproj
+++ b/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn3.11.Tests.csproj
@@ -23,11 +23,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.11.0" />

--- a/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn3.11.Tests.csproj
+++ b/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn3.11.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn4.0.Tests.csproj
+++ b/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn4.0.Tests.csproj
@@ -22,16 +22,16 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
   </ItemGroup>

--- a/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn4.0.Tests.csproj
+++ b/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn4.0.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF.ConfigurationManager.csproj
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF.ConfigurationManager.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\..\CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />
     <ProjectReference Include="..\..\CoreWCF.WebHttp\src\CoreWCF.WebHttp.csproj" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.ConfigurationManager/tests/CoreWCF.ConfigurationManager.Tests.csproj
+++ b/src/CoreWCF.ConfigurationManager/tests/CoreWCF.ConfigurationManager.Tests.csproj
@@ -8,16 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.9.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -31,12 +31,12 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.31" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.11" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">

--- a/src/CoreWCF.ConfigurationManager/tests/CoreWCF.ConfigurationManager.Tests.csproj
+++ b/src/CoreWCF.ConfigurationManager/tests/CoreWCF.ConfigurationManager.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
@@ -27,11 +27,6 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.31" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/CoreWCF.Http/src/CoreWCF.Http.csproj
+++ b/src/CoreWCF.Http/src/CoreWCF.Http.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -13,7 +13,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -28,7 +28,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
@@ -42,14 +42,14 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.17" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="3.1.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.31" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="3.1.31" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="6.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="6.0.11" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -38,12 +38,6 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.31" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="3.1.31" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">

--- a/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
+++ b/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
@@ -27,11 +27,6 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.31" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">

--- a/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
+++ b/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -31,12 +31,12 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.31" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.11" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">

--- a/src/CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj
+++ b/src/CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
+    <PackageReference Include="System.IO.Pipelines" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />

--- a/src/CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj
+++ b/src/CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.25" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="System.IO.Pipelines" Version="7.0.0" />

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.10.0" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.0" />

--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
@@ -22,10 +22,10 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.23.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens.Saml" Version="6.23.1" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="2.1.6" />
-    <PackageReference Include="System.DirectoryServices" Version="5.0.0" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.1" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+    <PackageReference Include="System.DirectoryServices" Version="7.0.0" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="7.0.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.7.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.23" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
@@ -25,7 +25,7 @@
     <PackageReference Include="System.DirectoryServices" Version="7.0.0" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="7.0.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.7.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
   </ItemGroup>
 

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/CoreWCF.WebHttp/src/CoreWCF.WebHttp.csproj
+++ b/src/CoreWCF.WebHttp/src/CoreWCF.WebHttp.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.6" />
+    <PackageReference Include="System.Text.Json" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\CoreWCF.Http\src\CoreWCF.Http.csproj" />

--- a/src/CoreWCF.WebHttp/tests/CoreWCF.WebHttp.Tests.csproj
+++ b/src/CoreWCF.WebHttp/tests/CoreWCF.WebHttp.Tests.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -18,11 +18,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net472'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Web" />

--- a/src/CoreWCF.WebHttp/tests/CoreWCF.WebHttp.Tests.csproj
+++ b/src/CoreWCF.WebHttp/tests/CoreWCF.WebHttp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/templates/TestStage.yml
+++ b/templates/TestStage.yml
@@ -10,11 +10,6 @@ stages:
   - job: TestRelease
     strategy:
       matrix:
-        Windows_netcore3.1:
-          imageName: 'windows-latest'
-          targetFramework: 'netcoreapp3.1'
-          testArgs: ''
-          additionalDotNetCoreSdk: '3.1.x'
         Windows_net6.0:
           imageName: 'windows-latest'
           targetFramework: 'net6.0'
@@ -30,11 +25,6 @@ stages:
           targetFramework: 'net472'
           testArgs: '--filter Category!=NetCoreOnly'
           additionalDotNetCoreSdk: ''
-        Linux_netcore3.1:
-          imageName: 'ubuntu-latest'
-          targetFramework: 'netcoreapp3.1'
-          testArgs: '--filter Category!=WindowsOnly'
-          additionalDotNetCoreSdk: '3.1.x'
         Linux_net6.0:
           imageName: 'ubuntu-latest'
           targetFramework: 'net6.0'
@@ -97,11 +87,6 @@ stages:
   - job: TestDebug
     strategy:
       matrix:
-        Windows_netcore3.1:
-          imageName: 'windows-latest'
-          targetFramework: 'netcoreapp3.1'
-          testArgs: ''       
-          additionalDotNetCoreSdk: '3.1.x'
         Windows_net6.0:
           imageName: 'windows-latest'
           targetFramework: 'net6.0'
@@ -117,11 +102,6 @@ stages:
           targetFramework: 'net472'
           testArgs: '--filter Category!=NetCoreOnly'
           additionalDotNetCoreSdk: ''
-        Linux_netcore3.1:
-          imageName: 'ubuntu-latest'
-          targetFramework: 'netcoreapp3.1'
-          testArgs: '--filter Category!=WindowsOnly'
-          additionalDotNetCoreSdk: '3.1.x'
         Linux_net6.0:
           imageName: 'ubuntu-latest'
           targetFramework: 'net6.0'

--- a/templates/TestTemplatesStage.yml
+++ b/templates/TestTemplatesStage.yml
@@ -30,13 +30,6 @@ stages:
         path: $(System.DefaultWorkingDirectory)/bin
 
     - task: UseDotNet@2
-      displayName: 'Use .NET Core 3.1 sdk'
-      inputs:
-        packageType: sdk
-        version: '3.1.x'
-        installationPath: $(Agent.ToolsDirectory)/dotnet
-
-    - task: UseDotNet@2
       displayName: 'Use .NET 6 sdk'
       inputs:
         packageType: sdk


### PR DESCRIPTION
Also includes:
* Improve release guide
* Removing netcoreapp3.1 tests
* Update AnalyzerReleases for new rules

We can't update System.Security.Cryptography.Xml to 7.0.0 due to a bug causing problems when running on .NET Framework. See dotnet/runtime#78652