### PR TITLE
Place LICENSE in the root of the package to create valid NuGet packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -79,7 +79,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <!-- Include license file in packages -->
-    <Content Include="$(ProjectDir)LICENSE" Pack="true" PackagePath="\" />
+    <!-- Set an empty PackagePath to place this file in the root of the package -->
+    <Content Include="$(ProjectDir)LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <!-- Configuring strong name signing -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -80,7 +80,7 @@
     </PackageReference>
     <!-- Include license file in packages -->
     <!-- Set an empty PackagePath to place this file in the root of the package -->
-    <Content Include="$(ProjectDir)LICENSE" Pack="true" PackagePath="" />
+    <None Include="$(ProjectDir)LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <!-- Configuring strong name signing -->


### PR DESCRIPTION
Fix for #1481.

Tested locally with System.IO.Packaging.ZipPackage.