### PR TITLE
Add net8.0 UT and keyed by service type ServiceBehavior injection support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <SourceDir>$(ProjectDir)src/</SourceDir>
     <ConfigPathSegment>Debug</ConfigPathSegment>
     <ConfigPathSegment Condition="'$(Configuration)'!=''">$(Configuration)</ConfigPathSegment>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <!-- Set up some common paths -->
@@ -26,6 +26,13 @@
     <IsTemplatesProject>$(MSBuildProjectName.Contains(`Templates`))</IsTemplatesProject>
     <IncludeCommonCode Condition="!($(IsTestProject) OR $(IsSampleProject) OR $(IsBuildToolsProject) OR $(IsTemplatesProject) OR $(IsClientProject))">true</IncludeCommonCode>
     <ReferenceCommonTestProject Condition="($(IsTestProject) AND !($(IsBuildToolsProject)) AND !($(IsTemplatesProject)) AND !($(IsClientProject)))">true</ReferenceCommonTestProject>
+  </PropertyGroup>
+
+  <!-- UT -->
+  <PropertyGroup>
+    <TestTargetFrameworks>net6.0;net7.0;net8.0</TestTargetFrameworks>
+    <TestTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TestTargetFrameworks);net472</TestTargetFrameworks>
+    <DotNetVersion>$(TargetFramework.Replace('net', ''))</DotNetVersion>
   </PropertyGroup>
 
   <!-- UT concurrency -->

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -12,7 +12,7 @@ trigger:
 pr: none
 
 variables:
-  _solution: 'src/CoreWCF.sln'
+  _solutions: 'src/*.sln'
   _libraryProjects: 'src/CoreWCF.*/src/CoreWCF.*.csproj'
   _testProjects: |
     **/CoreWCF.*.Tests.csproj
@@ -21,20 +21,18 @@ variables:
 stages:
 - template: templates/BuildStage.yml
   parameters:
-    buildProjects: $(_libraryProjects)
+    solutions: $(_solutions)
 
 - template: templates/TestStage.yml
   parameters:
     testProjects: $(_testProjects)
 
 - template: templates/TestTemplatesStage.yml
-  parameters:
-    libraryProjects: $(_libraryProjects)
 
 - template: templates/CodeAnalysis.yml
   parameters:
+    solutions: $(_solutions)
     testProjects: $(_testProjects)
-    solution: $(_solution)
 
 - template: templates/PackStage.yml
   parameters:

--- a/azure-pipelines-templates.yml
+++ b/azure-pipelines-templates.yml
@@ -11,15 +11,13 @@ pr:
     - src/CoreWCF.Templates/
 
 variables:
-  _solution: src/CoreWCF.Templates.sln
+  _solutions: src/CoreWCFTemplates.sln
   _libraryProjects: src/CoreWCF.Templates/src/CoreWCF.Templates.csproj
   _testProjects: src/CoreWCF.Templates.Tests.csproj
 
 stages:
 - template: templates/BuildStage.yml
   parameters:
-    buildProjects: $(_libraryProjects)
+    solutions: $(_solutions)
 
 - template: templates/TestTemplatesStage.yml
-  parameters:
-    libraryProjects: $(_libraryProjects)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,10 +13,7 @@ pr:
     - templates/TestTemplatesStage.yml
 
 variables:
-  _solution: src/CoreWCF.sln
-  _libraryProjects: |
-    src/CoreWCF.*/src/CoreWCF.*.csproj
-    !src/CoreWCF.Templates/src/CoreWCF.Templates.csproj
+  _solutions: src/CoreWCF.sln
   _testProjects: |
     **/CoreWCF.*.Tests.csproj
     !**/CoreWCF.Templates.Tests.csproj
@@ -24,7 +21,7 @@ variables:
 stages:
 - template: templates/BuildStage.yml
   parameters:
-    buildProjects: $(_libraryProjects)
+    solutions: $(_solutions)
 
 - template: templates/TestStage.yml
   parameters:
@@ -32,5 +29,5 @@ stages:
 
 - template: templates/CodeAnalysis.yml
   parameters:
+    solutions: $(_solutions)
     testProjects: $(_testProjects)
-    solution: $(_solution)

--- a/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn3.11.Tests.csproj
+++ b/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn3.11.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn4.0.Tests.csproj
+++ b/src/CoreWCF.BuildTools/tests/CoreWCF.BuildTools.Roslyn4.0.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/CoreWCF.ConfigurationManager/tests/CoreWCF.ConfigurationManager.Tests.csproj
+++ b/src/CoreWCF.ConfigurationManager/tests/CoreWCF.ConfigurationManager.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -23,20 +22,15 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netcoreapp2.1' ">
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)'!='net472'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.24" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(DotNetVersion).*-*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.ConfigurationManager/tests/CoreWCF.ConfigurationManager.Tests.csproj
+++ b/src/CoreWCF.ConfigurationManager/tests/CoreWCF.ConfigurationManager.Tests.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)'!='net472'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(DotNetVersion).*-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(DotNetVersion).*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.ConfigurationManager/tests/CustomBindingTests.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/CustomBindingTests.cs
@@ -28,9 +28,9 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}""
                          openTimeout=""{expectedDefaultTimeout:g}""
@@ -38,8 +38,8 @@ namespace CoreWCF.ConfigurationManager.Tests
                          sendTimeout=""{expectedDefaultTimeout:g}""
                          receiveTimeout=""{expectedReceiveTimeout:g}"">
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -69,14 +69,14 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -122,9 +122,9 @@ namespace CoreWCF.ConfigurationManager.Tests
             MessageVersion expectedMessageVersion = MessageVersion.Soap11;
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <textMessageEncoding maxReadPoolSize=""{expectedMaxReadPoolSize}""
@@ -134,8 +134,8 @@ namespace CoreWCF.ConfigurationManager.Tests
                         <readerQuotas maxDepth=""{expectedMaxDepth}"" />
                     </textMessageEncoding>
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -169,15 +169,15 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <textMessageEncoding />
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -215,9 +215,9 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <binaryMessageEncoding maxReadPoolSize=""{expectedMaxReadPoolSize}""
@@ -227,8 +227,8 @@ namespace CoreWCF.ConfigurationManager.Tests
                         <readerQuotas maxDepth=""{expectedMaxDepth}"" />
                     </binaryMessageEncoding>
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -262,15 +262,15 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <binaryMessageEncoding />
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -308,9 +308,9 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <mtomMessageEncoding maxReadPoolSize=""{expectedMaxReadPoolSize}""
@@ -320,8 +320,8 @@ namespace CoreWCF.ConfigurationManager.Tests
                         <readerQuotas maxDepth=""{expectedMaxDepth}"" />
                     </mtomMessageEncoding>
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -355,15 +355,15 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <mtomMessageEncoding />
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -403,16 +403,16 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <httpTransport maxReceivedMessageSize=""{expectedMaxReceivedMessageSize}""
                                    maxBufferSize=""{expectedMaxBufferSize}""/>
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -444,15 +444,15 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <httpTransport />
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -489,17 +489,17 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <httpsTransport maxReceivedMessageSize=""{expectedMaxReceivedMessageSize}""
                                     maxBufferSize=""{expectedMaxBufferSize}""
                                     requireClientCertificate=""{expectedRequireClientCertificate}""/>
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -533,15 +533,15 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <httpsTransport />
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -584,15 +584,15 @@ namespace CoreWCF.ConfigurationManager.Tests
             TransferMode expectedTransferMode = TransferMode.Streamed;
             int expectedListenBacklog = 96 * 2;
             string expectedServiceName = "expectedServiceName";
