### PR TITLE
Add property UseSynchronizationContext to class ServiceBehaviorAttribute

### DIFF
--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.10.0" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="Xunit.StaFact" Version="1.1.11" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/CoreWCF.NetTcp/tests/ServiceBehaviorUseSynchronizationContextAsyncTests.cs
+++ b/src/CoreWCF.NetTcp/tests/ServiceBehaviorUseSynchronizationContextAsyncTests.cs
@@ -1,0 +1,211 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ServiceModel.Channels;
+using System.Threading;
+using System.Threading.Tasks;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.NetTcp.Tests
+{
+    /// <summary>
+    /// Verifies the effect of <see cref="ServiceBehaviorAttribute.UseSynchronizationContext"/> on asynchronous operations.
+    /// </summary>
+    public class ServiceBehaviorUseSynchronizationContextAsyncTests
+    {
+        public const string RelativeAddress = "/nettcp.svc/UseSynchronizationContextAsync";
+        private readonly ITestOutputHelper _output;
+
+        public ServiceBehaviorUseSynchronizationContextAsyncTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        /// <summary>
+        /// This test exists only to demonstrate what the UIFact attribute does.
+        /// </summary>
+        [UIFact]
+        public async Task UIFactTestAsync()
+        {
+            int originalThread = Environment.CurrentManagedThreadId;
+            await Task.Yield();
+            Assert.Equal(originalThread, Environment.CurrentManagedThreadId);
+        }
+
+        [UIFact]
+        public async Task UseSynchronizationContextTrueWithSynchronizationContextTestAsync()
+        {
+            SynchronizationContext orgSynchronizationContext = SynchronizationContext.Current;
+            Assert.NotNull(orgSynchronizationContext); // Set by the UIFact attribute
+            int orgManagedThreadId = Environment.CurrentManagedThreadId;
+
+            AsyncServiceWithUseSynchronizationContextTrue serviceInstance =
+                await RunAsync<AsyncServiceWithUseSynchronizationContextTrue>();
+
+            Assert.Same(orgSynchronizationContext, serviceInstance.SynchronizationContextWhenCreated);
+            Assert.Same(orgSynchronizationContext, serviceInstance.SynchronizationContextWhenCalled);
+            Assert.Equal(orgManagedThreadId, serviceInstance.ManagedThreadIdWhenCalled);
+        }
+
+        [Fact]
+        public async Task UseSynchronizationContextTrueWithoutSynchronizationContextTestAsync()
+        {
+            await RunWithoutSynchronizationContextAsync(async () =>
+            {
+                Assert.Null(SynchronizationContext.Current);
+
+                AsyncServiceWithUseSynchronizationContextTrue serviceInstance =
+                    await RunAsync<AsyncServiceWithUseSynchronizationContextTrue>();
+
+                Assert.Null(serviceInstance.SynchronizationContextWhenCreated);
+                Assert.Null(serviceInstance.SynchronizationContextWhenCalled);
+                // NOTE: In this case, the original thread *can* be used when running the service,
+                // so we can't verify that it differs.
+            });
+        }
+
+        [UIFact]
+        public async Task UseSynchronizationContextFalseWithSynchronizationContextTestAsync()
+        {
+            Assert.NotNull(SynchronizationContext.Current); // Set by the UIFact attribute
+
+            AsyncServiceWithUseSynchronizationContextFalse serviceInstance =
+                await RunAsync<AsyncServiceWithUseSynchronizationContextFalse>();
+
+            Assert.Null(serviceInstance.SynchronizationContextWhenCreated);
+            Assert.Null(serviceInstance.SynchronizationContextWhenCalled);
+            // NOTE: In this case, the original thread *can* be used when running the service,
+            // so we can't verify that it differs.
+        }
+
+        [Fact]
+        public async Task UseSynchronizationContextFalseWithoutSynchronizationContextTestAsync()
+        {
+            await RunWithoutSynchronizationContextAsync(async () =>
+            {
+                Assert.Null(SynchronizationContext.Current);
+
+                AsyncServiceWithUseSynchronizationContextFalse serviceInstance =
+                    await RunAsync<AsyncServiceWithUseSynchronizationContextFalse>();
+
+                Assert.Null(serviceInstance.SynchronizationContextWhenCreated);
+                Assert.Null(serviceInstance.SynchronizationContextWhenCalled);
+                // NOTE: In this case, the original thread *can* be used when running the service,
+                // so we can't verify that it differs.
+            });
+        }
+
+        private static async Task RunWithoutSynchronizationContextAsync(Func<Task> action)
+        {
+            SynchronizationContext orgSynchronizationContext = SynchronizationContext.Current;
+            Assert.NotNull(orgSynchronizationContext); // Set by the Fact attribute
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            try
+            {
+                await action();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(orgSynchronizationContext);
+            }
+        }
+
+        private async Task<TService> RunAsync<TService>()
+            where TService : class
+        {
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup<TService>>(_output).Build();
+            using (host)
+            {
+                System.ServiceModel.ChannelFactory<IAsyncService> factory = null;
+                IAsyncService channel = null;
+                host.Start();
+                try
+                {
+                    System.ServiceModel.NetTcpBinding binding = ClientHelper.GetBufferedModeBinding();
+                    System.ServiceModel.EndpointAddress remoteAddress = new(host.GetNetTcpAddressInUse() + RelativeAddress);
+                    factory = new System.ServiceModel.ChannelFactory<IAsyncService>(binding, remoteAddress);
+                    channel = factory.CreateChannel();
+                    ((IChannel)channel).Open();
+                    await channel.DoStuffAsync();
+                    ((IChannel)channel).Close();
+                    factory.Close();
+                }
+                finally
+                {
+                    ServiceHelper.CloseServiceModelObjects((IChannel)channel, factory);
+                }
+
+                TService serviceInstance = host.Services.GetRequiredService<TService>();
+                return serviceInstance;
+            }
+        }
+
+        private class Startup<TService>
+            where TService : class
+        {
+            public static void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+                services.AddSingleton<TService>();
+            }
+
+            public static void Configure(IApplicationBuilder app)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<TService>();
+                    builder.AddServiceEndpoint<TService, IAsyncService>(
+                        new NetTcpBinding(SecurityMode.None),
+                        RelativeAddress);
+                });
+            }
+        }
+
+        [System.ServiceModel.ServiceContract]
+        private interface IAsyncService
+        {
+            [System.ServiceModel.OperationContract]
+            Task DoStuffAsync();
+        }
+
+        private abstract class AsyncServiceBase : IAsyncService
+        {
+            protected AsyncServiceBase()
+            {
+                SynchronizationContextWhenCreated = SynchronizationContext.Current;
+            }
+
+            public SynchronizationContext SynchronizationContextWhenCreated { get; private set; }
+
+            public SynchronizationContext SynchronizationContextWhenCalled { get; private set; }
+
+            public int? ManagedThreadIdWhenCalled { get; private set; }
+
+            public async Task DoStuffAsync()
+            {
+                SynchronizationContextWhenCalled = SynchronizationContext.Current;
+                ManagedThreadIdWhenCalled = Environment.CurrentManagedThreadId;
+                await Task.Yield();
+                return;
+            }
+        }
+
+        [ServiceBehavior(UseSynchronizationContext = true)]
+        private class AsyncServiceWithUseSynchronizationContextTrue : AsyncServiceBase
+        {
+        }
+
+        [ServiceBehavior(UseSynchronizationContext = false)]
+        private class AsyncServiceWithUseSynchronizationContextFalse : AsyncServiceBase
+        {
+        }
+    }
+}

