### PR TITLE
Enhance offset commit handling when using AtLeastOnce semantic

### DIFF
--- a/src/CoreWCF.Kafka/src/CoreWCF/Channels/KafkaReceiveContext.cs
+++ b/src/CoreWCF.Kafka/src/CoreWCF/Channels/KafkaReceiveContext.cs
@@ -31,14 +31,7 @@ internal class KafkaReceiveContext : ReceiveContext
 
             if (_kafkaTransportPump.TransportBindingElement.DeliverySemantics == KafkaDeliverySemantics.AtLeastOnce)
             {
-                if (_kafkaTransportPump.ConsumerConfig.EnableAutoCommit == false)
-                {
-                    _kafkaTransportPump.Consumer.Commit(_consumeResult);
-                }
-                else if (_kafkaTransportPump.ConsumerConfig.EnableAutoOffsetStore == false)
-                {
-                    _kafkaTransportPump.Consumer.StoreOffset(_consumeResult);
-                }
+                _kafkaTransportPump.OffsetTracker.MarkAsProcessed(_consumeResult.TopicPartitionOffset);
             }
         }
         finally
@@ -53,14 +46,7 @@ internal class KafkaReceiveContext : ReceiveContext
         {
             if (_kafkaTransportPump.TransportBindingElement.DeliverySemantics == KafkaDeliverySemantics.AtLeastOnce)
             {
-                if (_kafkaTransportPump.ConsumerConfig.EnableAutoCommit == false)
-                {
-                    _kafkaTransportPump.Consumer.Commit(_consumeResult);
-                }
-                else if (_kafkaTransportPump.ConsumerConfig.EnableAutoOffsetStore == false)
-                {
-                    _kafkaTransportPump.Consumer.StoreOffset(_consumeResult);
-                }
+                _kafkaTransportPump.OffsetTracker.MarkAsProcessed(_consumeResult.TopicPartitionOffset);
             }
         }
         finally

--- a/src/CoreWCF.Kafka/src/CoreWCF/Channels/KafkaReceiveContext.cs
+++ b/src/CoreWCF.Kafka/src/CoreWCF/Channels/KafkaReceiveContext.cs
@@ -31,7 +31,7 @@ internal class KafkaReceiveContext : ReceiveContext
 
             if (_kafkaTransportPump.TransportBindingElement.DeliverySemantics == KafkaDeliverySemantics.AtLeastOnce)
             {
-                _kafkaTransportPump.OffsetTracker.MarkAsProcessed(_consumeResult.TopicPartitionOffset);
+                _kafkaTransportPump.OffsetTracker.MarkAsProcessed(_consumeResult);
             }
         }
         finally
@@ -46,7 +46,7 @@ internal class KafkaReceiveContext : ReceiveContext
         {
             if (_kafkaTransportPump.TransportBindingElement.DeliverySemantics == KafkaDeliverySemantics.AtLeastOnce)
             {
-                _kafkaTransportPump.OffsetTracker.MarkAsProcessed(_consumeResult.TopicPartitionOffset);
+                _kafkaTransportPump.OffsetTracker.MarkAsProcessed(_consumeResult);
             }
         }
         finally

--- a/src/CoreWCF.Kafka/tests/Helpers/IntegrationTest.cs
+++ b/src/CoreWCF.Kafka/tests/Helpers/IntegrationTest.cs
@@ -32,7 +32,6 @@ public class IntegrationTest : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-
         await KafkaEx.CreateTopicAsync(Output, Topic);
         if (_useDlq)
         {

--- a/src/CoreWCF.Kafka/tests/Helpers/IntegrationTest.cs
+++ b/src/CoreWCF.Kafka/tests/Helpers/IntegrationTest.cs
@@ -28,8 +28,6 @@ public class IntegrationTest : IAsyncLifetime
         ConsumerGroup = $"cg-{Guid.NewGuid()}";
     }
 
-
-
     public async Task InitializeAsync()
     {
         await KafkaEx.CreateTopicAsync(Output, Topic);

--- a/src/CoreWCF.Kafka/tests/Helpers/KafkaEx.cs
+++ b/src/CoreWCF.Kafka/tests/Helpers/KafkaEx.cs
@@ -20,7 +20,7 @@ internal static class KafkaEx
     public static async Task CreateTopicAsync(ITestOutputHelper output, string name)
     {
         output.WriteLine($"Create topic {name}");
-        await AdminClient.Value.CreateTopicsAsync(new[] { new TopicSpecification() { Name = name } }, new CreateTopicsOptions()
+        await AdminClient.Value.CreateTopicsAsync(new[] { new TopicSpecification() { Name = name, NumPartitions = 4 } }, new CreateTopicsOptions()
         {
             OperationTimeout = TimeSpan.FromSeconds(30)
         });
@@ -61,8 +61,7 @@ internal static class KafkaEx
             long committed = tpo.Offset.Value;
             if (committed == Offset.Unset)
             {
-                throw new NotSupportedException(
-                    $"Invalid offset, no message of this partition have been consumed by the consumer '{consumerGroup}'");
+                continue;
             }
             long logEndOffset = watermarkOffsets.High.Value;
             lag += logEndOffset - committed;

--- a/src/CoreWCF.Kafka/tests/Services/TestService.cs
+++ b/src/CoreWCF.Kafka/tests/Services/TestService.cs
@@ -24,6 +24,14 @@ public interface ITestContract
     [System.ServiceModel.OperationContract(IsOneWay = true, Name = "CreateAsync")]
     [OperationContract(IsOneWay = true, Name = "CreateAsync")]
     Task CreateAsync(string name);
+
+    [System.ServiceModel.OperationContract(IsOneWay = true)]
+    [OperationContract(IsOneWay = true)]
+    void DoSomethingBlocking();
+
+    [System.ServiceModel.OperationContract(IsOneWay = true)]
+    [OperationContract(IsOneWay = true)]
+    void DoSomething();
 }
 
 public class TestService : ITestContract
@@ -46,6 +54,18 @@ public class TestService : ITestContract
         return Task.CompletedTask;
     }
 
+    public void DoSomething()
+    {
+        CountdownEvent.Signal(1);
+    }
+
+    public void DoSomethingBlocking()
+    {
+        BlockingManualResetEvent.Wait();
+        CountdownEvent.Signal(1);
+    }
+
     public CountdownEvent CountdownEvent { get; } = new(0);
     public ConcurrentBag<string> Names { get; } = new();
+    public ManualResetEventSlim BlockingManualResetEvent { get; set; } = new(false);
 }


### PR DESCRIPTION
- Use topic with 4 partitions in integration to bette simulate real production deployments
- Add an `AutoCommitInterval` delay before closing consumer to let librdkafka commit thread run.
- Finegrain offset storage and commit handling