### PR TITLE
making the API public for SamlSecurityToken 

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Tokens/SamlSecurityToken.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Tokens/SamlSecurityToken.cs
@@ -46,7 +46,7 @@ namespace CoreWCF.IdentityModel.Tokens
 
         internal MSIdentitySAML.SamlSecurityToken WrappedSamlSecurityToken { get; }
 
-        internal MSIdentitySAML.SamlAssertion Assertion { get; private set; }
+        public MSIdentitySAML.SamlAssertion Assertion { get; private set; }
 
         internal SecurityToken SigningToken { get; set; }
 


### PR DESCRIPTION
Fixing #1073 

The Saml2SecurityToken is already public and checked also [here](https://referencesource.microsoft.com/#System.IdentityModel/System/IdentityModel/Tokens/SamlSecurityToken.cs,60)