### PR TITLE
Add support for binding namespace for WCF xml based configs

### DIFF
--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ConfigurationHolder.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ConfigurationHolder.cs
@@ -27,7 +27,7 @@ namespace CoreWCF.Configuration
             _bindings.Add(binding.Name, binding);
         }
 
-        public Binding ResolveBinding(string bindingType, string name, string bindingNamespace)
+        public Binding ResolveBinding(string bindingType, string name, string bindingNamespace = null)
         {
             if (string.IsNullOrEmpty(bindingType))
             {

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ConfigurationManagerServiceModelOptions.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ConfigurationManagerServiceModelOptions.cs
@@ -101,7 +101,8 @@ namespace CoreWCF.Configuration
                         endpoint.Address,
                         endpoint.Contract,
                         endpoint.Binding,
-                        endpoint.BindingConfiguration);
+                        endpoint.BindingConfiguration,
+                        endpoint.BindingNamespace);
                 }
             }
         }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/IConfigurationHolder.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/IConfigurationHolder.cs
@@ -12,8 +12,8 @@ namespace CoreWCF.Configuration
     {
         ISet<ServiceEndpoint> Endpoints { get; }
         void AddBinding(Binding binding);
-        void AddServiceEndpoint(string name, string serviceName, Uri address, string contract, string bindingType, string bindingName);
-        Binding ResolveBinding(string bindingType, string name);
+        void AddServiceEndpoint(string name, string serviceName, Uri address, string contract, string bindingType, string bindingName, string bindingNamespace);
+        Binding ResolveBinding(string bindingType, string name, string bindingNamespace);
         IXmlConfigEndpoint GetXmlConfigEndpoint(ServiceEndpoint endPoint);
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/IConfigurationHolder.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/IConfigurationHolder.cs
@@ -13,7 +13,7 @@ namespace CoreWCF.Configuration
         ISet<ServiceEndpoint> Endpoints { get; }
         void AddBinding(Binding binding);
         void AddServiceEndpoint(string name, string serviceName, Uri address, string contract, string bindingType, string bindingName, string bindingNamespace);
-        Binding ResolveBinding(string bindingType, string name, string bindingNamespace);
+        Binding ResolveBinding(string bindingType, string name, string bindingNamespace = null);
         IXmlConfigEndpoint GetXmlConfigEndpoint(ServiceEndpoint endPoint);
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ServiceEndpoint.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ServiceEndpoint.cs
@@ -13,5 +13,6 @@ namespace CoreWCF.Configuration
         public string BindingConfiguration { get; set; }
         public string Name { get; set; }
         public string Contract { get; set; }
+        public string BindingNamespace { get; set; }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ServiceEndpointElement.cs
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF/Configuration/ServiceEndpointElement.cs
@@ -172,7 +172,8 @@ namespace CoreWCF.Configuration
                 Address = Address,
                 Binding = Binding,
                 BindingConfiguration = BindingConfiguration,
-                Contract = Contract
+                Contract = Contract,
+                BindingNamespace = BindingNamespace
             };
 
             return endpoint;

--- a/src/CoreWCF.ConfigurationManager/tests/ConfigurationHolderTests.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/ConfigurationHolderTests.cs
@@ -97,5 +97,41 @@ namespace CoreWCF.ConfigurationManager.Tests
                 }
             }
         }
+
+        [Fact]
+        public void CreateBindingWithNameSpaceTest()
+        {
+            string expectedAddress = "net.tcp://localhost:8740/";
+            string expectedEndpointName = "SomeEndpoint";
+            string expectedServiceName = typeof(SomeService).FullName;
+            string expectedNameSpace = "CustomEndpoint";
+            string xml = $@"
+<configuration> 
+    <system.serviceModel>
+        <services>
+            <service name=""{expectedServiceName}"">
+                  <endpoint address=""{expectedAddress}""
+                          name=""{expectedEndpointName}""
+                          binding=""netTcpBinding""
+                          bindingNamespace=""{expectedNameSpace}""
+                          contract=""{typeof(ISomeService).FullName}"" />
+            </service>
+        </services>
+   </system.serviceModel>
+</configuration>";
+
+            using (var fs = TemporaryFileStream.Create(xml))
+            {
+                using (ServiceProvider provider = CreateProvider(fs.Name))
+                {
+                    IConfigurationHolder settingHolder = GetConfigurationHolder(provider);
+                    IXmlConfigEndpoint endpoint = GetXmlConfigEndpointByEndpointName(settingHolder, expectedEndpointName);
+                    Assert.Equal(expectedServiceName, endpoint.Service.FullName);
+                    Assert.IsType<NetTcpBinding>(endpoint.Binding);
+                    Assert.Equal("NetTcpBinding", endpoint.Binding.Name);
+                    Assert.Equal(expectedNameSpace, endpoint.Binding.Namespace);
+                }
+            }
+        }
     }
 }

--- a/src/CoreWCF.ConfigurationManager/tests/CustomBindingTests.cs
+++ b/src/CoreWCF.ConfigurationManager/tests/CustomBindingTests.cs
@@ -97,6 +97,45 @@ namespace CoreWCF.ConfigurationManager.Tests
             }
         }
 
+        [Fact]
+        public void CustomBinding_WithNamespaceSettings()
+        {
+            string expectedName = "customBinding";
+            string expectedNamespace = "customNamespace";
+            TimeSpan expectedReceiveTimeout = TimeSpan.FromMinutes(10);
+            TimeSpan expectedDefaultTimeout = TimeSpan.FromMinutes(1);
+
+
+            string xml = $@"
+<configuration> 
+    <system.serviceModel>         
+        <bindings>         
+            <customBinding>
+                <binding name=""{expectedName}"">
+                </binding>
+            </customBinding>                             
+        </bindings>                             
+   </system.serviceModel>
+</configuration>";
+
+            using (var fs = TemporaryFileStream.Create(xml))
+            {
+                using (ServiceProvider provider = CreateProvider(fs.Name))
+                {
+                    IConfigurationHolder settingHolder = GetConfigurationHolder(provider);
+
+                    CustomBinding actualBinding = settingHolder.ResolveBinding(nameof(CustomBinding), expectedName, expectedNamespace) as CustomBinding;
+
+                    Assert.Equal(expectedName, actualBinding.Name);
+                    Assert.Equal(expectedDefaultTimeout, actualBinding.CloseTimeout);
+                    Assert.Equal(expectedDefaultTimeout, actualBinding.OpenTimeout);
+                    Assert.Equal(expectedDefaultTimeout, actualBinding.SendTimeout);
+                    Assert.Equal(expectedReceiveTimeout, actualBinding.ReceiveTimeout);
+                    Assert.Equal(expectedNamespace, actualBinding.Namespace);
+                }
+            }
+        }
+
         #endregion
 
         #region Encoding


### PR DESCRIPTION
Fixes this issue with http://tempuri.org/ namespace in case of WCF configuration manager used to parse XML config https://github.com/CoreWCF/CoreWCF/discussions/1298