### PR TITLE
reduce nuget package dependencies on modern target frameworks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,13 @@
     <IsCIBuild Condition="'$(TF_BUILD)' == 'true'">true</IsCIBuild>
   </PropertyGroup>
 
+  <!-- Library target frameworks -->
+  <PropertyGroup>
+    <LibraryTargetFrameworks>netstandard2.0;net6.0;net8.0</LibraryTargetFrameworks>
+    <IsAspNetCore Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net8.0'">true</IsAspNetCore>
+  </PropertyGroup>
+
+
   <!-- UT -->
   <PropertyGroup>
     <TestTargetFrameworks>net6.0;net8.0;net9.0</TestTargetFrameworks>

--- a/src/Common/UnitTests.Common/UnitTests.Common.csproj
+++ b/src/Common/UnitTests.Common/UnitTests.Common.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IncludeCommonCode>false</IncludeCommonCode>
   </PropertyGroup>
   <ItemGroup>

--- a/src/CoreWCF.ConfigurationManager/src/CoreWCF.ConfigurationManager.csproj
+++ b/src/CoreWCF.ConfigurationManager/src/CoreWCF.ConfigurationManager.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <RootNamespace />
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/CoreWCF.Http/src/CoreWCF.Http.csproj
+++ b/src/CoreWCF.Http/src/CoreWCF.Http.csproj
@@ -1,19 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AssemblyName>CoreWCF.Http</AssemblyName>
     <PackageId>CoreWCF.Http</PackageId>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace />
     <IncludeSharedDuplexChannelSource>True</IncludeSharedDuplexChannelSource>
   </PropertyGroup>
-  <ItemGroup>
+
+  <ItemGroup Condition="$(IsAspNetCore) != true">
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
   </ItemGroup>
