### PR TITLE
Fix service endpoint URL in WSDL for WCF deployed in container

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/ServiceHostObjectModel.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/ServiceHostObjectModel.cs
@@ -261,6 +261,14 @@ namespace CoreWCF
             {
                 address = "https://localhost" + address.Substring(9);
             }
+            else if (address.StartsWith("http://[::]", StringComparison.OrdinalIgnoreCase))
+            {
+                address = "http://localhost" + address.Substring(11);
+            }
+            else if (address.StartsWith("https://[::]", StringComparison.OrdinalIgnoreCase))
+            {
+                address = "https://localhost" + address.Substring(12);
+            }
             else if (address.StartsWith("https://*.", StringComparison.OrdinalIgnoreCase) ||
                     address.StartsWith("http://*.", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
This is a simple fix for an issue with serviceEndpoint URL when WCF is deployed in the container.
![Screenshot 2024-02-02 at 12 27 19 PM](https://github.com/CoreWCF/CoreWCF/assets/14877943/817b8498-b946-4f04-b891-b45ac5b2fef1)
The fix is pulled from stale PR https://github.com/CoreWCF/CoreWCF/pull/1101 with multiple other fixes.
Also, this issue is mentioned in several other places 
https://github.com/CoreWCF/CoreWCF/issues/700
https://github.com/CoreWCF/CoreWCF/issues/1291 
https://github.com/CoreWCF/CoreWCF/issues/659
