### PR TITLE
Use only parameter type to compare user provided impl and operation contract in source gen

### DIFF
--- a/src/CoreWCF.BuildTools/src/Extensions.cs
+++ b/src/CoreWCF.BuildTools/src/Extensions.cs
@@ -45,8 +45,7 @@ namespace CoreWCF.BuildTools
     internal static class ParameterSymbolExtensions
     {
         public static bool IsMatchingParameter(this IParameterSymbol symbol, IParameterSymbol parameterSymbol)
-            => SymbolEqualityComparer.Default.Equals(symbol.Type, parameterSymbol.Type)
-                && symbol.Name == parameterSymbol.Name;
+            => SymbolEqualityComparer.Default.Equals(symbol.Type, parameterSymbol.Type);
     }
 
     internal static class SymbolExtensions

--- a/src/CoreWCF.BuildTools/src/Extensions.cs
+++ b/src/CoreWCF.BuildTools/src/Extensions.cs
@@ -22,22 +22,19 @@ namespace CoreWCF.BuildTools
             }
 
             var parameters = methodSymbol.Parameters;
-            foreach (IParameterSymbol parameterSymbol in userProvidedMethodSymbol.Parameters)
+
+            for (int i = 0,j = 0; i < userProvidedMethodSymbol.Parameters.Length; i++)
             {
+                IParameterSymbol parameterSymbol = userProvidedMethodSymbol.Parameters[i];
                 if (parameterSymbol.GetOneAttributeOf(coreWCFInjectedAttribute, fromServicesAttribute) is not null)
                 {
                     continue;
                 }
 
-                foreach (IParameterSymbol parameter in parameters)
+                if (parameterSymbol.IsMatchingParameter(parameters[j]))
                 {
-                    if (parameterSymbol.IsMatchingParameter(parameter))
-                    {
-                        parameterFound++;
-                        break;
-                    }
-
-                    return false;
+                    j++;
+                    parameterFound++;
                 }
             }
 

--- a/src/CoreWCF.BuildTools/src/OperationParameterInjectionGenerator.Emitter.cs
+++ b/src/CoreWCF.BuildTools/src/OperationParameterInjectionGenerator.Emitter.cs
@@ -243,7 +243,7 @@ namespace {operationContractSpec.ServiceContractImplementation!.ContainingNamesp
                 void AppendInvokeUserProvidedImplementation()
                 {
                     _builder.Append($"{indentor}{@return}{@await}{operationContractSpec.UserProvidedOperationContractImplementation.Name}(");
-                    for (int i = 0; i < operationContractSpec.UserProvidedOperationContractImplementation.Parameters.Length; i++)
+                    for (int i = 0,j = 0; i < operationContractSpec.UserProvidedOperationContractImplementation.Parameters.Length; i++)
                     {
                         IParameterSymbol parameter = operationContractSpec.UserProvidedOperationContractImplementation.Parameters[i];
                         if (i != 0)
@@ -257,12 +257,14 @@ namespace {operationContractSpec.ServiceContractImplementation!.ContainingNamesp
                         }
                         else
                         {
-                            _builder.Append(parameter.RefKind switch
+                            IParameterSymbol originalParameter = operationContractSpec.MissingOperationContract.Parameters[j];
+                            _builder.Append(originalParameter.RefKind switch
                             {
-                                RefKind.Ref => $"ref {parameter.Name}",
-                                RefKind.Out => $"out {parameter.Name}",
-                                _ => parameter.Name,
+                                RefKind.Ref => $"ref {originalParameter.Name}",
+                                RefKind.Out => $"out {originalParameter.Name}",
+                                _ => originalParameter.Name,
                             });
+                            j++;
                         }
                     }
                     _builder.AppendLine(");");


### PR DESCRIPTION
Fixes #1029 