-            PolicyEnforcement expectedPolicyEnforcement = PolicyEnforcement.Always;
+            PolicyEnforcement expectedPolicyEnforcement = PolicyEnforcement.WhenSupported;
             ProtectionScenario expectedProtectionScenario = ProtectionScenario.TrustedProxy;
             TimeSpan expectedIdleTimeout = TimeSpan.FromMinutes(4);
             int expectedMaxOutboundConnectionsPerEndpoint = 20;
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <tcpTransport maxReceivedMessageSize=""{expectedMaxReceivedMessageSize}""
@@ -616,8 +616,8 @@ namespace CoreWCF.ConfigurationManager.Tests
                         </extendedProtectionPolicy>
                     </tcpTransport>
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -666,15 +666,15 @@ namespace CoreWCF.ConfigurationManager.Tests
             PolicyEnforcement expectedPolicyEnforcement = PolicyEnforcement.Never;
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <tcpTransport />
                 </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -720,9 +720,9 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <security defaultAlgorithmSuite=""Basic256Rsa15""
@@ -738,11 +738,11 @@ namespace CoreWCF.ConfigurationManager.Tests
                                 negotiationTimeout=""00:02:00"" replayWindow=""00:06:00"" inactivityTimeout=""00:03:00""
                                 sessionKeyRenewalInterval=""15:10:00"" sessionKeyRolloverInterval=""00:06:00""
                                 reconnectTransportOnFailure=""false"" maxPendingSessions=""256""
-                                maxCachedCookies=""2000"" timestampValidityDuration=""00:06:00"" />  
-                    </security>  
+                                maxCachedCookies=""2000"" timestampValidityDuration=""00:06:00"" />
+                    </security>
                   </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -775,19 +775,19 @@ namespace CoreWCF.ConfigurationManager.Tests
 
 
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <security authenticationMode=""IssuedTokenForCertificate"">
                         <issuedTokenParameters>
                             <issuer address=""https://github.com/CoreWCF/CoreWCF"" binding=""basicHttpBinding"" bindingConfiguration=""basicHttpBinding""/>
-                        </issuedTokenParameters> 
+                        </issuedTokenParameters>
                     </security>
                  </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 
@@ -805,19 +805,19 @@ namespace CoreWCF.ConfigurationManager.Tests
         {
             string expectedName = "customBinding";
             string xml = $@"
-<configuration> 
-    <system.serviceModel>         
-        <bindings>         
+<configuration>
+    <system.serviceModel>
+        <bindings>
             <customBinding>
                 <binding name=""{expectedName}"">
                     <security authenticationMode=""IssuedTokenForCertificate"">
                         <issuedTokenParameters>
-                            <issuerMetadata address=""https://github.com/CoreWCF/CoreWCF""/> 
-                        </issuedTokenParameters> 
+                            <issuerMetadata address=""https://github.com/CoreWCF/CoreWCF""/>
+                        </issuedTokenParameters>
                     </security>
                  </binding>
-            </customBinding>                             
-        </bindings>                             
+            </customBinding>
+        </bindings>
    </system.serviceModel>
 </configuration>";
 

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -1,12 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-
     <!-- Required for multi-framework support for in-memory integration testing-->
     <OutputType>Exe</OutputType>
     <GenerateProgramFile>false</GenerateProgramFile>
@@ -34,22 +32,16 @@
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)'!='net472'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.24" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="6.0.24" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="7.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(DotNetVersion).*-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(DotNetVersion).*-*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -44,10 +44,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(DotNetVersion).*-*" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.*-*" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />
     <ProjectReference Include="..\src\CoreWCF.Http.csproj" />

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -40,8 +40,8 @@
 
   <ItemGroup Condition="'$(TargetFramework)'!='net472'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(DotNetVersion).*-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(DotNetVersion).*-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(DotNetVersion).*" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(DotNetVersion).*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.csproj
@@ -44,6 +44,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(DotNetVersion).*-*" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.*-*" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />
     <ProjectReference Include="..\src\CoreWCF.Http.csproj" />

--- a/src/CoreWCF.Http/tests/DependencyInjection/KeyedServiceBehaviorTests.cs
+++ b/src/CoreWCF.Http/tests/DependencyInjection/KeyedServiceBehaviorTests.cs
@@ -42,9 +42,9 @@ public class KeyedServiceBehaviorTests
                 new System.ServiceModel.EndpointAddress(new Uri($"http://localhost:{host.GetHttpPort()}/service")));
             IReverseEchoService channel = factory.CreateChannel();
             string result = channel.Reverse(testString);
-            
+
             System.ServiceModel.BasicHttpBinding httpBinding2 = ClientHelper.GetBufferedModeBinding();
