### PR TITLE
NetNamedPipe System.ArgumentOutOfRangeException fix

### DIFF
--- a/src/CoreWCF.NetFramingBase/src/CoreWCF/Channels/Framing/ServerSingletonConnectionReaderMiddleware.cs
+++ b/src/CoreWCF.NetFramingBase/src/CoreWCF/Channels/Framing/ServerSingletonConnectionReaderMiddleware.cs
@@ -429,13 +429,7 @@ namespace CoreWCF.Channels.Framing
 
                         // Consume those bytes from our buffer
                         _buffer = _buffer.Slice(bytesToCopy);
-
-                        // If the buffer has been exhausted, advance the input pipe to consume them and release the buffer
-                        if (_buffer.Length == 0)
-                        {
-                            _connection.Input.AdvanceTo(_buffer.End);
-                        }
-
+                        
                         // Create an ArraySegment of the right size to copy the bytes to. The synchronous Read method uses a Span<byte> instead, but
                         // you can't instantiate a Span<T> in an async method but there's an implicit case of ArraySegment to Span.
                         var _toBuffer = new ArraySegment<byte>(buffer, offset, bytesToCopy);
@@ -450,6 +444,12 @@ namespace CoreWCF.Channels.Framing
                     {
                         // We are starting a new chunk. Read the size, and loop around again
                         DecodeSize(ref _buffer);
+                    }
+
+                    // If the buffer has been exhausted, advance the input pipe to consume them and release the buffer
+                    if (_buffer.Length == 0)
+                    {
+                        _connection.Input.AdvanceTo(_buffer.End);
                     }
                 }
             }


### PR DESCRIPTION
`Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)` is now advancing the buffer at the end of the method, just like `int Read(byte[] buffer, int offset, int count)` does it.

This helped fix a ArgumentOutOfRangeException. I don't know this project good enough however, so I can't really tell if this change makes sense or not.