### PR TITLE
Add keyed services injection support in source gen.

### DIFF
--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF.ConfigurationManager.csproj
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF.ConfigurationManager.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="$(SourceDir)CoreWCF.NetTcp\src\CoreWCF.NetTcp.csproj" />
     <ProjectReference Include="$(SourceDir)CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />
     <ProjectReference Include="$(SourceDir)CoreWCF.WebHttp\src\CoreWCF.WebHttp.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/CoreWCF.Http/src/CoreWCF.Http.csproj
+++ b/src/CoreWCF.Http/src/CoreWCF.Http.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />

--- a/src/CoreWCF.NetNamedPipe/src/CoreWCF.NetNamedPipe.csproj
+++ b/src/CoreWCF.NetNamedPipe/src/CoreWCF.NetNamedPipe.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.25" />
     <!-- See rationale in comment https://github.com/CoreWCF/CoreWCF/issues/1171#issuecomment-1675183317 -->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.40" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj
+++ b/src/CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.25" />
     <!-- See rationale in comment https://github.com/CoreWCF/CoreWCF/issues/1171#issuecomment-1675183317 -->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.40" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
@@ -16,14 +16,22 @@
     <!-- See rationale in comment https://github.com/CoreWCF/CoreWCF/issues/1171#issuecomment-1675183317 -->
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.23" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <!-- Need to reference Microsoft.Extensions.Primitives 8.x as it restores InplaceStringBuilder which aspnetcore 2.1 Kestrel needs -->
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <!-- Needed to add Configuration, Console, and Debug as Microsoft.AspNetCore.App includes earlier versions which aren't compatible with Logging 6.0.0 -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.WsFederation" Version="6.35.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.35.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens.Saml" Version="6.35.1" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="2.1.6" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.33" />
     <PackageReference Include="System.DirectoryServices" Version="6.0.1" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.2" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0" />
@@ -31,7 +39,7 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.7.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="System.Web.Services.Description" Version="4.10.3" />
+    <PackageReference Include="System.Web.Services.Description" Version="6.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)CoreWCF.BuildTools\src\CoreWCF.BuildTools.Roslyn4.0.csproj" PrivateAssets="All" />

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -34,7 +34,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../src/CoreWCF.Primitives.csproj" />
-    <ProjectReference Include="$(SourceDir)CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj" />
     <ProjectReference Include="$(SourceDir)CoreWCF.Http/src/CoreWCF.Http.csproj" />
   </ItemGroup>
 </Project>

--- a/src/CoreWCF.Primitives/tests/EndpointTests.cs
+++ b/src/CoreWCF.Primitives/tests/EndpointTests.cs
@@ -46,8 +46,8 @@ namespace CoreWCF.Primitives.Tests
                 app.UseServiceModel(builder =>
                 {
                     builder.AddService<TwoContractService>();
-                    var binding = new NetTcpBinding();
-                    var address = "net-tcp://localhost/Test";
+                    var binding = new BasicHttpBinding();
+                    var address = "http://localhost/Test";
                     builder.AddServiceEndpoint<TwoContractService, IContract1>(binding, address);
                     builder.AddServiceEndpoint<TwoContractService, IContract2>(binding, address);
                 });
@@ -58,7 +58,6 @@ namespace CoreWCF.Primitives.Tests
         public void MultipleEndpointsWithSameListenAddressShouldWork()
         {
             var builder = WebHost.CreateDefaultBuilder<Startup>(null);
-            builder.UseNetTcp(0);
             var host = builder.Build();
             using (host)
                 host.Start();

--- a/src/CoreWCF.UnixDomainSocket/src/CoreWCF.UnixDomainSocket.csproj
+++ b/src/CoreWCF.UnixDomainSocket/src/CoreWCF.UnixDomainSocket.csproj
@@ -16,9 +16,9 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="6.0.33" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
   </ItemGroup>

--- a/src/CoreWCF.WebHttp/src/CoreWCF.WebHttp.csproj
+++ b/src/CoreWCF.WebHttp/src/CoreWCF.WebHttp.csproj
@@ -8,6 +8,7 @@
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
   </PropertyGroup>
   <ItemGroup>
+    <!-- After .NET 6.0 goes EOL, WebUtilities should be updated to 8.0.0 -->
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.7.1" />
     <PackageReference Include="System.Text.Json" Version="6.0.9" />


### PR DESCRIPTION
Relates to https://github.com/CoreWCF/CoreWCF/issues/1430

Support injecting keyed services using either [CoreWCF.Injected(ServiceKey = key)] or [FromKeyedServices(key)] attributes.

Replaces #1431 created by @g7ed6e which got closed by GitHub automatically when I was trying to update the branch to avoid a merge commit.

I've added some fixes to the branch around package version dependencies. The way things were, consuming projects might have needed to be updated, I've fixed that so now a project shouldn't need any further changes beyond consuming a newer CoreWCF package.