### PR TITLE
Fix test that's timing out on .NET Framework

### DIFF
--- a/src/CoreWCF.Http/tests/AsyncNetAdoptionTests.cs
+++ b/src/CoreWCF.Http/tests/AsyncNetAdoptionTests.cs
@@ -45,6 +45,9 @@ namespace BasicHttp
         [InlineData(1000)]
         public async Task OneWayPatternTest_Parallel(int callCount)
         {
+            // Does nothing on .NET [Core], but enables .NET Framework to have sufficient concurrency
+            // to make all the requests
+            System.Net.ServicePointManager.DefaultConnectionLimit = callCount;
             var inputs = Enumerable.Range(0, callCount).Select(x => x.ToString()).ToArray();
             var host = ServiceHelper.CreateWebHostBuilder<AsyncNetAdoptionOneWayServiceStartup>(_output).Build();
             using (host)

--- a/src/CoreWCF.Http/tests/AsyncNetAdoptionTests.cs
+++ b/src/CoreWCF.Http/tests/AsyncNetAdoptionTests.cs
@@ -47,26 +47,34 @@ namespace BasicHttp
         {
             // Does nothing on .NET [Core], but enables .NET Framework to have sufficient concurrency
             // to make all the requests
+            int previousConnectionLimit = System.Net.ServicePointManager.DefaultConnectionLimit;
             System.Net.ServicePointManager.DefaultConnectionLimit = callCount;
-            var inputs = Enumerable.Range(0, callCount).Select(x => x.ToString()).ToArray();
-            var host = ServiceHelper.CreateWebHostBuilder<AsyncNetAdoptionOneWayServiceStartup>(_output).Build();
-            using (host)
+            try
             {
-                host.Start();
-                CountdownEvent countdownEvent = host.Services.GetService<CountdownEvent>();
-                countdownEvent.AddCount(inputs.Length - 1);
-                var httpBinding = ClientHelper.GetBufferedModeBinding();
-                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IOneWayContract>(httpBinding,
-                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/OneWayPatternTest/basichttp.svc")));
-                var channel = factory.CreateChannel();
-                var tasks = inputs.AsParallel().Select(x => channel.OneWay(x)).ToList();
-                await Task.WhenAll(tasks);
-                countdownEvent.Wait(TimeSpan.FromSeconds(30));
-                var bag = host.Services.GetService<ConcurrentBag<string>>();
-                foreach (string input in inputs)
+                var inputs = Enumerable.Range(0, callCount).Select(x => x.ToString()).ToArray();
+                var host = ServiceHelper.CreateWebHostBuilder<AsyncNetAdoptionOneWayServiceStartup>(_output).Build();
+                using (host)
                 {
-                    Assert.Contains(input, bag);
+                    host.Start();
+                    CountdownEvent countdownEvent = host.Services.GetService<CountdownEvent>();
+                    countdownEvent.AddCount(inputs.Length - 1);
+                    var httpBinding = ClientHelper.GetBufferedModeBinding();
+                    var factory = new System.ServiceModel.ChannelFactory<ClientContract.IOneWayContract>(httpBinding,
+                        new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/OneWayPatternTest/basichttp.svc")));
+                    var channel = factory.CreateChannel();
+                    var tasks = inputs.AsParallel().Select(x => channel.OneWay(x)).ToList();
+                    await Task.WhenAll(tasks);
+                    countdownEvent.Wait(TimeSpan.FromSeconds(30));
+                    var bag = host.Services.GetService<ConcurrentBag<string>>();
+                    foreach (string input in inputs)
+                    {
+                        Assert.Contains(input, bag);
+                    }
                 }
+            }
+            finally
+            {
+                System.Net.ServicePointManager.DefaultConnectionLimit = previousConnectionLimit;
             }
         }
 


### PR DESCRIPTION
AsyncNetAdoptionTests.OneWayPatternTest_Parallel is timing out on .NET Framework. Under the hood on .NET Framework, HttpWebRequest uses ServicePointManager to manage connection pooling. The default number of simultaneous connections to a single endpoint is 2, which means the test which is executing 1000 requests in parallel can only be concurrently sending 2 at a time. This causes the test to fail on .NET Framework due to some of the requests taking too long to obtain a free connection in the pool. This should make the test stable on .NET Framework now.