### PR TITLE
fix missing argument for SR.SendToViaTimedOut template

### DIFF
--- a/src/Common/src/DuplexChannels/CoreWCF/Channels/TransportDuplexSessionChannel.cs
+++ b/src/Common/src/DuplexChannels/CoreWCF/Channels/TransportDuplexSessionChannel.cs
@@ -307,7 +307,7 @@ namespace CoreWCF.Channels
             {
                 // TODO: Fix the timeout value reported
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(
-                                                SR.Format(SR.SendToViaTimedOut, TimeSpan.Zero),
+                                                SR.Format(SR.SendToViaTimedOut, Via, TimeSpan.Zero),
                                                 TimeoutHelper.CreateEnterTimedOutException(TimeSpan.Zero)));
             }
 


### PR DESCRIPTION
Fixes #1095
It fixes the missing argument for the TimeoutException message reported in #1095.