### PR TITLE
dotnet new --install deprecated, extra characters removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To keep up to date on what's going on with CoreWCF, you can subscribe to the [an
 
 * Install CoreWCF project templates, create a directory for your project and cd inside the directory and initialize your project
 ```cmd
-dotnet new --install CoreWCF.Templates 
+dotnet new install CoreWCF.Templates 
 dotnet new corewcf --name MyService
 ```
 * `CoreWCF Service` project template creates a minimal ASP.NET Core web application thats exposes the well-known WCF default service using a `BasicHttpBinding`.


### PR DESCRIPTION
use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.

![image](https://github.com/user-attachments/assets/52e45dc3-165b-440f-8df5-ef70ed11b2ad)