-            var factory2 = new System.ServiceModel.ChannelFactory<IReverseEchoService>(httpBinding,
+            var factory2 = new System.ServiceModel.ChannelFactory<IReverseEchoService>(httpBinding2,
                 new System.ServiceModel.EndpointAddress(new Uri($"http://localhost:{host.GetHttpPort()}/service2")));
             IReverseEchoService channel2 = factory2.CreateChannel();
             string result2 = channel2.Reverse(testString);

--- a/src/CoreWCF.Http/tests/DependencyInjection/KeyedServiceBehaviorTests.cs
+++ b/src/CoreWCF.Http/tests/DependencyInjection/KeyedServiceBehaviorTests.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET8_0_OR_GREATER
+using System;
+using System.Linq;
+using CoreWCF.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Helpers;
+using Xunit.Abstractions;
+using CoreWCF.Description;
+using System.Collections.ObjectModel;
+using CoreWCF.Channels;
+using System.Collections.Generic;
+
+namespace CoreWCF.Http.Tests;
+
+public class KeyedServiceBehaviorTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public KeyedServiceBehaviorTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void BasicHttpRequestReplyEchoString()
+    {
+        string testString = "azerty";
+        IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+        using (host)
+        {
+            host.Start();
+            MyServiceBehavior serviceBehavior = host.Services.GetKeyedService<IServiceBehavior>(typeof(ReverseEchoService)) as MyServiceBehavior;
+
+            System.ServiceModel.BasicHttpBinding httpBinding = ClientHelper.GetBufferedModeBinding();
+            var factory = new System.ServiceModel.ChannelFactory<IReverseEchoService>(httpBinding,
+                new System.ServiceModel.EndpointAddress(new Uri($"http://localhost:{host.GetHttpPort()}/service")));
+            IReverseEchoService channel = factory.CreateChannel();
+            string result = channel.Reverse(testString);
+            
+            System.ServiceModel.BasicHttpBinding httpBinding2 = ClientHelper.GetBufferedModeBinding();
+            var factory2 = new System.ServiceModel.ChannelFactory<IReverseEchoService>(httpBinding,
+                new System.ServiceModel.EndpointAddress(new Uri($"http://localhost:{host.GetHttpPort()}/service2")));
+            IReverseEchoService channel2 = factory2.CreateChannel();
+            string result2 = channel2.Reverse(testString);
+
+            Assert.Contains(typeof(ReverseEchoService), serviceBehavior.AppliedServices);
+            Assert.DoesNotContain(typeof(ReverseEchoService2), serviceBehavior.AppliedServices);
+        }
+    }
+
+    private class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<ReverseEchoService>();
+            services.AddSingleton<ReverseEchoService2>();
+            services.AddKeyedSingleton<IServiceBehavior, MyServiceBehavior>(typeof(ReverseEchoService));
+            services.AddServiceModelServices();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseServiceModel(builder =>
+            {
+                builder.AddService<ReverseEchoService>();
+                builder.AddServiceEndpoint<ReverseEchoService, IReverseEchoService>(new BasicHttpBinding(), "/service");
+                builder.AddService<ReverseEchoService2>();
+                builder.AddServiceEndpoint<ReverseEchoService2, IReverseEchoService>(new BasicHttpBinding(), "/service2");
+            });
+        }
+    }
+
+    [System.ServiceModel.ServiceContract]
+    private interface IReverseEchoService
+    {
+        [System.ServiceModel.OperationContract]
+        string Reverse(string value);
+    }
+
+    [ServiceBehavior(IncludeExceptionDetailInFaults = true)]
+    private class ReverseEchoService : IReverseEchoService
+    {
+        public string Reverse(string value) => new string(value.Reverse().ToArray());
+    }
+
+    [ServiceBehavior(IncludeExceptionDetailInFaults = true)]
+    private class ReverseEchoService2 : IReverseEchoService
+    {
+        public string Reverse(string value) => new string(value.Reverse().ToArray());
+    }
+
+    private class MyServiceBehavior : IServiceBehavior
+    {
+        public List<Type> AppliedServices { get; } = new();
+
+        public void AddBindingParameters(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase, Collection<ServiceEndpoint> endpoints, BindingParameterCollection bindingParameters)
+        {
+
+        }
+
+        public void ApplyDispatchBehavior(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
+        {
+            AppliedServices.Add(serviceDescription.ServiceType);
+        }
+
+        public void Validate(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
+        {
+
+        }
+    }
+}
+#endif

--- a/src/CoreWCF.Http/tests/DependencyInjection/KeyedServicesTests.cs
+++ b/src/CoreWCF.Http/tests/DependencyInjection/KeyedServicesTests.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET8_0_OR_GREATER
+using System;
+using System.Linq;
+using CoreWCF.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Helpers;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Http.Tests;
+
+public class KeyedServicesTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public KeyedServicesTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void BasicHttpRequestReplyEchoString()
+    {
+        string testString = "azerty";
+        IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+        using (host)
+        {
+            host.Start();
+            System.ServiceModel.BasicHttpBinding httpBinding = ClientHelper.GetBufferedModeBinding();
+            var factory = new System.ServiceModel.ChannelFactory<IReverseEchoService>(httpBinding,
+                new System.ServiceModel.EndpointAddress(new Uri($"http://localhost:{host.GetHttpPort()}/service")));
+            IReverseEchoService channel = factory.CreateChannel();
+            string result = channel.Reverse(testString);
+            Assert.Equal("ytreza", result);
+        }
+    }
+
+    private class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<ReverseEchoService>();
+            Func<string, string> reverse = value => new string(value.Reverse().ToArray());
+            services.AddKeyedSingleton(typeof(Func<string, string>), "reverse", (_, _) => reverse);
+            services.AddServiceModelServices();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseServiceModel(builder =>
+            {
+                builder.AddService<ReverseEchoService>();
+                builder.AddServiceEndpoint<ReverseEchoService, IReverseEchoService>(new BasicHttpBinding(), "/service");
+            });
+        }
+    }
+
+    [System.ServiceModel.ServiceContract]
+    private interface IReverseEchoService
+    {
+        [System.ServiceModel.OperationContract]
+        string Reverse(string value);
+    }
+
+    [ServiceBehavior(IncludeExceptionDetailInFaults = true)]
+    private class ReverseEchoService : IReverseEchoService
+    {
+        private readonly Func<string, string> _reverse;
+
+        public ReverseEchoService([FromKeyedServices("reverse")] Func<string, string> reverse)
+        {
+            _reverse = reverse;
+        }
+
+        public string Reverse(string value) => _reverse.Invoke(value);
+    }
+}
+#endif

--- a/src/CoreWCF.Kafka.Client/src/CoreWCF.Kafka.Client.csproj
+++ b/src/CoreWCF.Kafka.Client/src/CoreWCF.Kafka.Client.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="6.1.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreWCF.Kafka.Client/src/CoreWCF.Kafka.Client.csproj
+++ b/src/CoreWCF.Kafka.Client/src/CoreWCF.Kafka.Client.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="6.0.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="6.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreWCF.Kafka/tests/CoreWCF.Kafka.Tests.csproj
+++ b/src/CoreWCF.Kafka/tests/CoreWCF.Kafka.Tests.csproj
@@ -1,14 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
     <Compile Remove="**\*.cs" />
     <Compile Remove="*.cs" />
   </ItemGroup>
@@ -36,7 +34,7 @@
     <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)'!='net472'">
     <ProjectReference Include="$(SourceDir)CoreWCF.Kafka.Client\src\CoreWCF.Kafka.Client.csproj" />
     <ProjectReference Include="..\src\CoreWCF.Kafka.csproj" />
   </ItemGroup>

--- a/src/CoreWCF.MSMQ/tests/CoreWCF.MSMQ.Tests.csproj
+++ b/src/CoreWCF.MSMQ/tests/CoreWCF.MSMQ.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
+++ b/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -22,21 +21,16 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
     <Reference Include="System.Net.Http" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition=" '$(TargetFramework)'!='net472'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.24" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(DotNetVersion).*-*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