--- a/src/CoreWCF.NetTcp/tests/ServiceBehaviorUseSynchronizationContextSyncTests.cs
+++ b/src/CoreWCF.NetTcp/tests/ServiceBehaviorUseSynchronizationContextSyncTests.cs
@@ -1,0 +1,219 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ServiceModel.Channels;
+using System.Threading.Tasks;
+using System.Threading;
+using Contract;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.NetTcp.Tests
+{
+    /// <summary>
+    /// Verifies the effect of <see cref="ServiceBehaviorAttribute.UseSynchronizationContext"/> on synchronous operations.
+    /// </summary>
+    public class ServiceBehaviorUseSynchronizationContextSyncTests
+    {
+        public const string RelativeAddress = "/nettcp.svc/UseSynchronizationContextSync";
+
+        private readonly ITestOutputHelper _output;
+
+        public ServiceBehaviorUseSynchronizationContextSyncTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        /// <summary>
+        /// This test exists only to demonstrate what the UIFact attribute does.
+        /// </summary>
+        [UIFact]
+        public async Task UIFactTestAsync()
+        {
+            int originalThread = Environment.CurrentManagedThreadId;
+            await Task.Yield();
+            Assert.Equal(originalThread, Environment.CurrentManagedThreadId);
+        }
+
+        [UIFact]
+        public async Task UseSynchronizationContextTrueWithSynchronizationContextTestAsync()
+        {
+            SynchronizationContext orgSynchronizationContext = SynchronizationContext.Current;
+            Assert.NotNull(orgSynchronizationContext); // Set by the UIFact attribute
+            int orgManagedThreadId = Environment.CurrentManagedThreadId;
+
+            SyncServiceWithUseSynchronizationContextTrue serviceInstance =
+                await RunAsync<SyncServiceWithUseSynchronizationContextTrue>(runCallOnThreadPool: true);
+
+            Assert.Same(orgSynchronizationContext, serviceInstance.SynchronizationContextWhenCreated);
+            Assert.Same(orgSynchronizationContext, serviceInstance.SynchronizationContextWhenCalled);
+            Assert.Equal(orgManagedThreadId, serviceInstance.ManagedThreadIdWhenCalled);
+        }
+
+        [Fact]
+        public async Task UseSynchronizationContextTrueWithoutSynchronizationContextTestAsync()
+        {
+            await RunWithoutSynchronizationContextAsync(async () =>
+            {
+                Assert.Null(SynchronizationContext.Current);
+                int orgManagedThreadId = Environment.CurrentManagedThreadId;
+
+                SyncServiceWithUseSynchronizationContextTrue serviceInstance =
+                    await RunAsync<SyncServiceWithUseSynchronizationContextTrue>(runCallOnThreadPool: false);
+
+                Assert.Null(serviceInstance.SynchronizationContextWhenCreated);
+                Assert.Null(serviceInstance.SynchronizationContextWhenCalled);
+                Assert.NotEqual(orgManagedThreadId, serviceInstance.ManagedThreadIdWhenCalled);
+            });
+        }
+
+        [UIFact]
+        public async Task UseSynchronizationContextFalseWithSynchronizationContextTestAsync()
+        {
+            SynchronizationContext orgSynchronizationContext = SynchronizationContext.Current;
+            Assert.NotNull(orgSynchronizationContext); // Set by the UIFact attribute
+            int orgManagedThreadId = Environment.CurrentManagedThreadId;
+
+            SyncServiceWithUseSynchronizationContextFalse serviceInstance =
+                await RunAsync<SyncServiceWithUseSynchronizationContextFalse>(runCallOnThreadPool: false);
+
+            Assert.Null(serviceInstance.SynchronizationContextWhenCreated);
+            Assert.Null(serviceInstance.SynchronizationContextWhenCalled);
+            Assert.NotEqual(orgManagedThreadId, serviceInstance.ManagedThreadIdWhenCalled);
+        }
+
+        [Fact]
+        public async Task UseSynchronizationContextFalseWithoutSynchronizationContextTestAsync()
+        {
+            await RunWithoutSynchronizationContextAsync(async () =>
+            {
+                Assert.Null(SynchronizationContext.Current);
+                int orgManagedThreadId = Environment.CurrentManagedThreadId;
+
+                SyncServiceWithUseSynchronizationContextFalse serviceInstance =
+                    await RunAsync<SyncServiceWithUseSynchronizationContextFalse>(runCallOnThreadPool: false);
+
+                Assert.Null(serviceInstance.SynchronizationContextWhenCreated);
+                Assert.Null(serviceInstance.SynchronizationContextWhenCalled);
+                Assert.NotEqual(orgManagedThreadId, serviceInstance.ManagedThreadIdWhenCalled);
+            });
+        }
+
+        private static async Task RunWithoutSynchronizationContextAsync(Func<Task> action)
+        {
+            SynchronizationContext orgSynchronizationContext = SynchronizationContext.Current;
+            Assert.NotNull(orgSynchronizationContext); // Set by the Fact attribute
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            try
+            {
+                await action();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(orgSynchronizationContext);
+            }
+        }
+
+        private async Task<TService> RunAsync<TService>(bool runCallOnThreadPool)
+            where TService : class
+        {
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup<TService>>(_output).Build();
+            using (host)
+            {
+                System.ServiceModel.ChannelFactory<ISyncService> factory = null;
+                ISyncService channel = null;
+                host.Start();
+                try
+                {
+                    System.ServiceModel.NetTcpBinding binding = ClientHelper.GetBufferedModeBinding();
+                    System.ServiceModel.EndpointAddress remoteAddress = new(host.GetNetTcpAddressInUse() + RelativeAddress);
+                    factory = new System.ServiceModel.ChannelFactory<ISyncService>(binding, remoteAddress);
+                    channel = factory.CreateChannel();
+                    ((IChannel)channel).Open();
+                    if (runCallOnThreadPool)
+                    {
+                        await Task.Run(() => channel.DoStuff());
+                    }
+                    else
+                    {
+                        channel.DoStuff();
+                    }
+                    ((IChannel)channel).Close();
+                    factory.Close();
+
+                    TService serviceInstance = host.Services.GetRequiredService<TService>();
+                    return serviceInstance;
+                }
+                finally
+                {
+                    ServiceHelper.CloseServiceModelObjects((IChannel)channel, factory);
+                }
+            }
+        }
+
+        private class Startup<TService>
+            where TService : class
+        {
+            public static void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+                services.AddSingleton<TService>();
+            }
+
+            public static void Configure(IApplicationBuilder app)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<TService>();
+                    builder.AddServiceEndpoint<TService, ISyncService>(
+                        new NetTcpBinding(SecurityMode.None),
+                        RelativeAddress);
+                });
+            }
+        }
+
+        [System.ServiceModel.ServiceContract]
+        private interface ISyncService
+        {
+            [System.ServiceModel.OperationContract]
+            void DoStuff();
+        }
+
+        private class SyncServiceBase : ISyncService
+        {
+            protected SyncServiceBase()
+            {
+                SynchronizationContextWhenCreated = SynchronizationContext.Current;
+            }
+
+            public SynchronizationContext SynchronizationContextWhenCreated { get; private set; }
+
+            public SynchronizationContext SynchronizationContextWhenCalled { get; private set; }
+
+            public int? ManagedThreadIdWhenCalled { get; private set; }
+
+            public void DoStuff()
+            {
+                SynchronizationContextWhenCalled = SynchronizationContext.Current;
+                ManagedThreadIdWhenCalled = Environment.CurrentManagedThreadId;
+            }
+        }
+
+        [ServiceBehavior(UseSynchronizationContext = true)]
+        private class SyncServiceWithUseSynchronizationContextTrue : SyncServiceBase
+        {
+        }
+
+        [ServiceBehavior(UseSynchronizationContext = false)]
+        private class SyncServiceWithUseSynchronizationContextFalse : SyncServiceBase
+        {
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/ServiceBehaviorAttribute.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/ServiceBehaviorAttribute.cs
@@ -45,7 +45,7 @@ namespace CoreWCF
         private readonly bool _automaticSessionShutdown = true;
         private IInstanceProvider _instanceProvider = null;
         private IServiceProvider _serviceProvider = null;
-        private readonly bool _useSynchronizationContext = true;
+        private bool _useSynchronizationContext = true;
         private AddressFilterMode _addressFilterMode = AddressFilterMode.Exact;
 
         [DefaultValue(null)]
@@ -126,6 +126,13 @@ namespace CoreWCF
 
                 _instanceMode = value;
             }
