### PR TITLE
Fix CoreWCFWebApplicationExtensions when Microsoft.AspNetCore.App FrameworkReference isn't included

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
@@ -40,7 +40,7 @@
   <ItemGroup>
     <Compile Remove="CoreWCFWebApplicationExtensions.cs" />
     <None Include="CoreWCFWebApplicationExtensions.cs" Link="PackageFiles/CoreWCFWebApplicationExtensions.cs" />
-    <None Include="CoreWCF.Primitives.props" Link="PackageFiles/CoreWCF.Primitives.props"/>
+    <None Include="CoreWCF.Primitives.targets" Link="PackageFiles/CoreWCF.Primitives.targets"/>
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(OutputPath)\CoreWCF.BuildTools.Roslyn4.0.dll">
@@ -53,7 +53,7 @@
       <PackagePath>analyzers/dotnet/roslyn3.11/cs</PackagePath>
       <Visible>false</Visible>
     </Content>
-    <Content Include="CoreWCF.Primitives.props">
+    <Content Include="CoreWCF.Primitives.targets">
       <Pack>true</Pack>
       <PackagePath>build;buildTransitive</PackagePath>
       <Visible>false</Visible>

--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.props
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.props
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project>
-  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' != 'net' AND !$(TargetFramework.StartsWith('netstandard'))">
-    <Compile Include="$(MSBuildThisFileDirectory)/../contentFiles/CoreWCFWebApplicationExtensions.cs">
-      <Visible>false</Visible>
-    </Compile>
-  </ItemGroup>
-</Project>

--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.targets
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.targets
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup Condition="'$(_CoreWCFSuppressWebApplicationExtensions)' != 'true' AND
+                        '$(TargetFramework.TrimEnd(`0123456789`))' != 'net' AND
+                        !$(TargetFramework.StartsWith('netstandard')) AND
+                        (@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count()) != 0)">
+    <Compile Include="$(MSBuildThisFileDirectory)/../contentFiles/CoreWCFWebApplicationExtensions.cs">
+      <Visible>false</Visible>
+    </Compile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Tested with 2 projects, a library project with contract and implementation referencing CoreWCF packages, but no references to asp.net core, and a service app which launches an asp.net core app which doesn't reference the CoreWCF packages and inherits them transitively.
I tested with the library targeting netstandard2.0, and multi-targeting net6.0 and net472. Also tested with the service app targeting net6.0 and net472, as well as net6.0 using a FrameworkReference for  Microsoft.AspNetCore.App, or a PackageReference for Microsoft.AspNetCore, as well as using the Sdk Microsoft.NET.Sdk.Web. It appears to work correctly in all scenarios now.