### PR TITLE
Fix State transitions for AspNetCoreReplyChannel

### DIFF
--- a/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/AspNetCoreReplyChannel.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml;
 using CoreWCF.Configuration;
-using CoreWCF.Runtime;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -28,7 +26,7 @@ namespace CoreWCF.Channels
 
         // TODO: Might want to do something a bit smarter with the state and actually have a concept of opening and closing to enable event handlers to be
         // connected and fire them when the service is shutting down.
-        public CommunicationState State => CommunicationState.Created;
+        public CommunicationState State { get; private set; } = CommunicationState.Created;
 
         public IServiceChannelDispatcher ChannelDispatcher { get; set; }
 
@@ -42,15 +40,21 @@ namespace CoreWCF.Channels
 
         public void Abort()
         {
+            // Can skip Closing state as there's nothing to do during the Abort call
+            State = CommunicationState.Closed;
         }
 
         public Task CloseAsync()
         {
+            // Can skip Closing state as there's nothing to do during the Close call
+            State = CommunicationState.Closed;
             return Task.CompletedTask;
         }
 
         public Task CloseAsync(CancellationToken token)
         {
+            // Can skip Closing state as there's nothing to do during the Close call
+            State = CommunicationState.Closed;
             return Task.CompletedTask;
         }
 
@@ -61,11 +65,15 @@ namespace CoreWCF.Channels
 
         public Task OpenAsync()
         {
+            // Can skip Opening state as there's nothing to do during the Open call
+            State = CommunicationState.Opened;
             return Task.CompletedTask;
         }
 
         public Task OpenAsync(CancellationToken token)
         {
+            // Can skip Opening state as there's nothing to do during the Open call
+            State = CommunicationState.Opened;
             return Task.CompletedTask;
         }
 

--- a/src/CoreWCF.Http/tests/ExtensibilityFailureTests.cs
+++ b/src/CoreWCF.Http/tests/ExtensibilityFailureTests.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CoreWCF.Channels;
+using CoreWCF.Configuration;
+using CoreWCF.Description;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Http.Tests
+{
+    public class ExtensibilityFailureTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ExtensibilityFailureTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task ThrowingExtensibilityReturnsFaultAsync()
+        {
+            string testString = new('a', 3000);
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                await host.StartAsync();
+                System.ServiceModel.BasicHttpBinding httpBinding = ClientHelper.GetBufferedModeBinding();
+                var factory = new System.ServiceModel.ChannelFactory<ClientContract.IEchoService>(httpBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri("http://localhost:8080/BasicWcfService/basichttp.svc")));
+                ClientContract.IEchoService channel = factory.CreateChannel();
+                var ex = Assert.Throws<System.ServiceModel.FaultException<System.ServiceModel.ExceptionDetail>>(() => channel.EchoString(testString));
+                Assert.Equal("InternalServiceFault", ex.Code.Name);
+                Assert.Equal("http://schemas.microsoft.com/net/2005/12/windowscommunicationfoundation/dispatcher", ex.Code.Namespace);
+                await host.StopAsync();
+            }
+            // Work around bug in aspnetcore where they can write to the ILogger in the Heartbeat timer loop
+            // The implementation of Heartbeat as of April 2023 runs it every 1 second. Adding a delay slightly
+            // longer than 1 second to allow it to run and log a failure before the test ends. See aspnetcore
+            // issue for more details: https://github.com/dotnet/aspnetcore/issues/47577
+            await Task.Delay(1100);
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+                services.AddSingleton<IServiceBehavior, ThrowingOperationSelectorBehavior>();
+            }
+
+            public void Configure(IApplicationBuilder app)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.EchoService>();
+                    builder.AddServiceEndpoint<Services.EchoService, ServiceContract.IEchoService>(new CoreWCF.BasicHttpBinding(), "/BasicWcfService/basichttp.svc");
+                });
+            }
+        }
+
+        internal class ThrowingOperationSelectorBehavior : IServiceBehavior
+        {
+            public void AddBindingParameters(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase, Collection<ServiceEndpoint> endpoints, BindingParameterCollection bindingParameters) { }
+            public void ApplyDispatchBehavior(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
+            {
+                foreach(var cdb in serviceHostBase.ChannelDispatchers)
+                {
+                    var cd = cdb as Dispatcher.ChannelDispatcher;
+                    foreach(var endpoint in cd.Endpoints)
+                    {
+                        endpoint.DispatchRuntime.OperationSelector = new ThrowingOperationSelector();
+                    }
+                }
+            }
+            public void Validate(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase) { }
+
+            private class ThrowingOperationSelector : Dispatcher.IDispatchOperationSelector
+            {
+                public string SelectOperation(ref Message message)
+                {
+                    throw new Exception("failed");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Addresses #993, I wasn't able to work out the conditions where we would hit this bug. I suspect it might be in things like an exception thrown in extensibility such as a message inspector, but I'm not sure.