### PR TITLE
Change proposed to make more explicit exception handling

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ConcurrencyBehavior.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ConcurrencyBehavior.cs
@@ -112,7 +112,8 @@ namespace CoreWCF.Dispatcher
                 // TODO: Throw this on setup
                 if (_concurrencyMode == ConcurrencyMode.Reentrant)
                 {
-                    throw new NotSupportedException(nameof(ConcurrencyMode.Reentrant));
+                    //throw new NotSupportedException(nameof(ConcurrencyMode.Reentrant));
+                    throw new Exception($"ConcurrencyMode {nameof(ConcurrencyMode.Reentrant)} is not yet supported by current version" );
                 }
             }
         }


### PR DESCRIPTION
since some standard service components might wrapt it, making The exception error unreadable such as the one given below:
```bash
System.ServiceModel.FaultException`1
  HResult=0x80131500
  Message=Reentrant
  Source=System.Private.ServiceModel
  StackTrace:
   at System.ServiceModel.Channels.ServiceChannel.ThrowIfFaultUnderstood(Message reply, MessageFault fault, String action, MessageVersion version, FaultConverter faultConverter)
   at System.ServiceModel.Channels.ServiceChannel.HandleReply(ProxyOperationRuntime operation, ProxyRpc& rpc)
   at System.ServiceModel.Channels.ServiceChannel.Call(String action, Boolean oneway, ProxyOperationRuntime operation, Object[] ins, Object[] outs, TimeSpan timeout)
   at System.ServiceModel.Channels.ServiceChannel.Call(String action, Boolean oneway, ProxyOperationRuntime operation, Object[] ins, Object[] outs)
   at System.ServiceModel.Channels.ServiceChannelProxy.InvokeService(MethodCall methodCall, ProxyOperationRuntime operation)
   at System.ServiceModel.Channels.ServiceChannelProxy.Invoke(MethodInfo targetMethod, Object[] args)
   at generatedProxy_1.GetServiceStatus()
   at Program.Main(String[] args) in C:\Appl\source\stid\Equinor.Stid.Dev\Source\WCFDummyClient\WCFDummyClient\Program.cs:line 70
```