### PR TITLE
add support on IpV6Any addresses in soap:address location, add suppor…

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/ServiceHostObjectModel.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/ServiceHostObjectModel.cs
@@ -254,6 +254,14 @@ namespace CoreWCF
             {
                 address = "https://localhost" + address.Substring(9);
             }
+            else if (address.StartsWith("http://[::]", StringComparison.OrdinalIgnoreCase)) //IPAddress.IPv6Any
+            {
+                address = "http://localhost" + address.Substring(11);
+            }
+            else if (address.StartsWith("https://[::]", StringComparison.OrdinalIgnoreCase)) //IPAddress.IPv6Any
+            {
+                address = "https://localhost" + address.Substring(12);
+            }
             else if (address.StartsWith("https://*.", StringComparison.OrdinalIgnoreCase) ||
                     address.StartsWith("http://*.", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
Hey! I have the same [problem](https://github.com/CoreWCF/CoreWCF/discussions/853) and fixed it by add using LocalPath from URI which generated in UseRequestHeadersForMetadataAddressBehavior