### PR TITLE
Add missing UDS ProtectionLevel property

### DIFF
--- a/src/CoreWCF.NetTcp/tests/TransportFrameworkTests.cs
+++ b/src/CoreWCF.NetTcp/tests/TransportFrameworkTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -136,11 +137,13 @@ namespace CoreWCF.NetTcp.Tests
             string line;
             string originPort;
             string destinationPort = null;
+            string rawLine = null;
+            string matchingPortRawLine = null;
             bool verifiedClientPort = false;
 
             while (!myProcess.StandardOutput.EndOfStream)
             {
-                line = myProcess.StandardOutput.ReadLine();
+                rawLine = line = myProcess.StandardOutput.ReadLine();
 
                 int index = line.IndexOf("]");
 
@@ -169,6 +172,7 @@ namespace CoreWCF.NetTcp.Tests
 
                         index = line.IndexOf(":");
                         destinationPort = GetPort(line.Substring(++index));
+                        matchingPortRawLine = rawLine;
 
                         if (destinationPort == servicePort)
                         {
@@ -178,7 +182,9 @@ namespace CoreWCF.NetTcp.Tests
                 }
             }
 
-            Assert.True(verifiedClientPort, "Reported port does not match client machine info. Client port: " + clientPort + ", Service port (expected): " + servicePort + ", Destination port (actual): " + destinationPort);
+            // Test sometimes fail where the destinationPort string is empty so failing the destingationPort == servicePort check. Added more logging to help debug what's causing this.
+            Assert.True(verifiedClientPort, "Reported port does not match client machine info. Client port: \"" + clientPort + "\", Service port (expected): \"" + servicePort + "\", Destination port (actual): \""
+                + destinationPort + "\", client port matching line:" + Environment.NewLine + matchingPortRawLine);
             Assert.False(verifiedClientPort, "Reported port did not match any ports used by client.  Reported port: " + clientPort);
         }
 

--- a/src/CoreWCF.UnixDomainSocket/src/CoreWCF/UnixDomainSocketTransportSecurity.cs
+++ b/src/CoreWCF.UnixDomainSocket/src/CoreWCF/UnixDomainSocketTransportSecurity.cs
@@ -44,6 +44,21 @@ namespace CoreWCF
             }
         }
 
+        [DefaultValue(DefaultProtectionLevel)]
+        public ProtectionLevel ProtectionLevel
+        {
+            get { return _protectionLevel; }
+            set
+            {
+                if (!Security.ProtectionLevelHelper.IsDefined(value))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException(nameof(value)));
+                }
+
+                _protectionLevel = value;
+            }
+        }
+
         public ExtendedProtectionPolicy ExtendedProtectionPolicy
         {
             get

--- a/src/CoreWCF.UnixDomainSocket/tests/CoreWCF.UnixDomainSocket.Tests.csproj
+++ b/src/CoreWCF.UnixDomainSocket/tests/CoreWCF.UnixDomainSocket.Tests.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />  
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="Xunit.StaFact" Version="1.1.11" />
   </ItemGroup>
@@ -37,9 +37,13 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="System.ServiceModel.UnixDomainSocket" Version="6.2.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="6.2.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.ServiceModel.UnixDomainSocket" Version="8.0.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
There was also a problem where the unit tests had an extra catch block which would hide test failures.