### PR TITLE
Rolling back dependency on System.IO.Pipelines to 6.0.x version

### DIFF
--- a/src/CoreWCF.Kafka/src/CoreWCF.Kafka.csproj
+++ b/src/CoreWCF.Kafka/src/CoreWCF.Kafka.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="7.0.0" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The current policy is to depend on the oldest supported LTS version of dependencies to reduce compatibility issues.