+++ b/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)'!='net472'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(DotNetVersion).*-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(DotNetVersion).*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.NetNamedPipe/tests/CoreWCF.NetNamedPipe.Tests.csproj
+++ b/src/CoreWCF.NetNamedPipe/tests/CoreWCF.NetNamedPipe.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks);net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.ServiceModel" />
   </ItemGroup>

--- a/src/CoreWCF.NetNamedPipe/tests/CoreWCF.NetNamedPipe.Tests.csproj
+++ b/src/CoreWCF.NetNamedPipe/tests/CoreWCF.NetNamedPipe.Tests.csproj
@@ -44,8 +44,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="6.0.0" />
-    <PackageReference Include="System.ServiceModel.NetNamedPipe" Version="6.0.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="6.1.0" />
+    <PackageReference Include="System.ServiceModel.NetNamedPipe" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.NetNamedPipe/tests/CoreWCF.NetNamedPipe.Tests.csproj
+++ b/src/CoreWCF.NetNamedPipe/tests/CoreWCF.NetNamedPipe.Tests.csproj
@@ -44,8 +44,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="6.1.0" />
-    <PackageReference Include="System.ServiceModel.NetNamedPipe" Version="6.1.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="6.2.0" />
+    <PackageReference Include="System.ServiceModel.NetNamedPipe" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.NetNamedPipe/tests/CoreWCF.NetNamedPipe.Tests.csproj
+++ b/src/CoreWCF.NetNamedPipe/tests/CoreWCF.NetNamedPipe.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks>$(TestTargetFrameworks);net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
+++ b/src/CoreWCF.NetTcp/tests/CoreWCF.NetTcp.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceDescription.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceDescription.cs
@@ -373,19 +373,8 @@ namespace CoreWCF.Description
             {
                 const string assemblyName = "Microsoft.Extensions.DependencyInjection.Abstractions";
                 const string typeName = "Microsoft.Extensions.DependencyInjection.IKeyedServiceProvider";
-                try
-                {
-                    Assembly assembly = Assembly.Load(assemblyName);
-                    if (assembly == null)
-                    {
-                        return null;
-                    }
-                    return assembly.GetType(typeName, false);
-                }
-                catch
-                {
-                    return null;
-                }
+                const string fullName = typeName + ", " + assemblyName;
+                return Type.GetType(fullName, false);
             }
         }
     }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceDescription.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceDescription.cs
