### PR TITLE
Add OpenApi document defaults so more methods are documented and prefix address

### DIFF
--- a/src/CoreWCF.WebHttp/src/CoreWCF/Configuration/ServiceModelWebServiceBuilderExtensions.cs
+++ b/src/CoreWCF.WebHttp/src/CoreWCF/Configuration/ServiceModelWebServiceBuilderExtensions.cs
@@ -239,6 +239,7 @@ namespace CoreWCF.Configuration
                     documentProvider.Contracts.Add(new OpenApiContractInfo
                     {
                         Contract = implementedContract,
+                        Address = address,
                         ResponseFormat = webHttpBehavior.DefaultOutgoingResponseFormat
                     });
                 }

--- a/src/CoreWCF.WebHttp/src/CoreWCF/OpenApi/OpenApiContractInfo.cs
+++ b/src/CoreWCF.WebHttp/src/CoreWCF/OpenApi/OpenApiContractInfo.cs
@@ -17,6 +17,11 @@ namespace CoreWCF.OpenApi
         public Type Contract { get; set; }
 
         /// <summary>
+        /// The URI the contract is registered on.
+        /// </summary>
+        public Uri Address { get; set; }
+
+        /// <summary>
         /// Default format of the response.
         /// </summary>
         public WebMessageFormat ResponseFormat { get; set; }

--- a/src/CoreWCF.WebHttp/src/CoreWCF/OpenApi/OpenApiSchemaBuilder.cs
+++ b/src/CoreWCF.WebHttp/src/CoreWCF/OpenApi/OpenApiSchemaBuilder.cs
@@ -140,6 +140,7 @@ namespace CoreWCF.OpenApi
                         tagsToHide,
                         basePathAttribute?.BasePath,
                         contractInfo.ResponseFormat,
+                        contractInfo.Address,
                         GetMethodUriWebGet);
 
                     PopulateOpenApiPath(
@@ -148,6 +149,7 @@ namespace CoreWCF.OpenApi
                         tagsToHide,
                         basePathAttribute?.BasePath,
                         contractInfo.ResponseFormat,
+                        contractInfo.Address,
                         GetMethodUriWebInvoke);
                 }
             }
@@ -168,6 +170,7 @@ namespace CoreWCF.OpenApi
             IEnumerable<string> tagsToHide,
             string additionalBasePath,
             WebMessageFormat behaviorFormat,
+            Uri address,
             Func<MethodInfo, OperationInfo> getOperationInfo)
         {
             OperationInfo operationInfo = getOperationInfo(methodInfo);
@@ -193,6 +196,7 @@ namespace CoreWCF.OpenApi
 
             string uri = Regex.Replace(operationInfo.UriTemplate, @"\?.*", "");
 
+            uri = address.OriginalString + "/" + uri;
             if (!string.IsNullOrEmpty(additionalBasePath))
             {
                 uri = additionalBasePath + uri;
@@ -281,7 +285,7 @@ namespace CoreWCF.OpenApi
             return new OperationInfo
             {
                 Method = "get",
-                UriTemplate = attribute.UriTemplate,
+                UriTemplate = attribute.UriTemplate ?? methodInfo.Name,
                 IsResponseFormatSetExplicitly = attribute.IsResponseFormatSetExplicitly,
                 ResponseFormat = attribute.ResponseFormat,
                 IsRequestFormatSetExplicitly = attribute.IsRequestFormatSetExplicitly,
@@ -306,8 +310,8 @@ namespace CoreWCF.OpenApi
 
             return new OperationInfo
             {
-                Method = attribute.Method?.ToLower(CultureInfo.InvariantCulture),
-                UriTemplate = attribute.UriTemplate,
+                Method = attribute.Method?.ToLower(CultureInfo.InvariantCulture) ?? "post",
+                UriTemplate = attribute.UriTemplate ?? methodInfo.Name,
                 IsResponseFormatSetExplicitly = attribute.IsResponseFormatSetExplicitly,
                 ResponseFormat = attribute.ResponseFormat,
                 IsRequestFormatSetExplicitly = attribute.IsRequestFormatSetExplicitly,


### PR DESCRIPTION
This PR adds default for the `WebInvoke` - "post", and the `Method` properties for `WebInvoke` and `WebGet` so that more methods can be documented.  Also prefixes the registered address to the path.