### PR TITLE
Make it easy to locally host SourceBrowser for CoreWCF

### DIFF
--- a/src/SourceWebsite/.gitignore
+++ b/src/SourceWebsite/.gitignore
@@ -1,0 +1,2 @@
+# File created by building source website
+Messages.txt

--- a/src/SourceWebsite/SourceWebsite.csproj
+++ b/src/SourceWebsite/SourceWebsite.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-	<EnableDefaultItems>false</EnableDefaultItems>
-	<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-	<IsPackable>false</IsPackable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <IncludeCommonCode>false</IncludeCommonCode>
   </PropertyGroup>
@@ -15,7 +14,7 @@
   <ItemGroup>
     <Compile Remove="@(Compile)" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="SourceBrowser" Version="1.0.43" ExcludeAssets="build;compile" PrivateAssets="All" />
   </ItemGroup>
@@ -26,9 +25,9 @@
 
   <Target Name="StartSourceBrowser" >
     <ExecAsync FilePath="$(OutputPath)Index\Microsoft.SourceBrowser.SourceIndexServer.exe" WorkingDirectory="$(OutputPath)Index" />
-	<Exec Command="start http://localhost:5000" />
+    <Exec Command="start http://localhost:5000" />
   </Target>
-  
+
   <UsingTask
     TaskName="ExecAsync"
     TaskFactory="RoslynCodeTaskFactory"
@@ -36,8 +35,8 @@
     <ParameterGroup>
       <!--The file path is the full path to the executable file to run-->
       <FilePath ParameterType="System.String" Required="true" />
-	  <!--The working directory is the working directory to launch the app in-->
-	  <WorkingDirectory ParameterType="System.String" Required="true" />
+      <!--The working directory is the working directory to launch the app in-->
+      <WorkingDirectory ParameterType="System.String" Required="true" />
       <!--The arguments should contain all the command line arguments that need to be sent to the application-->
       <Arguments ParameterType="System.String" Required="false" />
     </ParameterGroup>
@@ -45,7 +44,7 @@
       <!--<Reference Include="" />
       <Using Namespace="" />-->
       <Code Type="Fragment" Language="cs">
-	          <![CDATA[
+              <![CDATA[
   string name = System.IO.Path.GetFileNameWithoutExtension(FilePath);
   Log.LogMessage("Starting {0}...", name);        
   System.Diagnostics.ProcessStartInfo processStartInfo;

--- a/src/SourceWebsite/SourceWebsite.csproj
+++ b/src/SourceWebsite/SourceWebsite.csproj
@@ -1,0 +1,68 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+	<EnableDefaultItems>false</EnableDefaultItems>
+	<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+	<IsPackable>false</IsPackable>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <IncludeCommonCode>false</IncludeCommonCode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="@(Compile)" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="SourceBrowser" Version="1.0.43" ExcludeAssets="build;compile" PrivateAssets="All" />
+  </ItemGroup>
+
+  <Target Name="GenerateWebsite" AfterTargets="PostBuildEvent">
+    <Exec Command="$(PkgSourceBrowser)\tools\HtmlGenerator.exe $(SourceDir)CoreWCF.sln /out:$(OutputPath)Index /nobuiltinfederations /federation:https://source.dot.net /federation:http://sourceroslyn.io /force" />
+  </Target>
+
+  <Target Name="StartSourceBrowser" >
+    <ExecAsync FilePath="$(OutputPath)Index\Microsoft.SourceBrowser.SourceIndexServer.exe" WorkingDirectory="$(OutputPath)Index" />
+	<Exec Command="start http://localhost:5000" />
+  </Target>
+  
+  <UsingTask
+    TaskName="ExecAsync"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    <ParameterGroup>
+      <!--The file path is the full path to the executable file to run-->
+      <FilePath ParameterType="System.String" Required="true" />
+	  <!--The working directory is the working directory to launch the app in-->
+	  <WorkingDirectory ParameterType="System.String" Required="true" />
+      <!--The arguments should contain all the command line arguments that need to be sent to the application-->
+      <Arguments ParameterType="System.String" Required="false" />
+    </ParameterGroup>
+    <Task>
+      <!--<Reference Include="" />
+      <Using Namespace="" />-->
+      <Code Type="Fragment" Language="cs">
+	          <![CDATA[
+  string name = System.IO.Path.GetFileNameWithoutExtension(FilePath);
+  Log.LogMessage("Starting {0}...", name);        
+  System.Diagnostics.ProcessStartInfo processStartInfo;
+  if (String.IsNullOrEmpty(Arguments))
+  {
+    processStartInfo = new System.Diagnostics.ProcessStartInfo(FilePath);
+  }
+  else
+  {
+    processStartInfo = new System.Diagnostics.ProcessStartInfo(FilePath, Arguments);
+  }
+  processStartInfo.UseShellExecute = true;
+  processStartInfo.WorkingDirectory = WorkingDirectory;
+  System.Diagnostics.Process.Start(processStartInfo);
+  Log.LogMessage("Finished running process {0}.", name);
+  ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+</Project>


### PR DESCRIPTION
We can add scripts around this to make it easier. But basically you go to the src\SourceWebsite folder and run:
```cmd
dotnet build
dotnet build /t:StartSourceBrowser
```

And builds the SourceBrowser website, launches it and opens a web browser to view it. This only works on Windows as the SourceBrowser nuget package needs Windows to run.  

There's also a problem with federation as we're targeting netstandard2.0. This means many of the links to https://source.dot.net will be broken due to it expecting the types to be defined in netstandard.dll. I've opened an issue https://github.com/KirillOsenkov/SourceBrowser/issues/233 looking for guidance on how to work around this.  

It would be great to eventually have this auto published to a website on the post merge CI pipeline.