+        }
+
+        [DefaultValue(true)]
+        public bool UseSynchronizationContext
+        {
+            get => _useSynchronizationContext;
+            set => _useSynchronizationContext = value;
         }
 
         internal IServiceProvider ServicePovider

--- a/src/CoreWCF.Primitives/tests/ServiceBehaviorUseSynchronizationContextTests.cs
+++ b/src/CoreWCF.Primitives/tests/ServiceBehaviorUseSynchronizationContextTests.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace CoreWCF.Primitives.Tests
+{
+    public static class ServiceBehaviorUseSynchronizationContextTests
+    {
+        [Fact]
+        public static void DefaultValueTest()
+        {
+            ServiceBehaviorAttribute attribute = new ServiceBehaviorAttribute();
+            Assert.True(attribute.UseSynchronizationContext);
+        }
+    }
+}


### PR DESCRIPTION
An attempt to handle #668.

First off, I am new to this project, so I am prepared for some re-work. Don't feel bad if you have a lot of comments :-)

I hope that I have understood the actual change needed, which in that case was trivial, but I am feeling unsure of how to best test this. I have provided a first attempt using nuget package _Xunit.StaFact_ to simulate a UI synchronization context, both for synchronous and asynchronous operations.

If the general test idea seems ok, please look extra carefully at _UseSynchronizationContextFalseWithSynchronizationContextTestAsync_ in both test classes, since the behavior differs between the synchronous and asynchronous cases. At that level of detail, I don't know what the expected behavior actually is. I have written the asserts based on a combination of what my gut says and what actually happens on my machine, so some asserts might be checking unwanted behavior. I can try to replicate the tests using the old WCF if needed, but have not done so yet.

I also want to say that I have seen some old tests failing occasionally in Visual Studio due to "address already in use"-problems when running all tests. Since I am new here I don't know if that happens or if I have done something bad in this PR.