### PR TITLE
Prevent duplicate AuthorizeRoleAttribute instances from being added to inherited operations

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/TypeLoader.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/TypeLoader.cs
@@ -221,7 +221,10 @@ namespace CoreWCF.Description
                         GetIOperationAttributesFromType<IAuthorizeOperation>(opDesc, targetIface, currentType);
                         for (int j = 0; j < toAdd.Count; j++)
                         {
-                            opDesc.AuthorizeOperation.Add(toAdd[j]);
+                            if (!opDesc.AuthorizeOperation.Contains(toAdd[j].GetType()))
+                            {
+                                opDesc.AuthorizeOperation.Add(toAdd[j]);
+                            }
                         }
                     });
             }

--- a/src/CoreWCF.Primitives/tests/ContractDescriptionTests.cs
+++ b/src/CoreWCF.Primitives/tests/ContractDescriptionTests.cs
@@ -15,8 +15,19 @@ namespace CoreWCF.Primitives.Tests
             ContractDescription.GetContract<MessagePropertyService>(typeof(IMessagePropertyService));
         }
 
+        [Fact]
+        public void ValidateInheritedContractWithAuthorizeRoleAttributeCanBeConstructed()
+        {
+            ContractDescription.GetContract<MessagePropertyService2>(typeof(IMessagePropertyService));
+        }
+
+        private class MessagePropertyService2 : MessagePropertyService
+        {
+        }
+
         public class MessagePropertyService : IMessagePropertyService
         {
+            [AuthorizeRole]
             public SimpleResponse Request(SimpleRequest request)
             {
                 return new SimpleResponse


### PR DESCRIPTION
Fixes #1339