### PR TITLE
Draft: Ported Telemetry from Opentelemetry-dotnet

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/ActionMetadata.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/ActionMetadata.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace CoreWCF.Telemetry;
+
+internal sealed class ActionMetadata
+{
+    public ActionMetadata(string? contractName, string operationName)
+    {
+        this.ContractName = contractName;
+        this.OperationName = operationName;
+    }
+
+    public string? ContractName { get; set; }
+
+    public string OperationName { get; set; }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/AssemblyVersionExtensions.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/AssemblyVersionExtensions.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Reflection;
+
+namespace CoreWCF.Telemetry;
+
+internal static class AssemblyVersionExtensions
+{
+    public static string GetPackageVersion(this Assembly assembly)
+    {
+        // MinVer https://github.com/adamralph/minver?tab=readme-ov-file#version-numbers
+        // together with Microsoft.SourceLink.GitHub https://github.com/dotnet/sourcelink
+        // fills AssemblyInformationalVersionAttribute by
+        // {majorVersion}.{minorVersion}.{patchVersion}.{pre-release label}.{pre-release version}.{gitHeight}+{Git SHA of current commit}
+        // Ex: 1.5.0-alpha.1.40+807f703e1b4d9874a92bd86d9f2d4ebe5b5d52e4
+        // The following parts are optional: pre-release label, pre-release version, git height, Git SHA of current commit
+        // For package version, value of AssemblyInformationalVersionAttribute without commit hash is returned.
+
+        var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        Debug.Assert(!string.IsNullOrEmpty(informationalVersion), "AssemblyInformationalVersionAttribute was not found in assembly");
+
+#if NET || NETSTANDARD2_1_OR_GREATER
+        var indexOfPlusSign = informationalVersion!.IndexOf('+', StringComparison.Ordinal);
+#else
+        var indexOfPlusSign = informationalVersion!.IndexOf('+');
+#endif
+        return indexOfPlusSign > 0
+            ? informationalVersion.Substring(0, indexOfPlusSign)
+            : informationalVersion;
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/ExceptionExtensions.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/ExceptionExtensions.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace CoreWCF.Telemetry;
+
+internal static class ExceptionExtensions
+{
+    /// <summary>
+    /// Returns a culture-independent string representation of the given <paramref name="exception"/> object,
+    /// appropriate for diagnostics tracing.
+    /// </summary>
+    /// <param name="exception">Exception to convert to string.</param>
+    /// <returns>Exception as string with no culture.</returns>
+    public static string ToInvariantString(this Exception exception)
+    {
+        var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+        try
+        {
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+            return exception.ToString();
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentUICulture = originalUICulture;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/HttpRequestMessagePropertyWrapper.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/HttpRequestMessagePropertyWrapper.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Reflection;
+
+namespace CoreWCF.Telemetry;
+
+
+/// <summary>
+/// This is a reflection-based wrapper around the HttpRequestMessageProperty class. It is done this way so we don't need to
+/// have an explicit reference to System.ServiceModel.Http.dll. If the consuming application has a reference to
+/// System.ServiceModel.Http.dll then the HttpRequestMessageProperty class will be available (IsHttpFunctionalityEnabled == true).
+/// If the consuming application does not have a reference to System.ServiceModel.Http.dll then all http-related functionality
+/// will be disabled (IsHttpFunctionalityEnabled == false).
+/// </summary>
+internal static class HttpRequestMessagePropertyWrapper
+{
+    private static readonly ReflectedInfo? ReflectedValues = Initialize();
+
+    public static bool IsHttpFunctionalityEnabled => ReflectedValues != null;
+
+    public static string Name
+    {
+        get
+        {
+            AssertHttpEnabled();
+            return ReflectedValues!.Name;
+        }
+    }
+
+    public static object CreateNew()
+    {
+        AssertHttpEnabled();
+        return Activator.CreateInstance(ReflectedValues!.Type)!;
+    }
+
+    public static WebHeaderCollection GetHeaders(object httpRequestMessageProperty)
+    {
+        AssertHttpEnabled();
+        AssertIsFrameworkMessageProperty(httpRequestMessageProperty);
+        return ReflectedValues!.HeadersFetcher.Fetch(httpRequestMessageProperty);
+    }
+
+    private static ReflectedInfo? Initialize()
+    {
+        Type? type = null;
+        try
+        {
+            type = Type.GetType(
+                "System.ServiceModel.Channels.HttpRequestMessageProperty, System.ServiceModel, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                true)!;
+
+            var constructor = type.GetConstructor(Type.EmptyTypes)
+                ?? throw new NotSupportedException("HttpRequestMessageProperty public parameterless constructor was not found");
+
+            var headersProp = type.GetProperty("Headers", BindingFlags.Public | BindingFlags.Instance, null, typeof(WebHeaderCollection),
+                                  Type.EmptyTypes, null)
+                ?? throw new NotSupportedException("HttpRequestMessageProperty.Headers property not found");
+
+            var nameProp = type.GetProperty("Name", BindingFlags.Public | BindingFlags.Static, null, typeof(string),
+                               Type.EmptyTypes, null)
+                ?? throw new NotSupportedException("HttpRequestMessageProperty.Name property not found");
+
+            return nameProp.GetValue(null) is not string name
+                ? throw new NotSupportedException("HttpRequestMessageProperty.Name property was null")
+                : new ReflectedInfo(
+                    type: type,
+                    name: name,
+                    headersFetcher: new PropertyFetcher<WebHeaderCollection>("Headers"));
+        }
+        catch (Exception ex)
+        {
+            WcfInstrumentationEventSource.Log.HttpServiceModelReflectionFailedToBind(ex, type?.Assembly);
+        }
+
+        return null;
+    }
+
+    [Conditional("DEBUG")]
+    private static void AssertHttpEnabled()
+    {
+        if (!IsHttpFunctionalityEnabled)
+        {
+            throw new InvalidOperationException("Http functionality is not enabled, check IsHttpFunctionalityEnabled before calling this method");
+        }
+    }
+
+    [Conditional("DEBUG")]
+    private static void AssertIsFrameworkMessageProperty(object httpRequestMessageProperty)
+    {
+        AssertHttpEnabled();
+        if (httpRequestMessageProperty == null || !httpRequestMessageProperty.GetType().Equals(ReflectedValues!.Type))
+        {
+            throw new ArgumentException("Object must be of type HttpRequestMessageProperty");
+        }
+    }
+
+    private sealed class ReflectedInfo
+    {
+        public readonly Type Type;
+        public readonly string Name;
+        public readonly PropertyFetcher<WebHeaderCollection> HeadersFetcher;
+
+        public ReflectedInfo(Type type, string name, PropertyFetcher<WebHeaderCollection> headersFetcher)
+        {
+            this.Type = type;
+            this.Name = name;
+            this.HeadersFetcher = headersFetcher;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/PropertyFetcher.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/PropertyFetcher.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace CoreWCF.Telemetry;
+
+/// <summary>
+/// PropertyFetcher fetches a property from an object.
+/// </summary>
+/// <typeparam name="T">The type of the property being fetched.</typeparam>
+#pragma warning disable CA1812
+internal sealed class PropertyFetcher<T>
+#pragma warning restore CA1812
+{
+    private readonly string propertyName;
+    private PropertyFetch innerFetcher;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyFetcher{T}"/> class.
+    /// </summary>
+    /// <param name="propertyName">Property name to fetch.</param>
+    public PropertyFetcher(string propertyName)
+    {
+        this.propertyName = propertyName;
+    }
+
+    /// <summary>
+    /// Fetch the property from the object.
+    /// </summary>
+    /// <param name="obj">Object to be fetched.</param>
+    /// <returns>Property fetched.</returns>
+    public T Fetch(object obj)
+    {
+        return !this.TryFetch(obj, out var value)
+            ? throw new ArgumentException("Supplied object was null or did not match the expected type.", nameof(obj))
+            : value;
+    }
+
+    /// <summary>
+    /// Try to fetch the property from the object.
+    /// </summary>
+    /// <param name="obj">Object to be fetched.</param>
+    /// <param name="value">Fetched value.</param>
+    /// <returns><see langword="true"/> if the property was fetched.</returns>
+    public bool TryFetch(object obj, out T value)
+    {
+        if (obj == null)
+        {
+            value = default;
+            return false;
+        }
+
+        if (this.innerFetcher == null)
+        {
+            var type = obj.GetType().GetTypeInfo();
+            var property = type.DeclaredProperties.FirstOrDefault(p => string.Equals(p.Name, this.propertyName, StringComparison.OrdinalIgnoreCase)) ?? type.GetProperty(this.propertyName);
+            this.innerFetcher = PropertyFetch.FetcherForProperty(property);
+        }
+
+        return this.innerFetcher.TryFetch(obj, out value);
+    }
+
+    // see https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+    private class PropertyFetch
+    {
+        /// <summary>
+        /// Create a property fetcher from a .NET Reflection PropertyInfo class that
+        /// represents a property of a particular type.
+        /// </summary>
+        public static PropertyFetch FetcherForProperty(PropertyInfo propertyInfo)
+        {
+            if (propertyInfo == null || !typeof(T).IsAssignableFrom(propertyInfo.PropertyType))
+            {
+                // returns null on any fetch.
+                return new PropertyFetch();
+            }
+
+            var typedPropertyFetcher = typeof(TypedPropertyFetch<,>);
+            var instantiatedTypedPropertyFetcher = typedPropertyFetcher.MakeGenericType(
+                typeof(T), propertyInfo.DeclaringType, propertyInfo.PropertyType);
+            return (PropertyFetch)Activator.CreateInstance(instantiatedTypedPropertyFetcher, propertyInfo);
+        }
+
+        public virtual bool TryFetch(object obj, out T value)
+        {
+            value = default;
+            return false;
+        }
+
+#pragma warning disable CA1812
+        private sealed class TypedPropertyFetch<TDeclaredObject, TDeclaredProperty> : PropertyFetch
+#pragma warning restore CA1812
+            where TDeclaredProperty : T
+        {
+            private readonly Func<TDeclaredObject, TDeclaredProperty> propertyFetch;
+
+            public TypedPropertyFetch(PropertyInfo property)
+            {
+#if NET
+                this.propertyFetch = property.GetMethod.CreateDelegate<Func<TDeclaredObject, TDeclaredProperty>>();
+#else
+                this.propertyFetch = (Func<TDeclaredObject, TDeclaredProperty>)property.GetMethod.CreateDelegate(typeof(Func<TDeclaredObject, TDeclaredProperty>));
+#endif
+            }
+
+            public override bool TryFetch(object obj, out T value)
+            {
+                if (obj is TDeclaredObject o)
+                {
+                    value = this.propertyFetch(o);
+                    return true;
+                }
+
+                value = default;
+                return false;
+            }
+        }
+    }
+}
+

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/RequestTelemetryState.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/RequestTelemetryState.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+
+namespace CoreWCF.Telemetry;
+
+internal sealed class RequestTelemetryState
+{
+    public IDisposable? SuppressionScope { get; set; }
+
+    public Activity? Activity { get; set; }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/RequestTelemetryStateTracker.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/RequestTelemetryStateTracker.cs
@@ -1,0 +1,160 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using CoreWCF.Channels;
+
+namespace CoreWCF.Telemetry;
+
+
+internal static class RequestTelemetryStateTracker
+{
+    private static readonly Dictionary<string, Entry> OutstandingRequestStates = new() { };
+    private static readonly SortedSet<EntryTimeoutProperties> TimeoutQueue = new() { };
+    private static readonly object Sync = new();
+    private static readonly Timer Timer = new(OnTimer);
+    private static long currentTimerDueAt = Timeout.Infinite;
+
+    public static void PushTelemetryState(Message request, RequestTelemetryState telemetryState, TimeSpan timeout, Action<RequestTelemetryState> timeoutCallback)
+    {
+        var messageId = request?.Headers.MessageId?.ToString();
+        if (messageId != null)
+        {
+            var expiresAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() + (long)timeout.TotalMilliseconds;
+            var timeoutProps = new EntryTimeoutProperties(messageId, expiresAt, timeoutCallback);
+            var entry = new Entry(telemetryState, timeoutProps);
+            lock (Sync)
+            {
+                OutstandingRequestStates.Add(messageId, entry);
+                TimeoutQueue.Add(timeoutProps);
+                SetTimerEarlierIfNeeded(expiresAt);
+            }
+        }
+    }
+
+    public static RequestTelemetryState? PopTelemetryState(Message reply)
+    {
+        var relatesTo = reply?.Headers.RelatesTo?.ToString();
+        return relatesTo == null ? null : PopTelemetryState(relatesTo);
+    }
+
+    private static RequestTelemetryState? PopTelemetryState(string messageId)
+    {
+        lock (Sync)
+        {
+            if (OutstandingRequestStates.TryGetValue(messageId, out var entry))
+            {
+                OutstandingRequestStates.Remove(messageId);
+                TimeoutQueue.Remove(entry.TimeoutProperties);
+            }
+
+            return entry?.State;
+        }
+    }
+
+    private static void OnTimer(object? state)
+    {
+        List<Tuple<EntryTimeoutProperties, Entry>>? timedOutEntries = null;
+        lock (Sync)
+        {
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            EntryTimeoutProperties? nextToExpire = null;
+            foreach (var entryTimeoutProps in TimeoutQueue)
+            {
+                if (entryTimeoutProps.ExpiresAt <= now)
+                {
+                    timedOutEntries ??= new() { };
+
+                    timedOutEntries.Add(new(entryTimeoutProps, OutstandingRequestStates[entryTimeoutProps.MessageId]));
+                }
+                else
+                {
+                    nextToExpire = entryTimeoutProps;
+                    break;
+                }
+            }
+
+            foreach (var entry in timedOutEntries ?? Enumerable.Empty<Tuple<EntryTimeoutProperties, Entry>>())
+            {
+                OutstandingRequestStates.Remove(entry.Item1.MessageId);
+                TimeoutQueue.Remove(entry.Item1);
+            }
+
+            // when there's no more outstanding requests we set time timer to infinite, effectively disabling it until another request arrives
+            var nextExpiry = nextToExpire?.ExpiresAt ?? Timeout.Infinite;
+            SetTimer(nextExpiry);
+        }
+
+        timedOutEntries?.ForEach(entry => entry.Item1.TimeoutCallback(entry.Item2.State));
+    }
+
+    private static void SetTimerEarlierIfNeeded(long dueAt)
+    {
+        if (currentTimerDueAt == Timeout.Infinite || currentTimerDueAt > dueAt)
+        {
+            SetTimer(dueAt);
+        }
+    }
+
+    private static void SetTimer(long dueAt)
+    {
+        long dueIn;
+        if (dueAt == Timeout.Infinite)
+        {
+            dueIn = Timeout.Infinite;
+        }
+        else
+        {
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            dueIn = Math.Max(0, dueAt - now) + 50; // add 50ms here because the timer is not precise and often fires just a bit early
+        }
+
+        Timer.Change(dueIn, Timeout.Infinite);
+        currentTimerDueAt = dueAt;
+    }
+
+    private class Entry
+    {
+        public readonly RequestTelemetryState State;
+        public readonly EntryTimeoutProperties TimeoutProperties;
+
+        public Entry(RequestTelemetryState state, EntryTimeoutProperties timeoutProperties)
+        {
+            this.State = state;
+            this.TimeoutProperties = timeoutProperties;
+        }
+    }
+
+    private class EntryTimeoutProperties : IComparable
+    {
+        public readonly string MessageId;
+        public readonly long ExpiresAt;
+        public readonly Action<RequestTelemetryState> TimeoutCallback;
+
+        public EntryTimeoutProperties(string messageId, long expiresAt, Action<RequestTelemetryState> timeoutCallback)
+        {
+            this.MessageId = messageId;
+            this.ExpiresAt = expiresAt;
+            this.TimeoutCallback = timeoutCallback;
+        }
+
+        public int CompareTo(object? obj)
+        {
+            if (obj is not EntryTimeoutProperties other)
+            {
+                return 1;
+            }
+
+            var result = this.ExpiresAt.CompareTo(other.ExpiresAt);
+            if (result == 0)
+            {
+                result = string.Compare(this.MessageId, other.MessageId, StringComparison.Ordinal);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/TelemetryContextMessageProperty.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/TelemetryContextMessageProperty.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace CoreWCF.Telemetry;
+
+internal sealed class TelemetryContextMessageProperty
+{
+    public const string Name = "OpenTelemetry.Instrumentation.Wcf.Implementation.TelemetryContextMessageProperty";
+
+    public TelemetryContextMessageProperty(IDictionary<string, ActionMetadata> actionMappings)
+    {
+        this.ActionMappings = actionMappings;
+    }
+
+    public IDictionary<string, ActionMetadata> ActionMappings { get; set; }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/TelemetryMessageHeader.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/TelemetryMessageHeader.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml;
+using CoreWCF.Channels;
+
+namespace CoreWCF.Telemetry;
+
+
+internal class TelemetryMessageHeader : MessageHeader
+{
+    private const string NAMESPACE = "https://www.w3.org/TR/trace-context/";
+    private readonly string name;
+
+    private TelemetryMessageHeader(string name, string value)
+    {
+        this.name = name;
+        this.Value = value;
+    }
+
+    public override string Name => this.name;
+
+    public string Value { get; }
+
+    public override string Namespace => NAMESPACE;
+
+    public static TelemetryMessageHeader CreateHeader(string name, string value)
+    {
+        return new TelemetryMessageHeader(name, value);
+    }
+
+    public static TelemetryMessageHeader? FindHeader(string name, MessageHeaders allHeaders)
+    {
+        try
+        {
+            var headerIndex = allHeaders.FindHeader(name, NAMESPACE);
+            if (headerIndex < 0)
+            {
+                return null;
+            }
+
+            using var reader = allHeaders.GetReaderAtHeader(headerIndex);
+            reader.Read();
+            return new TelemetryMessageHeader(name, reader.ReadContentAsString());
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
+    }
+
+    protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
+    {
+        writer.WriteString(this.Value);
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/TelemetryPropagationReader.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/TelemetryPropagationReader.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using CoreWCF.Channels;
+
+namespace CoreWCF.Telemetry;
+
+
+/// <summary>
+/// Pre-defined PropagationReader callbacks.
+/// </summary>
+internal static class TelemetryPropagationReader
+{
+    private static readonly Func<Message, string, IEnumerable<string>> DefaultReader = Compose(HttpRequestHeaders, SoapMessageHeaders);
+
+    /// <summary>
+    /// Reads the values from the SOAP message headers. If the message is not a SOAP message it returns null.
+    /// </summary>
+    /// <param name="request">The incoming <see cref="Message"/> to read trace context from.</param>
+    /// <param name="name">The header name being requested.</param>
+    /// <returns>An enumerable of all the values for the requested header, or null if the requested header was not present on the request.</returns>
+    public static IEnumerable<string>? SoapMessageHeaders(Message request, string name)
+    {
+        if (request.Version == MessageVersion.None)
+        {
+            return null;
+        }
+
+        var header = TelemetryMessageHeader.FindHeader(name, request.Headers);
+        return header == null ? null : new[] { header.Value };
+    }
+
+    /// <summary>
+    /// Reads the values from the incoming HTTP request headers. If the message was not made via an HTTP request it returns null.
+    /// </summary>
+    /// <param name="request">The incoming <see cref="Message"/> to read trace context from.</param>
+    /// <param name="name">The header name being requested.</param>
+    /// <returns>An enumerable of all the values for the requested header, or null if the requested header was not present on the request.</returns>
+    public static IEnumerable<string>? HttpRequestHeaders(Message request, string name)
+    {
+        if (!HttpRequestMessagePropertyWrapper.IsHttpFunctionalityEnabled || !request.Properties.TryGetValue(HttpRequestMessagePropertyWrapper.Name, out var prop))
+        {
+            return null;
+        }
+
+        var value = HttpRequestMessagePropertyWrapper.GetHeaders(prop)[name];
+        return value == null ? null : new[] { value };
+    }
+
+    /// <summary>
+    /// Reads the values from the incoming HTTP request headers and falls back to SOAP message headers if not found on the HTTP request.
+    /// </summary>
+    /// <param name="request">The incoming <see cref="Message"/> to read trace context from.</param>
+    /// <param name="name">The header name being requested.</param>
+    /// <returns>An enumerable of all the values for the requested header, or null if the requested header was not present on the request.</returns>
+    public static IEnumerable<string>? Default(Message request, string name)
+    {
+        return DefaultReader(request, name);
+    }
+
+    /// <summary>
+    /// Compose multiple PropagationReader callbacks into a single callback. The callbacks
+    /// are called sequentially and the first one to return a non-null value wins.
+    /// </summary>
+    /// <param name="callbacks">The callbacks to compose into a single callback.</param>
+    /// <returns>The composed callback.</returns>
+    public static Func<Message, string, IEnumerable<string>?> Compose(params Func<Message, string, IEnumerable<string>?>[] callbacks)
+    {
+        return (Message request, string name) =>
+        {
+            foreach (var reader in callbacks)
+            {
+                var values = reader(request, name);
+                if (values != null)
+                {
+                    return values;
+                }
+            }
+
+            return null;
+        };
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/TelemetryPropagationWriter.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/TelemetryPropagationWriter.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using CoreWCF.Channels;
+
+namespace CoreWCF.Telemetry;
+
+/// <summary>
+/// Pre-defined PropagationWriter callbacks.
+/// </summary>
+internal static class TelemetryPropagationWriter
+{
+    /// <summary>
+    /// Writes the values to SOAP message headers. If the message is not a SOAP message it does nothing.
+    /// </summary>
+    /// <param name="request">The outgoing request <see cref="Message"/> (carrier) to write trace context to.</param>
+    /// <param name="name">The header name being written.</param>
+    /// <param name="value">The header value to write.</param>
+    public static void SoapMessageHeaders(Message request, string name, string value)
+    {
+        if (request.Version == MessageVersion.None)
+        {
+            return;
+        }
+
+        request.Headers.Add(TelemetryMessageHeader.CreateHeader(name, value));
+    }
+
+    /// <summary>
+    /// Writes the values to outgoing HTTP request headers. If the message is not ultimately transmitted via HTTP these will be ignored.
+    /// </summary>
+    /// <param name="request">The outgoing request <see cref="Message"/> (carrier) to write trace context to.</param>
+    /// <param name="name">The header name being written.</param>
+    /// <param name="value">The header value to write.</param>
+    public static void HttpRequestHeaders(Message request, string name, string value)
+    {
+        if (!HttpRequestMessagePropertyWrapper.IsHttpFunctionalityEnabled)
+        {
+            return;
+        }
+
+        if (!request.Properties.TryGetValue(HttpRequestMessagePropertyWrapper.Name, out var prop))
+        {
+            prop = HttpRequestMessagePropertyWrapper.CreateNew();
+            request.Properties.Add(HttpRequestMessagePropertyWrapper.Name, prop);
+        }
+
+        HttpRequestMessagePropertyWrapper.GetHeaders(prop)[name] = value;
+    }
+
+    /// <summary>
+    /// Writes values to both SOAP message headers and outgoing HTTP request headers when suppressing downstream instrumentation.
+    /// When not suppressing downstream instrumentation it is assumed the transport will be propagating the context itself, so
+    /// only SOAP message headers are written.
+    /// </summary>
+    /// <param name="request">The outgoing request <see cref="Message"/> (carrier) to write trace context to.</param>
+    /// <param name="name">The header name being written.</param>
+    /// <param name="value">The header value to write.</param>
+    public static void Default(Message request, string name, string value)
+    {
+        SoapMessageHeaders(request, name, value);
+        if (WcfInstrumentationActivitySource.Options?.SuppressDownstreamInstrumentation ?? false)
+        {
+            HttpRequestHeaders(request, name, value);
+        }
+    }
+
+    /// <summary>
+    /// Compose multiple PropagationWriter callbacks into a single callback. All callbacks
+    /// are executed to allow for propagating the context in multiple ways.
+    /// </summary>
+    /// <param name="callbacks">The callbacks to compose into a single callback.</param>
+    /// <returns>The composed callback.</returns>
+    public static Action<Message, string, string> Compose(params Action<Message, string, string>[] callbacks)
+    {
+        return (Message request, string name, string value) =>
+        {
+            foreach (var writer in callbacks)
+            {
+                writer(request, name, value);
+            }
+        };
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/WcfInstrumentationActivitySource.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/WcfInstrumentationActivitySource.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using CoreWCF.Channels;
+
+namespace CoreWCF.Telemetry;
+
+/// <summary>
+/// WCF instrumentation.
+/// </summary>
+internal static class WcfInstrumentationActivitySource
+{
+    internal static readonly Assembly Assembly = typeof(WcfInstrumentationActivitySource).Assembly;
+    internal static readonly AssemblyName AssemblyName = Assembly.GetName();
+    internal static readonly string ActivitySourceName = AssemblyName.Name!;
+    internal static readonly string IncomingRequestActivityName = ActivitySourceName + ".IncomingRequest";
+    internal static readonly string OutgoingRequestActivityName = ActivitySourceName + ".OutgoingRequest";
+
+    public static ActivitySource ActivitySource { get; } = new(ActivitySourceName, Assembly.GetPackageVersion());
+
+    public static WcfInstrumentationOptions? Options { get; set; }
+
+    public static IEnumerable<string>? MessageHeaderValuesGetter(Message request, string name)
+    {
+        return TelemetryPropagationReader.Default(request, name);
+    }
+
+    public static void MessageHeaderValueSetter(Message request, string name, string value)
+    {
+        TelemetryPropagationWriter.Default(request, name, value);
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/WcfInstrumentationConstants.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/WcfInstrumentationConstants.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace CoreWCF.Telemetry;
+
+internal static class WcfInstrumentationConstants
+{
+    public const string RpcSystemTag = "rpc.system";
+    public const string RpcServiceTag = "rpc.service";
+    public const string RpcMethodTag = "rpc.method";
+    public const string NetHostNameTag = "net.host.name";
+    public const string NetHostPortTag = "net.host.port";
+    public const string NetPeerNameTag = "net.peer.name";
+    public const string NetPeerPortTag = "net.peer.port";
+    public const string SoapMessageVersionTag = "soap.message_version";
+    public const string SoapReplyActionTag = "soap.reply_action";
+    public const string SoapViaTag = "soap.via";
+    public const string WcfChannelSchemeTag = "wcf.channel.scheme";
+    public const string WcfChannelPathTag = "wcf.channel.path";
+
+    public const string WcfSystemValue = "dotnet_wcf";
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/WcfInstrumentationEventSource.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/WcfInstrumentationEventSource.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace CoreWCF.Telemetry;
+
+
+[EventSource(Name = "OpenTelemetry-Instrumentation-Wcf")]
+internal sealed class WcfInstrumentationEventSource : EventSource
+{
+    public static readonly WcfInstrumentationEventSource Log = new();
+
+    [NonEvent]
+    public void RequestFilterException(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
+        {
+            this.RequestFilterException(ex.ToInvariantString());
+        }
+    }
+
+    [Event(EventIds.RequestIsFilteredOut, Message = "Request is filtered out.", Level = EventLevel.Verbose)]
+    public void RequestIsFilteredOut()
+    {
+        this.WriteEvent(EventIds.RequestIsFilteredOut);
+    }
+
+    [Event(EventIds.RequestFilterException, Message = "InstrumentationFilter threw exception. Request will not be collected. Exception {0}.", Level = EventLevel.Error)]
+    public void RequestFilterException(string exception)
+    {
+        this.WriteEvent(EventIds.RequestFilterException, exception);
+    }
+
+    [NonEvent]
+    public void EnrichmentException(Exception exception)
+    {
+        if (this.IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
+        {
+            this.EnrichmentException(exception.ToInvariantString());
+        }
+    }
+
+    [Event(EventIds.EnrichmentException, Message = "Enrichment threw exception. Exception {0}.", Level = EventLevel.Error)]
+    public void EnrichmentException(string exception)
+    {
+        this.WriteEvent(EventIds.EnrichmentException, exception);
+    }
+
+    [NonEvent]
+    public void HttpServiceModelReflectionFailedToBind(Exception exception, System.Reflection.Assembly? assembly)
+    {
+        if (this.IsEnabled(EventLevel.Verbose, (EventKeywords)(-1)))
+        {
+            this.HttpServiceModelReflectionFailedToBind(exception.ToInvariantString(), assembly?.FullName);
+        }
+    }
+
+    [Event(EventIds.HttpServiceModelReflectionFailedToBind, Message = "Failed to bind to System.ServiceModel.Http. Exception {0}. Assembly {1}.", Level = EventLevel.Verbose)]
+    public void HttpServiceModelReflectionFailedToBind(string exception, string? assembly)
+    {
+        this.WriteEvent(EventIds.HttpServiceModelReflectionFailedToBind, exception, assembly);
+    }
+
+    [NonEvent]
+    public void AspNetReflectionFailedToBind(Exception exception)
+    {
+        if (this.IsEnabled(EventLevel.Verbose, (EventKeywords)(-1)))
+        {
+            this.AspNetReflectionFailedToBind(exception.ToInvariantString());
+        }
+    }
+
+    [Event(EventIds.AspNetReflectionFailedToBind, Message = "Failed to bind to ASP.NET instrumentation. Exception {0}.", Level = EventLevel.Verbose)]
+    public void AspNetReflectionFailedToBind(string exception)
+    {
+        this.WriteEvent(EventIds.AspNetReflectionFailedToBind, exception);
+    }
+
+    private class EventIds
+    {
+        public const int RequestIsFilteredOut = 1;
+        public const int RequestFilterException = 2;
+        public const int EnrichmentException = 3;
+        public const int HttpServiceModelReflectionFailedToBind = 4;
+        public const int AspNetReflectionFailedToBind = 5;
+    }
+}

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/WcfInstrumentationOptions.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/WcfInstrumentationOptions.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using CoreWCF.Channels;
+
+namespace CoreWCF.Telemetry;
+
+
+/// <summary>
+/// Options for WCF instrumentation.
+/// </summary>
+public class WcfInstrumentationOptions
+{
+    /// <summary>
+    /// Gets or sets an action to enrich an Activity.
+    /// </summary>
+    /// <remarks>
+    /// <para><see cref="Activity"/>: the activity being enriched.</para>
+    /// <para>string: the name of the event. Will be one of the constants in <see cref="WcfEnrichEventNames"/>.
+    /// </para>
+    /// <para>object: the raw <see cref="Message"/> from which additional information can be extracted to enrich the activity.
+    /// </para>
+    /// </remarks>
+    public Action<Activity, string, object>? Enrich { get; set; }
+
+    /// <summary>
+    /// Gets or sets a Filter function to filter instrumentation for requests on a per request basis.
+    /// The Filter gets the Message, and should return a boolean.
+    /// If Filter returns true, the request is collected.
+    /// If Filter returns false or throw exception, the request is filtered out.
+    /// </summary>
+    public Func<Message, bool>? IncomingRequestFilter { get; set; }
+
+    /// <summary>
+    /// Gets or sets a Filter function to filter instrumentation for requests on a per request basis.
+    /// The Filter gets the Message, and should return a boolean.
+    /// If Filter returns true, the request is collected.
+    /// If Filter returns false or throw exception, the request is filtered out.
+    /// </summary>
+    public Func<Message, bool>? OutgoingRequestFilter { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether down stream instrumentation (HttpClient) is suppressed (disabled). Default value: True.
+    /// </summary>
+    public bool SuppressDownstreamInstrumentation { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not the SOAP message version should be added as the <see cref="WcfInstrumentationConstants.SoapMessageVersionTag"/> tag. Default value: False.
+    /// </summary>
+    public bool SetSoapMessageVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether exception will be recorded
+    /// as an <see cref="ActivityEvent"/> or not. Default value: <see
+    /// langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>For specification details see: <see
+    /// href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-spans.md"
+    /// />.</para>
+    /// </remarks>
+    public bool RecordException { get; set; }
+}


### PR DESCRIPTION
Added Opentelemetry support #790

I just ported the server Otel code to CoreWCF. I integrated it directly and did not make an extra IDispatchMessageInspector or an IClientMessageInspector. Hope this is ok, but I can also change that

I had no time by now to test if it is really working. Will do that in the coming days.