### PR TITLE
Fix issues with CoreWCFWebApplicationExtensions

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
@@ -39,6 +39,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="CoreWCFWebApplicationExtensions.cs" />
+    <None Include="CoreWCFWebApplicationExtensions.cs" Link="PackageFiles/CoreWCFWebApplicationExtensions.cs" />
+    <None Include="CoreWCF.Primitives.props" Link="PackageFiles/CoreWCF.Primitives.props"/>
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(OutputPath)\CoreWCF.BuildTools.Roslyn4.0.dll">

--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.props
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' != 'net'">
+  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' != 'net' AND !$(TargetFramework.StartsWith('netstandard'))">
     <Compile Include="$(MSBuildThisFileDirectory)/../contentFiles/CoreWCFWebApplicationExtensions.cs">
       <Visible>false</Visible>
     </Compile>

--- a/src/CoreWCF.Primitives/src/CoreWCFWebApplicationExtensions.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCFWebApplicationExtensions.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace CoreWCF.Configuration
 {
-    public static class WebApplicationExtensions
+    internal static class WebApplicationExtensions
     {
         public static Microsoft.Extensions.Hosting.IHost UseServiceModel(this Microsoft.AspNetCore.Builder.WebApplication app, Action<IServiceBuilder> configureServices)
         {


### PR DESCRIPTION
Stop CoreWCFWebApplicationExtensions being included for netstandard projects. 
Make included source internal as it's buildtransitive in the package. Without this fix, ProjectA depending on ProjectB depending on CoreWCF.Primitives will have CoreWCFWebApplicationExtensions compiled into ProjectB and ProjectA. If ProjectA has code which calls WebApplication.UseServiceModel, it will be ambiguous between the two public copies. Making it internal removes the ambiguity.