### PR TITLE
Fixed: Calling OperationContext.Current before the host started

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/MessageRpc.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/MessageRpc.cs
@@ -471,15 +471,12 @@ namespace CoreWCF.Dispatcher
             // bool completed = true;
 
             OperationContext originalContext;
-            OperationContext.Holder contextHolder;
             if (!isOperationContextSet)
             {
-                contextHolder = OperationContext.CurrentHolder;
-                originalContext = contextHolder.Context;
+                originalContext = OperationContext.Current;
             }
             else
             {
-                contextHolder = null;
                 originalContext = null;
             }
             IncrementBusyCount();
@@ -488,7 +485,7 @@ namespace CoreWCF.Dispatcher
             {
                 if (!isOperationContextSet)
                 {
-                    contextHolder.Context = OperationContext;
+                    OperationContext.Current = OperationContext;
                 }
 
                 await AsyncProcessor(this);
@@ -514,7 +511,7 @@ namespace CoreWCF.Dispatcher
 
                     if (!isOperationContextSet)
                     {
-                        contextHolder.Context = originalContext;
+                        OperationContext.Current = originalContext;
                     }
 
                     OperationContext.ClearClientReplyNoThrow();

--- a/src/CoreWCF.Primitives/src/CoreWCF/OperationContext.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/OperationContext.cs
@@ -13,7 +13,7 @@ namespace CoreWCF
 {
     public sealed class OperationContext : IExtensibleObject<OperationContext>
     {
-        private static readonly AsyncLocal<Holder> s_currentContext = new AsyncLocal<Holder>();
+        private static readonly AsyncLocal<OperationContext> s_currentContext = new AsyncLocal<OperationContext>();
         private Message _clientReply;
         private bool _closeClientReply;
         private ExtensionCollection<OperationContext> _extensions;
@@ -79,26 +79,12 @@ namespace CoreWCF
         {
             get
             {
-                return CurrentHolder.Context;
+                return s_currentContext.Value;
             }
 
             set
             {
-                CurrentHolder.Context = value;
-            }
-        }
-
-        internal static Holder CurrentHolder
-        {
-            get
-            {
-                Holder holder = s_currentContext.Value;
-                if (holder == null)
-                {
-                    holder = new Holder();
-                    s_currentContext.Value = holder;
-                }
-                return holder;
+                s_currentContext.Value = value;
             }
         }
 
@@ -353,11 +339,6 @@ namespace CoreWCF
         internal void SetInstanceContext(InstanceContext instanceContext)
         {
             InstanceContext = instanceContext;
-        }
-
-        internal class Holder
-        {
-            public OperationContext Context { get; set; }
         }
     }
 }

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -36,5 +36,6 @@
   <ItemGroup>
     <ProjectReference Include="../src/CoreWCF.Primitives.csproj" />
     <ProjectReference Include="$(SourceDir)CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj" />
+    <ProjectReference Include="$(SourceDir)CoreWCF.Http/src/CoreWCF.Http.csproj" />
   </ItemGroup>
 </Project>

--- a/src/CoreWCF.Primitives/tests/OperationContextTests.cs
+++ b/src/CoreWCF.Primitives/tests/OperationContextTests.cs
@@ -58,7 +58,7 @@ namespace CoreWCF.Primitives.Tests
                     try
                     {
                         // Wait until a second request is running.
-                        if (!SecondRequestInMidOperationEvent.Wait(TimeSpan.FromSeconds(10)))
+                        if (!SecondRequestInMidOperationEvent.Wait(TimeSpan.FromSeconds(30)))
                         {
                             throw new FaultException("An expected event from the second request did not set in time.");
                         }
@@ -82,7 +82,7 @@ namespace CoreWCF.Primitives.Tests
                     SecondRequestInMidOperationEvent.Set();
 
                     // Wait until OperationContext assertion happens in the first request
-                    if (!OperationContextAssertedEvent.Wait(TimeSpan.FromSeconds(10)))
+                    if (!OperationContextAssertedEvent.Wait(TimeSpan.FromSeconds(30)))
                     {
                         throw new FaultException("An expected assertion event from the first request did not set in time.");
                     }
@@ -139,7 +139,7 @@ namespace CoreWCF.Primitives.Tests
                     Task firstRequest = RequestAndAssert(cancellationSource);
 
                     // Wait until the first request stored initial OperationContext.Current .
-                    if (!service.FirstRequestStoredOperationContextEvent.Wait(TimeSpan.FromSeconds(10), cancellationToken))
+                    if (!service.FirstRequestStoredOperationContextEvent.Wait(TimeSpan.FromSeconds(30), cancellationToken))
                     {
                         // In case we don't get the event on time, we want first and foremost to see any exception thrown
                         // from the request.

--- a/src/CoreWCF.Primitives/tests/OperationContextTests.cs
+++ b/src/CoreWCF.Primitives/tests/OperationContextTests.cs
@@ -3,22 +3,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
-using System.Net.NetworkInformation;
-using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web.Services.Description;
 using CoreWCF.Configuration;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace CoreWCF.Primitives.Tests

--- a/src/CoreWCF.Primitives/tests/OperationContextTests.cs
+++ b/src/CoreWCF.Primitives/tests/OperationContextTests.cs
@@ -141,6 +141,11 @@ namespace CoreWCF.Primitives.Tests
                     // Wait until the first request stored initial OperationContext.Current .
                     if (!service.FirstRequestStoredOperationContextEvent.Wait(TimeSpan.FromSeconds(10), cancellationToken))
                     {
+                        // In case we don't get the event on time, we want first and foremost to see any exception thrown
+                        // from the request.
+                        await firstRequest;
+
+                        // This is a fallback in case there is no exception from the request.
                         Assert.Fail("An expected context event from the first request did not set in time.");
                     }
 
@@ -151,8 +156,7 @@ namespace CoreWCF.Primitives.Tests
 
                     // The first request is the one that actually asserts for the changed OperationContext.
                     // If there is any assertion failure, this is the one that will throw it.
-                    await firstRequest;
-                    await secondRequest;
+                    await Task.WhenAll(firstRequest, secondRequest);
                 }
                 finally
                 {

--- a/src/CoreWCF.Primitives/tests/OperationContextTests.cs
+++ b/src/CoreWCF.Primitives/tests/OperationContextTests.cs
@@ -1,0 +1,153 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Services.Description;
+using CoreWCF.Configuration;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CoreWCF.Primitives.Tests
+{
+    public partial class OperationContextTests
+    {
+        private static readonly Uri _serviceAddress = new Uri($"http://localhost:8080/Test", UriKind.Absolute);
+
+        [ServiceContract]
+        private interface IContract
+        {
+            [OperationContract]
+            void Operation();
+        }
+
+        // IncludeExceptionDetailInFaults is not needed to reproduce the original bug,
+        // it's here purely for better Exception visibility in case of a failure.
+        [ServiceBehavior(IncludeExceptionDetailInFaults = true)]
+        private class Service : IContract
+        {
+            public void Operation()
+            {
+                var context = OperationContext.Current;
+
+                // This sleep is not needed to reproduce the original bug in a real environment,
+                // but is essential to reproduce it in a test environment.
+                Thread.Sleep(100);
+
+                if (context != OperationContext.Current)
+                {
+                    throw new FaultException("OperationContext.Current was replaced in mid-operation.");
+                }
+            }
+        }
+
+        private class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Service>();
+                    var binding = new BasicHttpBinding(Channels.BasicHttpSecurityMode.None);
+                    builder.AddServiceEndpoint<Service, IContract>(binding, _serviceAddress);
+                });
+            }
+        }
+
+        [Fact]
+        public async Task AccessingCurrentOperationContextBeforeStartingTheHostSouldNotCauseExceptionsLater()
+        {
+            // This single line is what actually caused the original bug to occur
+            var context = OperationContext.Current;
+
+            var builder = WebHost.CreateDefaultBuilder<Startup>(null);
+            builder.UseKestrel(o =>
+            {
+                o.ListenAnyIP(_serviceAddress.Port);
+            });
+            var host = builder.Build();
+            using (host)
+            {
+                host.Start();
+
+                CancellationTokenSource cancellationSource = new CancellationTokenSource();
+                CancellationToken cancellationToken = cancellationSource.Token;
+
+                IEnumerable<Task> clientTasks = Enumerable.Range(0, 2).Select(async i =>
+                {
+                    using (var client = new HttpClient())
+                    {
+                        for (int j = 0; j < 10 && !cancellationToken.IsCancellationRequested; j++)
+                        {
+                            try
+                            {
+                                //
+                                // FIXME:
+                                // - Pre-read buffer breaks message parsing when Transfer-Encoding is set to chunked (removes first byte)
+                                // - When a message is invalid, but no error is thrown, message reply crashes because a null message is passed to the Close channel
+                                //
+
+                                var request = new HttpRequestMessage(HttpMethod.Post, _serviceAddress);
+
+                                const string action = "http://tempuri.org/IContract/Operation";
+                                request.Headers.TryAddWithoutValidation("SOAPAction", $"\"{action}\"");
+
+                                const string requestBody = @"<s:Envelope xmlns:s=""http://schemas.xmlsoap.org/soap/envelope/"">
+   <s:Header/>
+   <s:Body>
+      <Operation xmlns=""http://tempuri.org/"" />
+   </s:Body>
+</s:Envelope>";
+
+                                request.Content = new StringContent(requestBody, Encoding.UTF8, "text/xml");
+
+                                // FIXME: Commenting out this line will induce a chunked response, which will break the pre-read message parser
+                                request.Content.Headers.ContentLength = Encoding.UTF8.GetByteCount(requestBody);
+
+                                var response = await client.SendAsync(request);
+
+                                var responseBody = await response.Content.ReadAsStringAsync();
+
+                                const string expected = "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+                                                        "<s:Body>" +
+                                                        "<OperationResponse xmlns=\"http://tempuri.org/\"/>" +
+                                                        "</s:Body>" +
+                                                        "</s:Envelope>";
+
+                                // The <object> is a workaround for xUnit to print the whole string in case of a failure
+                                Assert.Equal<object>(expected, responseBody);
+                                Assert.True(response.IsSuccessStatusCode);
+
+                            }
+                            catch
+                            {
+                                cancellationSource.Cancel();
+                                throw;
+                            }
+                        }
+                    }
+                });
+
+                await Task.WhenAll(clientTasks);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Fixed: Calling OperationContext.Current before the host started causes later exceptions and bugs.
- Implemented a test that validates the above fixed issue.

#1126