+
+  <ItemGroup Condition="$(IsAspNetCore) == true">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)CoreWCF.Primitives\src\CoreWCF.Primitives.csproj" />
   </ItemGroup>

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs
@@ -935,7 +935,7 @@ namespace CoreWCF.Channels
                     _httpResponse.Headers.ContainsKey("Connection"))
                 {
                     // Need to remove existing keep-alive and/or close values
-                    StringValues connectionHeaderValue;
+                    StringValues connectionHeaderValue = StringValues.Empty;
                     StringValues previousValues = _httpResponse.Headers["Connection"];
                     for (int i = 0; i < previousValues.Count; i++)
                     {

--- a/src/CoreWCF.Kafka.Client/src/CoreWCF.Kafka.Client.csproj
+++ b/src/CoreWCF.Kafka.Client/src/CoreWCF.Kafka.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>CoreWCF.Kafka.Client</AssemblyName>
     <PackageId>CoreWCF.Kafka.Client</PackageId>
     <RootNamespace />

--- a/src/CoreWCF.Kafka/src/CoreWCF.Kafka.csproj
+++ b/src/CoreWCF.Kafka/src/CoreWCF.Kafka.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AssemblyName>CoreWCF.Kafka</AssemblyName>
     <PackageId>CoreWCF.Kafka</PackageId>
     <RootNamespace />

--- a/src/CoreWCF.MSMQ/src/CoreWCF.MSMQ.csproj
+++ b/src/CoreWCF.MSMQ/src/CoreWCF.MSMQ.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AssemblyName>CoreWCF.MSMQ</AssemblyName>
     <PackageId>CoreWCF.MSMQ</PackageId>
     <RootNamespace />

--- a/src/CoreWCF.NetFramingBase/src/CoreWCF.NetFramingBase.csproj
+++ b/src/CoreWCF.NetFramingBase/src/CoreWCF.NetFramingBase.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AssemblyName>CoreWCF.NetFramingBase</AssemblyName>
     <PackageId>CoreWCF.NetFramingBase</PackageId>
     <RootNamespace />
@@ -9,7 +9,7 @@
     <IncludeSharedDuplexChannelSource>True</IncludeSharedDuplexChannelSource>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$(IsAspNetCore) != true">
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.25" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />

--- a/src/CoreWCF.NetNamedPipe/src/CoreWCF.NetNamedPipe.csproj
+++ b/src/CoreWCF.NetNamedPipe/src/CoreWCF.NetNamedPipe.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AssemblyName>CoreWCF.NetNamedPipe</AssemblyName>
     <PackageId>CoreWCF.NetNamedPipe</PackageId>
     <RootNamespace />
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace />
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="$(IsAspNetCore) != true">
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />

--- a/src/CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj
+++ b/src/CoreWCF.NetTcp/src/CoreWCF.NetTcp.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AssemblyName>CoreWCF.NetTcp</AssemblyName>
     <PackageId>CoreWCF.NetTcp</PackageId>
     <RootNamespace />
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace />
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="$(IsAspNetCore) != true">
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />

--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj
@@ -1,12 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AssemblyName>CoreWCF.Primitives</AssemblyName>
     <PackageId>CoreWCF.Primitives</PackageId>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace />
   </PropertyGroup>
+
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
@@ -18,8 +24,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <!-- Need to reference Microsoft.Extensions.Primitives 8.x as it restores InplaceStringBuilder which aspnetcore 2.1 Kestrel needs -->
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
@@ -41,6 +45,33 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="System.Web.Services.Description" Version="6.2.0" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Web.Services.Description" Version="6.*" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.WsFederation" Version="6.*" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.*" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens.Saml" Version="6.*" />
+    <PackageReference Include="System.DirectoryServices" Version="6.*" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="6.*" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.*" />
+    <PackageReference Include="System.Security.Cryptography.xml" Version="6.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Web.Services.Description" Version="8.*" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.WsFederation" Version="8.*" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.*" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens.Saml" Version="8.*" />
+    <PackageReference Include="System.DirectoryServices" Version="8.*" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="8.*" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.*" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(IsAspNetCore) == true">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)CoreWCF.BuildTools\src\CoreWCF.BuildTools.Roslyn4.0.csproj" PrivateAssets="All" />
     <ProjectReference Include="$(SourceDir)CoreWCF.BuildTools\src\CoreWCF.BuildTools.Roslyn3.11.csproj" PrivateAssets="All" />

--- a/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Tokens/SessionSecurityToken.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Tokens/SessionSecurityToken.cs
@@ -915,7 +915,9 @@ namespace CoreWCF.IdentityModel.Tokens
                 byte[] bytes = dictionaryReader.ReadContentAsBase64();
                 using (MemoryStream ms = new MemoryStream(bytes))
                 {
+#pragma warning disable SYSLIB0011
                     BinaryFormatter formatter = new BinaryFormatter();
+#pragma warning restore SYSLIB0011
                     identity.BootstrapContext = (BootstrapContext)formatter.Deserialize(ms);
                 }
 
@@ -1248,7 +1250,9 @@ namespace CoreWCF.IdentityModel.Tokens
 
                 using (MemoryStream ms = new MemoryStream())
                 {
+#pragma warning disable SYSLIB0011
                     BinaryFormatter formatter = new BinaryFormatter();
+#pragma warning restore SYSLIB0011
                     formatter.Serialize(ms, identity.BootstrapContext);
                     byte[] bootstrapArray = ms.ToArray();
                     dictionaryWriter.WriteBase64(bootstrapArray, 0, bootstrapArray.Length);

--- a/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Tokens/SessionSecurityTokenHandler.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/IdentityModel/Tokens/SessionSecurityTokenHandler.cs
@@ -388,7 +388,9 @@ namespace CoreWCF.IdentityModel.Tokens
 
                     using (MemoryStream ms = new MemoryStream(decodedCookie))
                     {
+#pragma warning disable SYSLIB0011
                         BinaryFormatter formatter = new BinaryFormatter();
+#pragma warning restore SYSLIB0011
                         securityContextToken = formatter.Deserialize(ms) as SecurityToken;
                     }
 
@@ -726,7 +728,9 @@ namespace CoreWCF.IdentityModel.Tokens
 
                 using (MemoryStream ms = new MemoryStream())
                 {
+#pragma warning disable SYSLIB0011
                     BinaryFormatter formatter = new BinaryFormatter();
+#pragma warning restore SYSLIB0011
                     formatter.Serialize(ms, token);
                     cookie = ms.ToArray();
                 }

--- a/src/CoreWCF.Queue/src/CoreWCF.Queue.csproj
+++ b/src/CoreWCF.Queue/src/CoreWCF.Queue.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AssemblyName>CoreWCF.Queue</AssemblyName>
     <PackageId>CoreWCF.Queue</PackageId>
     <RootNamespace />

--- a/src/CoreWCF.RabbitMQ.Client/src/CoreWCF.RabbitMQ.Client.csproj
+++ b/src/CoreWCF.RabbitMQ.Client/src/CoreWCF.RabbitMQ.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>CoreWCF.RabbitMQ.Client</AssemblyName>
     <PackageId>CoreWCF.RabbitMQ.Client</PackageId>
     <RootNamespace />

--- a/src/CoreWCF.RabbitMQ/src/CoreWCF.RabbitMQ.csproj
+++ b/src/CoreWCF.RabbitMQ/src/CoreWCF.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AssemblyName>CoreWCF.RabbitMQ</AssemblyName>
     <PackageId>CoreWCF.RabbitMQ</PackageId>
     <RootNamespace />

--- a/src/CoreWCF.UnixDomainSocket/src/CoreWCF.UnixDomainSocket.csproj
+++ b/src/CoreWCF.UnixDomainSocket/src/CoreWCF.UnixDomainSocket.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>CoreWCF.UnixDomainSocket</AssemblyName>
     <PackageId>CoreWCF.UnixDomainSocket</PackageId>
     <RootNamespace />

--- a/src/CoreWCF.WebHttp/src/CoreWCF.WebHttp.csproj
+++ b/src/CoreWCF.WebHttp/src/CoreWCF.WebHttp.csproj
@@ -1,18 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AssemblyName>CoreWCF.WebHttp</AssemblyName>
     <PackageId>CoreWCF.WebHttp</PackageId>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace />
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
   </PropertyGroup>
+
   <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.7.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(IsAspNetCore) != true">
     <!-- After .NET 6.0 goes EOL, WebUtilities should be updated to 8.0.0 -->
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.7.1" />
     <PackageReference Include="System.Text.Json" Version="6.0.9" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)CoreWCF.Http\src\CoreWCF.Http.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This pull request tries to minime the number of dependencies when client application targets modern target framework (i.e. NET6+)

