### PR TITLE
Fix multiple problems with listen uri

### DIFF
--- a/src/CoreWCF.NetFramingBase/src/CoreWCF/Channels/Framing/NetMessageFramingConnectionHandler.cs
+++ b/src/CoreWCF.NetFramingBase/src/CoreWCF/Channels/Framing/NetMessageFramingConnectionHandler.cs
@@ -132,14 +132,17 @@ namespace CoreWCF.Channels.Framing
             else if ((upgradeBindingElements.Count == 1) && tbe.SupportsUpgrade(upgradeBindingElements[0]))
             {
                 SecurityCredentialsManager credentialsManager = dispatcher.Host.Description.Behaviors.Find<SecurityCredentialsManager>();
-                var bindingContext = new BindingContext(new CustomBinding(dispatcher.Binding), new BindingParameterCollection());
+                var bindingContext = new BindingContext(new CustomBinding(dispatcher.Binding), new BindingParameterCollection(), dispatcher.BaseAddress, string.Empty);
 
                 if (credentialsManager != null)
                     bindingContext.BindingParameters.Add(credentialsManager);
 
                 streamUpgradeProvider = upgradeBindingElements[0].BuildServerStreamUpgradeProvider(bindingContext);
-                streamUpgradeProvider.OpenAsync().GetAwaiter().GetResult();
-                securityCapabilities = upgradeBindingElements[0].GetProperty<ISecurityCapabilities>(bindingContext);
+                if (streamUpgradeProvider != null)
+                {
+                    streamUpgradeProvider.OpenAsync().GetAwaiter().GetResult();
+                    securityCapabilities = upgradeBindingElements[0].GetProperty<ISecurityCapabilities>(bindingContext);
+                }
             }
             return (connection) =>
             {

--- a/src/CoreWCF.NetTcp/tests/Helpers/ListenAddressVerifyingBindingElement.cs
+++ b/src/CoreWCF.NetTcp/tests/Helpers/ListenAddressVerifyingBindingElement.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using CoreWCF.Channels;
+using CoreWCF.Configuration;
+
+namespace Helpers
+{
+    internal class ListenAddressVerifyingBindingElement : StreamUpgradeBindingElement
+    {
+        public Uri ListenUriBaseAddress { get; private set; }
+
+        public override StreamUpgradeProvider BuildServerStreamUpgradeProvider(BindingContext context)
+        {
+            ListenUriBaseAddress = context.ListenUriBaseAddress;
+            return null;
+        }
+
+        public override BindingElement Clone() => this;
+        public override T GetProperty<T>(BindingContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return context.GetInnerProperty<T>();
+        }
+    }
+}

--- a/src/CoreWCF.NetTcp/tests/NetTcpServiceDispatcherTests.cs
+++ b/src/CoreWCF.NetTcp/tests/NetTcpServiceDispatcherTests.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using CoreWCF.Channels;
+using CoreWCF.Configuration;
+using Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.NetTcp.Tests
+{
+    public class NetTcpServiceDispatcherTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public NetTcpServiceDispatcherTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task ValidateListenUriPassedFromTransport()
+        {
+            string testString = new string('a', 3000);
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<Startup>(_output).Build();
+            using (host)
+            {
+                await host.StartAsync();
+                var dispatcherBuilder = host.Services.GetRequiredService<IDispatcherBuilder>();
+                var dispatcher = dispatcherBuilder.BuildDispatchers(typeof(Services.TestService))[0];
+                var binding = new CustomBinding(dispatcher.Binding);
+                var lavbe = binding.Elements.Find<ListenAddressVerifyingBindingElement>();
+                Assert.NotNull(lavbe.ListenUriBaseAddress);
+            }
+        }
+
+        internal class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddServiceModelServices();
+            }
+
+            public void Configure(IApplicationBuilder app)
+            {
+                app.UseServiceModel(builder =>
+                {
+                    builder.AddService<Services.TestService>();
+                    var binding = AddTestBindingElement(new NetTcpBinding(SecurityMode.None));
+                    builder.AddServiceEndpoint<Services.TestService, ServiceContract.ITestService>(binding, "/TestService.svc");
+                });
+            }
+
+            private static Binding AddTestBindingElement(Binding binding)
+            {
+                var customBinding = new CustomBinding(binding);
+                customBinding.Elements.Insert(1, new ListenAddressVerifyingBindingElement());
+                return customBinding;
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/Binding.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/Binding.cs
@@ -186,7 +186,17 @@ namespace CoreWCF.Channels
         public virtual IServiceDispatcher BuildServiceDispatcher<TChannel>(BindingParameterCollection parameters, IServiceDispatcher dispatcher)
 where TChannel : class, IChannel
         {
-            UriBuilder listenUriBuilder = new UriBuilder(Scheme, DnsCache.MachineName);
+            UriBuilder listenUriBuilder;
+            if (dispatcher.BaseAddress == null)
+            {
+                listenUriBuilder = new UriBuilder(Scheme, DnsCache.MachineName);
+            }
+            else
+            {
+                listenUriBuilder = new UriBuilder(dispatcher.BaseAddress);
+                listenUriBuilder.Scheme = Scheme;
+            }
+
             return BuildServiceDispatcher<TChannel>(listenUriBuilder.Uri, string.Empty, parameters, dispatcher);
         }
 

--- a/src/CoreWCF.RabbitMQ/tests/IntegrationTests.cs
+++ b/src/CoreWCF.RabbitMQ/tests/IntegrationTests.cs
@@ -153,7 +153,7 @@ namespace CoreWCF.RabbitMQ.Tests
 
     public class ClassicQueueWithTLSStartup
     {
-        public static Uri Uri = new("net.amqps://HOST:PORT/amq.direct/QUEUE_NAME#ROUTING_KEY");
+        public static Uri Uri = new("soap.amqps://HOST:PORT/amq.direct/QUEUE_NAME#ROUTING_KEY");
         public static readonly ICredentials Credentials = new NetworkCredential(ConnectionFactory.DefaultUser, ConnectionFactory.DefaultPass);
         public static readonly SslOption SslOption = new SslOption
         {
@@ -188,7 +188,7 @@ namespace CoreWCF.RabbitMQ.Tests
 
     public class DefaultClassicQueueStartup
     {
-        public static Uri Uri = new("net.amqp://localhost:5672/amq.direct/corewcf-test-default-classic-queue#corewcf-test-default-classic-key");
+        public static Uri Uri = new("soap.amqp://localhost:5672/amq.direct/corewcf-test-default-classic-queue#corewcf-test-default-classic-key");
         public static readonly ICredentials Credentials = new NetworkCredential(ConnectionFactory.DefaultUser, ConnectionFactory.DefaultPass);
 
         public static RabbitMqConnectionSettings ConnectionSettings => RabbitMqConnectionSettings.FromUri(Uri, Credentials);
@@ -217,7 +217,7 @@ namespace CoreWCF.RabbitMQ.Tests
 
     public class DefaultQuorumQueueStartup
     {
-        public static Uri Uri = new("net.amqp://localhost:5672/amq.direct/corewcf-test-default-quorum-queue#corewcf-test-default-quorum-key");
+        public static Uri Uri = new("soap.amqp://localhost:5672/amq.direct/corewcf-test-default-quorum-queue#corewcf-test-default-quorum-key");
         public static readonly ICredentials Credentials = new NetworkCredential(ConnectionFactory.DefaultUser, ConnectionFactory.DefaultPass);
 
         public static RabbitMqConnectionSettings ConnectionSettings =>
@@ -247,7 +247,7 @@ namespace CoreWCF.RabbitMQ.Tests
 
     public class DefaultQueueStartup
     {
-        public static Uri Uri = new("net.amqp://localhost:5672/amq.direct/corewcf-test-default-queue#corewcf-test-default-key");
+        public static Uri Uri = new("soap.amqp://localhost:5672/amq.direct/corewcf-test-default-queue#corewcf-test-default-key");
         public static readonly ICredentials Credentials = new NetworkCredential(ConnectionFactory.DefaultUser, ConnectionFactory.DefaultPass);
 
         public static RabbitMqConnectionSettings ConnectionSettings => RabbitMqConnectionSettings.FromUri(Uri, Credentials);


### PR DESCRIPTION
We were passing a null listen uri (via BindingContext) to StreamUpgradeProvider, which means the security token requirements passed to SecurityTokenManager was missing the listen uri. This is important as CoreWCF aggregates a single ServiceHostBase instance for all services of the same service type. In .NET Framework, you can create multiple ServiceHost instances for the same service type, and each would have it's own ServiceCredentials class. With CoreWCF, they get combined. If you want different credentials (ie service certificate) for different endpoints, it needs a custom SerivceCredential which needs the listen uri in the token requirements.  

Also fixed issue where a hostname provided in base paths would get replaced with the local machine name when building the bindings.  

Noticed some of the rabbitmq tests were specifying the wrong scheme. We replace the scheme with the correct one so it wasn't a problem, but people might copy from tests so should be correct.