### PR TITLE
Default value for AutoDisposeParameters should be true

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/OperationBehaviorAttribute.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/OperationBehaviorAttribute.cs
@@ -15,7 +15,7 @@ namespace CoreWCF
         private ImpersonationOption _impersonation = ImpersonationOption.NotAllowed;
         private ReleaseInstanceMode _releaseInstance = ReleaseInstanceMode.None;
 
-        public bool AutoDisposeParameters { get; set; }
+        public bool AutoDisposeParameters { get; set; } = true;
 
         public ImpersonationOption Impersonation
         {


### PR DESCRIPTION
In old WCF default value for OperationBehaviorAttribute.AutoDisposeParameters was true, but in CoreWCF it is false.

https://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/OperationBehaviorAttribute.cs,b18c31b796a39833

This is a breaking change for anyone coming from .NET Framework, who relies on WCF to dispose their parameters/return value.

This PR fixes #932 