### PR TITLE
Fix buffer not being returned to pool

### DIFF
--- a/src/CoreWCF.NetFramingBase/src/CoreWCF/Channels/ServerFramingDuplexSessionChannel.cs
+++ b/src/CoreWCF.NetFramingBase/src/CoreWCF/Channels/ServerFramingDuplexSessionChannel.cs
@@ -332,8 +332,15 @@ namespace CoreWCF.Channels
             allowOutputBatching = message.Properties.AllowOutputBatching;
             Connection.Logger.SendMessage(message);
             messageData = EncodeMessage(message);
-            await Connection.Output.WriteAsync(messageData, token);
-            await Connection.Output.FlushAsync();
+            try
+            {
+                await Connection.Output.WriteAsync(messageData, token);
+                await Connection.Output.FlushAsync();
+            }
+            finally
+            {
+                BufferManager.ReturnBuffer(messageData.Array);
+            }
         }
 
         protected override async Task CloseOutputAsync(CancellationToken token)


### PR DESCRIPTION
We discovered that byte arrays were not being returned to the pool that they were taking from when sending a message through ServerFramingDuplexSessionChannel, which caused a lot of allocations.

I checked how it worked in old WCF, there the buffer was returned by the Connection:
![image](https://github.com/user-attachments/assets/db8b9d60-5e89-4890-837a-07124d392edf)

But since the code shape has changed a bit, I decided to do it in OnSendCoreAsync instead. This is also where it is done in WebSocketTransportDuplexSessionChannel.