@@ -348,7 +348,21 @@ namespace CoreWCF.Description
         private static Func<IServiceProvider, IEnumerable<IServiceBehavior>> BuildGetKeyedServiceBehaviors()
         {
             IEnumerable<IServiceBehavior> NoOp(IServiceProvider _) => Enumerable.Empty<IServiceBehavior>();
-            Type keyedServiceProviderType = Type.GetType("Microsoft.Extensions.DependencyInjection.IKeyedServiceProvider", false);
+
+            Type keyedServiceProviderType;
+            try
+            {
+                Assembly assembly = Assembly.Load("Microsoft.Extensions.DependencyInjection.Abstractions");
+                if (assembly == null)
+                {
+                    return NoOp;
+                }
+                keyedServiceProviderType = assembly.GetType("Microsoft.Extensions.DependencyInjection.IKeyedServiceProvider", false);
+            }
+            catch
+            {
+                return NoOp;
+            }
             if (keyedServiceProviderType == null)
             {
                 return NoOp;

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/CoreWCF.Queue/tests/CoreWCF.Queue.Tests.csproj
+++ b/src/CoreWCF.Queue/tests/CoreWCF.Queue.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/CoreWCF.RabbitMQ.Client/src/CoreWCF.RabbitMQ.Client.csproj
+++ b/src/CoreWCF.RabbitMQ.Client/src/CoreWCF.RabbitMQ.Client.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="6.6.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="6.1.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreWCF.RabbitMQ.Client/src/CoreWCF.RabbitMQ.Client.csproj
+++ b/src/CoreWCF.RabbitMQ.Client/src/CoreWCF.RabbitMQ.Client.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="6.6.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="6.0.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="6.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreWCF.RabbitMQ/tests/CoreWCF.RabbitMQ.Tests.csproj
+++ b/src/CoreWCF.RabbitMQ/tests/CoreWCF.RabbitMQ.Tests.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
     <Compile Remove="**\*.cs" />
     <Compile Remove="*.cs" />
   </ItemGroup>
@@ -33,7 +32,7 @@
     <PackageReference Include="RabbitMQ.Client" Version="6.6.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition="'$(TargetFramework)'!='net472'">
     <ProjectReference Include="$(SourceDir)CoreWCF.RabbitMQ.Client\src\CoreWCF.RabbitMQ.Client.csproj" />
     <ProjectReference Include="..\src\CoreWCF.RabbitMQ.csproj" />
   </ItemGroup>

--- a/src/CoreWCF.Templates/src/templates/CoreWCFService/.template.config/template.json
+++ b/src/CoreWCF.Templates/src/templates/CoreWCFService/.template.config/template.json
@@ -98,6 +98,10 @@
       "datatype": "choice",
       "choices": [
         {
+          "choice": "net8.0",
+          "description": "Target net8.0"
+        },
+        {
           "choice": "net7.0",
           "description": "Target net7.0"
         },
@@ -118,7 +122,7 @@
           "description": "Target net462"
         }
       ],
-      "replaces": "net6.0",
+      "replaces": "net8.0",
       "defaultValue": "net6.0"
     },
     "isNetFramework": {
@@ -146,11 +150,11 @@
     },
     "implicitUsings": {
       "type": "computed",
-      "value": "(Framework==\"net6.0\")||(Framework==\"net7.0\")"
+      "value": "(Framework==\"net6.0\")||(Framework==\"net7.0\")||(Framework==\"net8.0\")"
     },
     "nullableEnabled": {
       "type": "computed",
-      "value": "(Framework==\"net6.0\")||(Framework==\"net7.0\")"
+      "value": "(Framework==\"net6.0\")||(Framework==\"net7.0\")||(Framework==\"net8.0\")"
     },
     "NoWsdl": {
       "type": "parameter",
@@ -160,7 +164,7 @@
     },
     "minimal": {
       "type": "computed",
-      "value": "(((Framework==\"net6.0\")||(Framework==\"net7.0\"))&&(!UseProgramMain))"
+      "value": "(((Framework==\"net6.0\")||(Framework==\"net7.0\")||(Framework==\"net8.0\"))&&(!UseProgramMain))"
     }
   },
   "primaryOutputs": [

--- a/src/CoreWCF.Templates/src/templates/CoreWCFService/CoreWCFService.csproj
+++ b/src/CoreWCF.Templates/src/templates/CoreWCFService/CoreWCFService.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!--#if(nullableEnabled)-->
     <Nullable>enable</Nullable>
     <!--#endif-->

--- a/src/CoreWCF.Templates/tests/BasicTests.cs
+++ b/src/CoreWCF.Templates/tests/BasicTests.cs
@@ -23,6 +23,7 @@ public class BasicTests : IClassFixture<ProjectFactoryFixture>
 
     public static class Frameworks
     {
+        public const string Net8 = "net8.0";
         public const string Net7 = "net7.0";
         public const string Net6 = "net6.0";
         public const string Net48 = "net48";
@@ -95,27 +96,35 @@ public class BasicTests : IClassFixture<ProjectFactoryFixture>
     private static IEnumerable<TestVariation> GetTestVariations()
     {
         yield return TestVariation.New();
+        yield return TestVariation.New().Framework(Frameworks.Net8);
         yield return TestVariation.New().Framework(Frameworks.Net7);
         yield return TestVariation.New().Framework(Frameworks.Net6);
         yield return TestVariation.New().NoHttps();
+        yield return TestVariation.New().Framework(Frameworks.Net8).NoHttps();
         yield return TestVariation.New().Framework(Frameworks.Net7).NoHttps();
         yield return TestVariation.New().Framework(Frameworks.Net6).NoHttps();
         yield return TestVariation.New().NoWsdl();
+        yield return TestVariation.New().Framework(Frameworks.Net8).NoWsdl();
         yield return TestVariation.New().Framework(Frameworks.Net7).NoWsdl();
         yield return TestVariation.New().Framework(Frameworks.Net6).NoWsdl();
         yield return TestVariation.New().NoHttps().NoWsdl();
+        yield return TestVariation.New().Framework(Frameworks.Net8).NoHttps().NoWsdl();
         yield return TestVariation.New().Framework(Frameworks.Net7).NoHttps().NoWsdl();
         yield return TestVariation.New().Framework(Frameworks.Net6).NoHttps().NoWsdl();
         yield return TestVariation.New().UseProgramMain();
+        yield return TestVariation.New().Framework(Frameworks.Net8).UseProgramMain();
         yield return TestVariation.New().Framework(Frameworks.Net7).UseProgramMain();
         yield return TestVariation.New().Framework(Frameworks.Net6).UseProgramMain();
         yield return TestVariation.New().NoHttps().UseProgramMain();
+        yield return TestVariation.New().Framework(Frameworks.Net8).NoHttps().UseProgramMain();
         yield return TestVariation.New().Framework(Frameworks.Net7).NoHttps().UseProgramMain();
         yield return TestVariation.New().Framework(Frameworks.Net6).NoHttps().UseProgramMain();
         yield return TestVariation.New().NoWsdl().UseProgramMain();
+        yield return TestVariation.New().Framework(Frameworks.Net8).NoWsdl().UseProgramMain();
         yield return TestVariation.New().Framework(Frameworks.Net7).NoWsdl().UseProgramMain();
         yield return TestVariation.New().Framework(Frameworks.Net6).NoWsdl().UseProgramMain();
         yield return TestVariation.New().NoHttps().NoWsdl().UseProgramMain();
+        yield return TestVariation.New().Framework(Frameworks.Net8).NoHttps().NoWsdl().UseProgramMain();
         yield return TestVariation.New().Framework(Frameworks.Net7).NoHttps().NoWsdl().UseProgramMain();
         yield return TestVariation.New().Framework(Frameworks.Net6).NoHttps().NoWsdl().UseProgramMain();
 
@@ -163,7 +172,7 @@ public class BasicTests : IClassFixture<ProjectFactoryFixture>
 
     private async Task CoreWCFTemplateDefaultCore(string[] args, bool assertMetadataEndpoint, bool useHttps, string expectedListeningUriScheme)
     {
-        var targetFramework = args.FirstOrDefault(arg => arg.StartsWith("--framework"))?.Split(" ")[1] ?? "net6.0";
+        var targetFramework = args.FirstOrDefault(arg => arg.StartsWith("--framework"))?.Split(" ")[1] ?? Frameworks.Net6;
         var project = ProjectFactory.GetOrCreateProject($"corewcf-{Guid.NewGuid()}", targetFramework,  _output);
 
         var createResult = await project.RunDotNetNewAsync("corewcf", args: args);

--- a/src/CoreWCF.Templates/tests/CoreWCF.Templates.Tests.csproj
+++ b/src/CoreWCF.Templates/tests/CoreWCF.Templates.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>disable</Nullable>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/CoreWCF.UnixDomainSocket/tests/BasicTest.cs
+++ b/src/CoreWCF.UnixDomainSocket/tests/BasicTest.cs
@@ -27,7 +27,7 @@ namespace CoreWCF.UnixDomainSocket.Tests
             _output = output;
             LinuxSocketFilepath = Path.Combine(Path.GetTempPath(), "unix1.txt");
         }
-        
+
         [Fact]
         public void NoAuthUnixDomainSocket()
         {
@@ -78,8 +78,8 @@ namespace CoreWCF.UnixDomainSocket.Tests
                 host.Start();
                 try
                 {
-                    System.ServiceModel.UnixDomainSocketBinding binding = ClientHelper.GetBufferedModeBinding(System.ServiceModel.SecurityMode.Transport);
-                    binding.Security.Transport.ClientCredentialType = System.ServiceModel.UnixDomainSocketClientCredentialType.IdentityOnly;
+                    System.ServiceModel.UnixDomainSocketBinding binding = ClientHelper.GetBufferedModeBinding(System.ServiceModel.UnixDomainSocketSecurityMode.Transport);
+                    binding.Security.Transport.ClientCredentialType = System.ServiceModel.UnixDomainSocketClientCredentialType.PosixIdentity;
 
                     factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
                         new System.ServiceModel.EndpointAddress(new Uri("net.uds://" + LinuxSocketFilepath)));
@@ -98,7 +98,7 @@ namespace CoreWCF.UnixDomainSocket.Tests
                 {
                     ServiceHelper.CloseServiceModelObjects((IChannel)channel, factory);
                 }
-                
+
             }
         }
 
@@ -114,7 +114,7 @@ namespace CoreWCF.UnixDomainSocket.Tests
                 host.Start();
                 try
                 {
-                    System.ServiceModel.UnixDomainSocketBinding binding = ClientHelper.GetBufferedModeBinding(System.ServiceModel.SecurityMode.Transport);
+                    System.ServiceModel.UnixDomainSocketBinding binding = ClientHelper.GetBufferedModeBinding(System.ServiceModel.UnixDomainSocketSecurityMode.Transport);
                     binding.Security.Transport.ClientCredentialType = System.ServiceModel.UnixDomainSocketClientCredentialType.Windows;
 
                     var uriBuilder = new UriBuilder()
@@ -128,7 +128,7 @@ namespace CoreWCF.UnixDomainSocket.Tests
                     ((IChannel)channel).Open();
                     string result = channel.EchoString(testString);
                     Assert.Equal(testString, result);
-                    ((IChannel)channel).Close();    
+                    ((IChannel)channel).Close();
                     factory.Close();
                 }
                 catch (Exception ex)
@@ -151,7 +151,7 @@ namespace CoreWCF.UnixDomainSocket.Tests
             using (host)
             {
                 host.Start();
-                System.ServiceModel.UnixDomainSocketBinding binding = ClientHelper.GetBufferedModeBinding(System.ServiceModel.SecurityMode.Transport);
+                System.ServiceModel.UnixDomainSocketBinding binding = ClientHelper.GetBufferedModeBinding(System.ServiceModel.UnixDomainSocketSecurityMode.Transport);
                 binding.Security.Transport.ClientCredentialType = System.ServiceModel.UnixDomainSocketClientCredentialType.Certificate;
                 var uriBuilder = new UriBuilder()
                 {
@@ -191,7 +191,7 @@ namespace CoreWCF.UnixDomainSocket.Tests
         [InlineData(UnixDomainSocketSecurityMode.TransportCredentialOnly, UnixDomainSocketClientCredentialType.Certificate)]
         private void CheckForSecurityModeCompatibility(UnixDomainSocketSecurityMode securityMode, UnixDomainSocketClientCredentialType clientCredType)
         {
-            
+
             var udsBinding = new UnixDomainSocketBinding
             {
                 Security = new UnixDomainSocketSecurity

--- a/src/CoreWCF.UnixDomainSocket/tests/CoreWCF.UnixDomainSocket.Tests.csproj
+++ b/src/CoreWCF.UnixDomainSocket/tests/CoreWCF.UnixDomainSocket.Tests.csproj
@@ -38,8 +38,8 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
-    <PackageReference Include="System.ServiceModel.UnixDomainSocket" Version="6.0.0-dev.23371.1" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="6.1.0" />
+    <PackageReference Include="System.ServiceModel.UnixDomainSocket" Version="6.2.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreWCF.UnixDomainSocket/tests/CoreWCF.UnixDomainSocket.Tests.csproj
+++ b/src/CoreWCF.UnixDomainSocket/tests/CoreWCF.UnixDomainSocket.Tests.csproj
@@ -38,12 +38,8 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
-    <PackageReference Include="System.ServiceModel.UnixDomainSocket">
-      <Version>6.0.0-dev.23371.1</Version>
-    </PackageReference>
-    <PackageReference Include="System.ServiceModel.Primitives">
-      <Version>6.0.0-dev.23371.1</Version>
-    </PackageReference>
+    <PackageReference Include="System.ServiceModel.UnixDomainSocket" Version="6.0.0-dev.23371.1" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="6.1.0" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/CoreWCF.UnixDomainSocket/tests/CoreWCF.UnixDomainSocket.Tests.csproj
+++ b/src/CoreWCF.UnixDomainSocket/tests/CoreWCF.UnixDomainSocket.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/CoreWCF.UnixDomainSocket/tests/Helpers/ClientHelper.cs
+++ b/src/CoreWCF.UnixDomainSocket/tests/Helpers/ClientHelper.cs
@@ -12,14 +12,14 @@ namespace Helpers
     {
         private static readonly TimeSpan s_debugTimeout = TimeSpan.FromMinutes(20);
 
-        public static UnixDomainSocketBinding GetBufferedModeBinding(SecurityMode securityMode = SecurityMode.None)
+        public static UnixDomainSocketBinding GetBufferedModeBinding(UnixDomainSocketSecurityMode securityMode = UnixDomainSocketSecurityMode.None)
         {
             var binding = new UnixDomainSocketBinding(securityMode);
             ApplyDebugTimeouts(binding);
             return binding;
         }
 
-        public static UnixDomainSocketBinding GetStreamedModeBinding(SecurityMode securityMode = SecurityMode.None)
+        public static UnixDomainSocketBinding GetStreamedModeBinding(UnixDomainSocketSecurityMode securityMode = UnixDomainSocketSecurityMode.None)
         {
             var binding = new UnixDomainSocketBinding(securityMode)
             {

--- a/src/CoreWCF.WebHttp/tests/CoreWCF.WebHttp.Tests.csproj
+++ b/src/CoreWCF.WebHttp/tests/CoreWCF.WebHttp.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/templates/BuildStage.yml
+++ b/templates/BuildStage.yml
@@ -51,6 +51,8 @@ stages:
         displayName: Restore
         inputs:
           command: restore
+          feedsToUse: config
+          nugetConfigPath: src/NuGet.config
           projects: ${{ parameters.solutions }}
       
       - task: DotNetCoreCLI@2

--- a/templates/BuildStage.yml
+++ b/templates/BuildStage.yml
@@ -1,5 +1,5 @@
 parameters:
-- name: buildProjects
+- name: solutions
   default: ''
 
 stages:
@@ -9,19 +9,32 @@ stages:
   - job: Build
     strategy:
       matrix:
-        Release:
-          _buildConfig: 'Release'
-        Debug:
-          _buildConfig: 'Debug'
+        WindowsRelease:
+          configuration: 'Release'
+          imageName: 'windows-latest'
+          artifactName: 'WindowsReleaseBuild'
+        WindowsDebug:
+          configuration: 'Debug'
+          imageName: 'windows-latest'
+          artifactName: 'WindowsDebugBuild'
+        LinuxRelease:
+          configuration: 'Release'
+          imageName: 'ubuntu-latest'
+          artifactName: 'LinuxReleaseBuild'
+        LinuxDebug:
+          configuration: 'Debug'     
+          imageName: 'ubuntu-latest'     
+          artifactName: 'LinuxDebugBuild'
     pool:
-      vmImage: 'windows-latest'
+      vmImage: $(imageName)
     steps:
       - task: UseDotNet@2
-        displayName: 'Use .NET Core sdk'
+        displayName: 'Use .NET 8 sdk'
         inputs:
           packageType: sdk
-          version: 7.0.x
+          version: 8.0.x
           installationPath: $(Agent.ToolsDirectory)/dotnet
+          includePreviewVersions: true
 
       # NGBV project at https://github.com/dotnet/Nerdbank.GitVersioning
       - task: DotNetCoreCLI@2
@@ -37,15 +50,14 @@ stages:
       - task: DotNetCoreCLI@2
         displayName: Restore
         inputs:
-          command: 'build'
-          projects: ${{ parameters.buildProjects}}
-          arguments: '--configuration $(_buildConfig) /t:restore'
+          command: restore
+          projects: ${{ parameters.solutions }}
       
       - task: DotNetCoreCLI@2
-        displayName: Build $(_buildConfig)
+        displayName: Build $(configuration)
         inputs:
           command: 'build'
-          projects: ${{ parameters.buildProjects}}
-          arguments: '--no-restore --configuration $(_buildConfig)'
+          projects: ${{ parameters.solutions }}
+          arguments: '--no-restore -c $(configuration)'
       - publish: $(System.DefaultWorkingDirectory)/bin
-        artifact: $(_buildConfig)Build
+        artifact: $(artifactName)

--- a/templates/CodeAnalysis.yml
+++ b/templates/CodeAnalysis.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: testProjects
   default: ''
-- name: solution
+- name: solutions
   default: ''
 
 stages:
@@ -24,10 +24,18 @@ stages:
       retryCountOnTaskFailure: 2
 
     - task: UseDotNet@2
-      displayName: 'Use .NET Core 7 sdk'
+      displayName: 'Use .NET 6 sdk'
       inputs:
         packageType: sdk
-        version: '7.0.x'
+        version: '6.0.x'
+        installationPath: $(Agent.ToolsDirectory)/dotnet
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET 8 sdk'
+      inputs:
+        packageType: sdk
+        version: '8.0.x'
+        includePreviewVersions: true
         installationPath: $(Agent.ToolsDirectory)/dotnet
 
     - task: DotNetCoreCLI@2
@@ -36,7 +44,7 @@ stages:
         command: restore
         feedsToUse: config
         nugetConfigPath: src/NuGet.config
-        projects: src/CoreWCF.sln
+        projects: ${{ parameters.solutions }}
 
     - task: SonarCloudPrepare@1
       displayName: 'Prepare analysis on SonarCloud'
@@ -55,7 +63,7 @@ stages:
       displayName: Build
       inputs:
         command: build
-        projects: ${{ parameters.solution }}
+        projects: ${{ parameters.solutions }}
         arguments: '--no-restore -c Release'
 
     - task: DotNetCoreCLI@2
@@ -63,8 +71,8 @@ stages:
       timeoutInMinutes: 20
       inputs:
         command: test
-        projects: ${{ parameters.testProjects}}
-        arguments: '--no-restore --no-build -c Release -f net7.0 --filter Category!=WindowsOnly --collect:"XPlat Code Coverage" --settings coverlet.runsettings'
+        projects: ${{ parameters.testProjects }}
+        arguments: '--no-restore --no-build -c Release -f net6.0 --collect:"XPlat Code Coverage" --settings coverlet.runsettings'
 
     - task: PublishCodeCoverageResults@1
       displayName: Publish Code Coverage report

--- a/templates/CodeAnalysis.yml
+++ b/templates/CodeAnalysis.yml
@@ -24,13 +24,6 @@ stages:
       retryCountOnTaskFailure: 2
 
     - task: UseDotNet@2
-      displayName: 'Use .NET 6 sdk'
-      inputs:
-        packageType: sdk
-        version: '6.0.x'
-        installationPath: $(Agent.ToolsDirectory)/dotnet
-
-    - task: UseDotNet@2
       displayName: 'Use .NET 8 sdk'
       inputs:
         packageType: sdk
@@ -72,7 +65,7 @@ stages:
       inputs:
         command: test
         projects: ${{ parameters.testProjects }}
-        arguments: '--no-restore --no-build -c Release -f net6.0 --collect:"XPlat Code Coverage" --settings coverlet.runsettings'
+        arguments: '--no-restore --no-build -c Release -f net8.0 --collect:"XPlat Code Coverage" --settings coverlet.runsettings'
 
     - task: PublishCodeCoverageResults@1
       displayName: Publish Code Coverage report

--- a/templates/PackStage.yml
+++ b/templates/PackStage.yml
@@ -16,15 +16,16 @@ stages:
       displayName: Download build artifacts
       inputs:
         source: current
-        artifact: ReleaseBuild
+        artifact: WindowsReleaseBuild
         path: $(System.DefaultWorkingDirectory)/bin
 
     - task: UseDotNet@2
-      displayName: 'Use .NET Core sdk'
+      displayName: 'Use .NET 8 sdk'
       inputs:
         packageType: sdk
-        version: 6.0.x
+        version: 8.0.x
         installationPath: $(Agent.ToolsDirectory)/dotnet   
+        includePreviewVersions: true
 
     - task: DotNetCoreCLI@2
       displayName: Restore

--- a/templates/TestStage.yml
+++ b/templates/TestStage.yml
@@ -60,7 +60,7 @@ stages:
             targetFramework: 'net8.0'
             testArgs: ''
             dotnetSdk: '8.0.x'
-            continueOnError: 'true'            
+            continueOnError: 'false'            
             artifactName: 'Linux${{ configuration }}Build'
       displayName: Test ${{ configuration }}
       pool:

--- a/templates/TestStage.yml
+++ b/templates/TestStage.yml
@@ -18,49 +18,42 @@ stages:
             targetFramework: 'net6.0'
             testArgs: ''
             dotnetSdk: '6.0.x'
-            continueOnError: 'false'
             artifactName: 'Windows${{ configuration }}Build'
           Windows_net7.0:
             imageName: 'windows-latest'
             targetFramework: 'net7.0'
             testArgs: ''
             dotnetSdk: '7.0.x'
-            continueOnError: 'false'
             artifactName: 'Windows${{ configuration }}Build'
           Windows_net8.0:
             imageName: 'windows-latest'
             targetFramework: 'net8.0'
             testArgs: ''
             dotnetSdk: '8.0.x'
-            continueOnError: 'true'            
             artifactName: 'Windows${{ configuration }}Build'
           Windows_netfx:
             imageName: 'windows-latest'
             targetFramework: 'net472'
             testArgs: ''
             dotnetSdk: '8.0.x'
-            continueOnError: 'false'
             artifactName: 'Windows${{ configuration }}Build'
           Linux_net6.0:
             imageName: 'ubuntu-latest'
             targetFramework: 'net6.0'
             testArgs: ''
             dotnetSdk: '6.0.x'
-            continueOnError: 'false'
             artifactName: 'Linux${{ configuration }}Build'
           Linux_net7.0:
             imageName: 'ubuntu-latest'
             targetFramework: 'net7.0'
             testArgs: ''
             dotnetSdk: '7.0.x'
-            continueOnError: 'false'
             artifactName: 'Linux${{ configuration }}Build'
           Linux_net8.0:
             imageName: 'ubuntu-latest'
             targetFramework: 'net8.0'
             testArgs: ''
             dotnetSdk: '8.0.x'
-            continueOnError: 'false'            
             artifactName: 'Linux${{ configuration }}Build'
       displayName: Test ${{ configuration }}
       pool:
@@ -95,17 +88,12 @@ stages:
       - task: DotNetCoreCLI@2
         displayName: Run Tests
         timeoutInMinutes: 20
-        continueOnError: true
         inputs:
           command: 'test'
           projects: ${{ parameters.testProjects }}
           publishTestResults: true
           arguments: '--no-restore --no-build -c ${{ configuration }} -f $(targetFramework) $(testArgs)'
 
-      # fail the build if any tests failed
-      - bash: echo "##vso[task.complete result=Failed;]DONE"
-        condition: and(in(variables['Agent.JobStatus'], 'Failed', 'SucceededWithIssues'), eq(variables.continueOnError, 'false'))
-       
       - bash: |
           echo 'Cleaning up docker services...'
           docker compose down --rmi all

--- a/templates/TestStage.yml
+++ b/templates/TestStage.yml
@@ -17,27 +17,51 @@ stages:
             imageName: 'windows-latest'
             targetFramework: 'net6.0'
             testArgs: ''
-            additionalDotNetCoreSdk: '6.0.x'
+            dotnetSdk: '6.0.x'
+            continueOnError: 'false'
+            artifactName: 'Windows${{ configuration }}Build'
           Windows_net7.0:
             imageName: 'windows-latest'
             targetFramework: 'net7.0'
             testArgs: ''
-            additionalDotNetCoreSdk: ''
+            dotnetSdk: '7.0.x'
+            continueOnError: 'false'
+            artifactName: 'Windows${{ configuration }}Build'
+          Windows_net8.0:
+            imageName: 'windows-latest'
+            targetFramework: 'net8.0'
+            testArgs: ''
+            dotnetSdk: '8.0.x'
+            continueOnError: 'true'            
+            artifactName: 'Windows${{ configuration }}Build'
           Windows_netfx:
             imageName: 'windows-latest'
             targetFramework: 'net472'
             testArgs: ''
-            additionalDotNetCoreSdk: ''
+            dotnetSdk: '8.0.x'
+            continueOnError: 'false'
+            artifactName: 'Windows${{ configuration }}Build'
           Linux_net6.0:
             imageName: 'ubuntu-latest'
             targetFramework: 'net6.0'
             testArgs: ''
-            additionalDotNetCoreSdk: '6.0.x'
+            dotnetSdk: '6.0.x'
+            continueOnError: 'false'
+            artifactName: 'Linux${{ configuration }}Build'
           Linux_net7.0:
             imageName: 'ubuntu-latest'
             targetFramework: 'net7.0'
             testArgs: ''
-            additionalDotNetCoreSdk: ''
+            dotnetSdk: '7.0.x'
+            continueOnError: 'false'
+            artifactName: 'Linux${{ configuration }}Build'
+          Linux_net8.0:
+            imageName: 'ubuntu-latest'
+            targetFramework: 'net8.0'
+            testArgs: ''
+            dotnetSdk: '8.0.x'
+            continueOnError: 'true'            
+            artifactName: 'Linux${{ configuration }}Build'
       displayName: Test ${{ configuration }}
       pool:
         vmImage: $(imageName)
@@ -57,47 +81,31 @@ stages:
         displayName: Download build artifacts
         inputs:
           source: current
-          artifact: ReleaseBuild
+          artifact: $(artifactName)
           path: $(System.DefaultWorkingDirectory)/bin
 
       - task: UseDotNet@2
-        displayName: 'Use .NET 7.0 sdk'
+        displayName: 'Use .NET sdk $(dotnetSdk)'
         inputs:
           packageType: sdk
-          version: '7.0.x'
+          version: $(dotnetSdk)
           installationPath: $(Agent.ToolsDirectory)/dotnet
-
-      - task: UseDotNet@2
-        displayName: 'Use additional .NET Core sdk'
-        inputs:
-          packageType: sdk
-          version: $(additionalDotNetCoreSdk)
-          installationPath: $(Agent.ToolsDirectory)/dotnet
-        condition: not(eq(variables.additionalDotNetCoreSdk, ''))
-
-      - task: DotNetCoreCLI@2
-        displayName: Restore packages
-        inputs:
-          command: 'build'
-          projects: ${{ parameters.testProjects}}
-          arguments: '-c ${{ configuration }} /t:restore'
-
-      - task: DotNetCoreCLI@2
-        displayName: Build test projects
-        inputs:
-          command: 'build'
-          projects: ${{ parameters.testProjects}}
-          arguments: '-c ${{ configuration }} -f $(targetFramework)'
+          includePreviewVersions: true
 
       - task: DotNetCoreCLI@2
         displayName: Run Tests
         timeoutInMinutes: 20
+        continueOnError: true
         inputs:
           command: 'test'
-          projects: ${{ parameters.testProjects}}
+          projects: ${{ parameters.testProjects }}
           publishTestResults: true
           arguments: '--no-restore --no-build -c ${{ configuration }} -f $(targetFramework) $(testArgs)'
-        
+
+      # fail the build if any tests failed
+      - bash: echo "##vso[task.complete result=Failed;]DONE"
+        condition: and(in(variables['Agent.JobStatus'], 'Failed', 'SucceededWithIssues'), eq(variables.continueOnError, 'false'))
+       
       - bash: |
           echo 'Cleaning up docker services...'
           docker compose down --rmi all

--- a/templates/TestTemplatesStage.yml
+++ b/templates/TestTemplatesStage.yml
@@ -1,9 +1,3 @@
-parameters:
-- name: libraryProjects
-  default: ''
-- name: templateTestProjects
-  default: '**/CoreWCF.Templates.Tests.csproj'
-
 stages:
 - stage: 'TestTemplates'
   displayName: Run Templates Tests
@@ -15,9 +9,11 @@ stages:
         Windows:
           imageName: 'windows-latest'
           testArgs: '--filter Category=Templates'
+          artifactName: 'WindowsReleaseBuild'
         Linux:
           imageName: 'ubuntu-latest'
           testArgs: '--filter Category=Templates'
+          artifactName: 'LinuxReleaseBuild'
     displayName: Test Templates Release
     pool:
       vmImage: $(imageName)
@@ -26,7 +22,7 @@ stages:
       displayName: Download build artifacts
       inputs:
         source: current
-        artifact: ReleaseBuild
+        artifact: $(artifactName)
         path: $(System.DefaultWorkingDirectory)/bin
 
     - task: UseDotNet@2
@@ -42,7 +38,14 @@ stages:
         packageType: sdk
         version: '7.0.x'
         installationPath: $(Agent.ToolsDirectory)/dotnet
-        includePreviewVersions: true       
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET 8 sdk'
+      inputs:
+        packageType: sdk
+        version: '8.0.x'
+        installationPath: $(Agent.ToolsDirectory)/dotnet
+        includePreviewVersions: true               
 
     - task: PowerShell@2
       inputs:


### PR DESCRIPTION
- Add .net8.0 tfm to unit tests
- Move building the unit tests projects in the build stage
- ~~Introduce a flag in test matrix to control whether build fail or not (only used for net8.0, we should drop it soon)~~
- update S.SM 4.x references to 4.10.3
- update S.SM 6.x references to ~~6.1.0~~ 6.2.0
- Add keyed by service ServiceBehavior support starting from net8