### PR TITLE
Prevent null reference exception when a client makes request to wrong endpoint address (#1331)

### DIFF
--- a/src/Common/UnitTests.Common/Helpers/ExceptionCapturingLogger.cs
+++ b/src/Common/UnitTests.Common/Helpers/ExceptionCapturingLogger.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Helpers
+{
+    public class ExceptionCapturingLogger : ILogger
+    {
+        private readonly ILogger _wrappedLogger;
+        private readonly ConcurrentBag<Exception> _exceptionsLogged = new();
+        public ExceptionCapturingLogger(ILogger wrappedLogger)
+        {
+            _wrappedLogger = wrappedLogger;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            _wrappedLogger?.Log(logLevel, eventId, state, exception, formatter);
+            if (exception != null)
+            {
+                _exceptionsLogged.Add(exception);
+            }
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => _wrappedLogger?.IsEnabled(logLevel) ?? (int)logLevel>= (int)LogLevel.Error;
+
+        public IDisposable BeginScope<TState>(TState state) => NoopDisposable.Instance;
+        public IEnumerable<Exception> ExceptionsLogged => _exceptionsLogged;
+        private class NoopDisposable : IDisposable
+        {
+            public static NoopDisposable Instance = new NoopDisposable();
+            public void Dispose()
+            { }
+        }
+    }
+}

--- a/src/Common/UnitTests.Common/Helpers/ExceptionCapturingLoggerProvider.cs
+++ b/src/Common/UnitTests.Common/Helpers/ExceptionCapturingLoggerProvider.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace Helpers
+{
+    public class ExceptionCapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly XunitLoggerProvider _wrappedProvider;
+        private readonly ConcurrentDictionary<string, ExceptionCapturingLogger> _loggers = new ConcurrentDictionary<string, ExceptionCapturingLogger>();
+        public ExceptionCapturingLoggerProvider(XunitLoggerProvider wrappedProvider)
+        {
+            _wrappedProvider = wrappedProvider;
+        }
+
+        public void Dispose()
+        { }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _loggers.GetOrAdd(categoryName, new ExceptionCapturingLogger(_wrappedProvider?.CreateLogger(categoryName)));
+        }
+
+        public IEnumerable<TException> GetExceptionsLogged<TException>() where TException : Exception
+        {
+            return _loggers.SelectMany(l=>l.Value.ExceptionsLogged).OfType<TException>();
+        }
+    }
+}

--- a/src/CoreWCF.NetFramingBase/src/CoreWCF/Channels/Framing/FramingModeHandshakeMiddleware.cs
+++ b/src/CoreWCF.NetFramingBase/src/CoreWCF/Channels/Framing/FramingModeHandshakeMiddleware.cs
@@ -73,7 +73,15 @@ namespace CoreWCF.Channels.Framing
                     // Unwrap the connection.
                     // TODO: Investigate calling Dispose on the wrapping stream to improve cleanup. nb: .NET Framework does not call Dispose.
                     connection.Transport = connection.RawTransport;
+
                     // connection.ServiceDispatcher is null until later middleware layers are executed.
+                    if (connection.ServiceDispatcher == null)
+                    {
+                        await connection.SendFaultAsync(FramingEncodingString.EndpointNotFoundFault, Timeout.InfiniteTimeSpan/*GetRemainingTimeout()*/,
+                            ConnectionOrientedTransportDefaults.MaxViaSize + ConnectionOrientedTransportDefaults.MaxContentTypeSize);
+                        return;
+                    }
+
                     if (reuseHandler == null)
                     {
                         reuseHandler = connection.ServiceDispatcher.Binding.GetProperty<IConnectionReuseHandler>(new BindingParameterCollection());

--- a/src/CoreWCF.NetTcp/tests/BadRequestTest.cs
+++ b/src/CoreWCF.NetTcp/tests/BadRequestTest.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.NetTcp.Tests
+{
+    public class BadRequestTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public BadRequestTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void UsingWrongUrlShouldNotThrowNullReferenceException()
+        {
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output, IPAddress.Loopback).Build();
+
+            using (host)
+            {
+                host.Start();
+                var netTcpBinding = ClientHelper.GetBufferedModeBinding();
+                var testServiceFactory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(netTcpBinding,
+                    new System.ServiceModel.EndpointAddress(new Uri($"{host.GetNetTcpAddressInUse()}/TestService.svc/1")));
+                var testServiceChannel = testServiceFactory.CreateChannel();
+
+
+                // Verify the EchoService throws exception because of invalid url
+                string toEcho = "hello, world!";
+                Assert.Throws<System.ServiceModel.EndpointNotFoundException>(() => testServiceChannel.EchoString(toEcho));
+                host.AssertNoExceptionsLogged<NullReferenceException>();
+            }
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.TestService>();
+                    builder.AddServiceEndpoint<Services.TestService, ServiceContract.ITestService>(new NetTcpBinding(SecurityMode.None), "/TestService.svc/0");
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Simple code fix with test that asserts that a NullReferenceException is no longer thrown when a client makes a request to a wrong endpoint