### PR TITLE
Fix AuthorizeRoleAttribute use on methods in inherited contract interfaces

### DIFF
--- a/src/CoreWCF.NetTcp/tests/AuthorizationTest.cs
+++ b/src/CoreWCF.NetTcp/tests/AuthorizationTest.cs
@@ -9,6 +9,7 @@ using System.ServiceModel.Security;
 using System.Threading.Tasks;
 using CoreWCF.Configuration;
 using CoreWCF.Description;
+using CoreWCF.Dispatcher;
 using CoreWCF.IdentityModel.Claims;
 using CoreWCF.IdentityModel.Policy;
 using CoreWCF.Security;
@@ -31,11 +32,94 @@ namespace CoreWCF.NetTcp.Tests
             _output = output;
         }
 
-        [Fact]
-        public void AuthorizationBasedonRolesTest()
+        [Theory]
+        [MemberData(nameof(GetAuthorizationVariations))]
+        public void AuthorizationBasedOnRolesTest(Dictionary<string, List<Claim>> authorizeClaims, Claim[] authenticatedClaims, bool shouldSucced )
         {
             string testString = "a" + PrincipalPermissionMode.Always + "test";
             IWebHost host = ServiceHelper.CreateWebHostBuilder<StartupForAuthorization>(_output).Build();
+            var serviceBuilder = host.Services.GetRequiredService<IServiceBuilder>();
+            serviceBuilder.ConfigureAllServiceHostBase(serviceHostBase =>
+            {
+                var customPolicy = new CustomAuthorizationPolicy(authenticatedClaims);
+                serviceHostBase.Authorization.ExternalAuthorizationPolicies = new List<IAuthorizationPolicy> { customPolicy }.AsReadOnly();
+
+                var authorizeClaimsBehavior = new AuthorizeClaimsSetterOperationBehavior(authorizeClaims, true);
+                foreach (var endpoint in serviceHostBase.Description.Endpoints)
+                {
+                    OperationDescription echoAuthOperation = endpoint.Contract.Operations.Find("EchoForAuthorizarionOneRole");
+                    if (echoAuthOperation != null)
+                    {
+                        if (!echoAuthOperation.OperationBehaviors.Contains(typeof(AuthorizeClaimsSetterOperationBehavior)))
+                        {
+                            echoAuthOperation.OperationBehaviors.Add(authorizeClaimsBehavior);
+                        }
+                    }
+                }
+            });
+
+            using (host)
+            {
+                System.ServiceModel.ChannelFactory<ClientContract.ITestService> factory = null;
+                ClientContract.ITestService channel = null;
+                host.Start();
+                try
+                {
+                    System.ServiceModel.NetTcpBinding binding = ClientHelper.GetBufferedModeBinding(System.ServiceModel.SecurityMode.None);
+                    factory = new System.ServiceModel.ChannelFactory<ClientContract.ITestService>(binding,
+                        new System.ServiceModel.EndpointAddress(host.GetNetTcpAddressInUse() + FakeAuthRelativePath));
+                    channel = factory.CreateChannel();
+                    ((IChannel)channel).Open();
+                    if (shouldSucced)
+                    {
+                        string result = channel.EchoForAuthorizarionOneRole(testString);
+                        Assert.Equal(testString, result);
+                    }
+                    else
+                    {
+                        var sade = Assert.Throws<SecurityAccessDeniedException>(() => channel.EchoForAuthorizarionOneRole(testString));
+                        Assert.Contains("Access is denied", sade.Message);
+                    }
+
+                    ((IChannel)channel).Close();
+                    factory.Close();
+                }
+                finally
+                {
+                    ServiceHelper.CloseServiceModelObjects((IChannel)channel, factory);
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> GetAuthorizationVariations()
+        {
+            var adminRoleClaim = new Claim(ClaimTypes.Role, "CoreWCFGroupAdmin", Rights.Identity);
+            var userRoleClaim = new Claim(ClaimTypes.Role, "CoreWCFGroupUsers", Rights.Identity);
+            var alwaysFailsClaim = new Claim(ClaimTypes.Role, "AlwaysFails", Rights.Identity);
+            yield return new object[] { new Dictionary<string, List<Claim>>() { { "Default", new() { adminRoleClaim } } }, new Claim[] { adminRoleClaim }, true };
+            yield return new object[] { new Dictionary<string, List<Claim>>() { { "Default", new() { adminRoleClaim } } }, new Claim[] { userRoleClaim }, false };
+            yield return new object[] { new Dictionary<string, List<Claim>>() { { "Default", new() { adminRoleClaim } } }, new Claim[] { }, false };
+            yield return new object[] { new Dictionary<string, List<Claim>>() { { "Default", new() { alwaysFailsClaim } } }, new Claim[] { adminRoleClaim }, false };
+            yield return new object[] { new Dictionary<string, List<Claim>>() { { "Primary", new() { adminRoleClaim } },
+                                                                                { "Secondary", new() { userRoleClaim} } }, new Claim[] { adminRoleClaim }, false };
+            yield return new object[] { new Dictionary<string, List<Claim>>() { { "Primary", new() { adminRoleClaim } },
+                                                                                { "Secondary", new() { userRoleClaim} } }, new Claim[] { userRoleClaim }, false };
+            yield return new object[] { new Dictionary<string, List<Claim>>() { { "Default", new() { adminRoleClaim, userRoleClaim } } }, new Claim[] { adminRoleClaim }, true };
+            yield return new object[] { new Dictionary<string, List<Claim>>() { { "Default", new() { adminRoleClaim, userRoleClaim } } }, new Claim[] { userRoleClaim }, true };
+        }
+
+        [Fact]
+        public void AuthorizationBasedOnRolesUsingAttributesTest()
+        {
+            string testString = "a" + PrincipalPermissionMode.Always + "test";
+            IWebHost host = ServiceHelper.CreateWebHostBuilder<StartupForAuthorization>(_output).Build();
+            var serviceBuilder = host.Services.GetRequiredService<IServiceBuilder>();
+            serviceBuilder.ConfigureAllServiceHostBase(serviceHostBase =>
+            {
+                var customPolicy = new CustomAuthorizationPolicy(new Claim(ClaimTypes.Role, "CoreWCFGroupAdmin", Rights.Identity));
+                serviceHostBase.Authorization.ExternalAuthorizationPolicies = new List<IAuthorizationPolicy> { customPolicy }.AsReadOnly();
+            });
+
             using (host)
             {
                 System.ServiceModel.ChannelFactory<ClientContract.ITestService> factory = null;
@@ -76,7 +160,10 @@ namespace CoreWCF.NetTcp.Tests
         {
             app.UseServiceModel(builder =>
             {
-                builder.AddService<Services.TestService>();
+                builder.AddService<Services.TestService>(options =>
+                {
+                    options.DebugBehavior.IncludeExceptionDetailInFaults = true;
+                });
                 builder.AddServiceEndpoint<Services.TestService, ServiceContract.ITestService>(new CoreWCF.NetTcpBinding(SecurityMode.None), FakeAuthRelativePath);
                 builder.AddServiceEndpoint<Services.TestService, ServiceContract.ITestService>(new CoreWCF.NetTcpBinding(SecurityMode.None), NoSecurityRelativePath);
                 Action<ServiceHostBase> serviceHost = host => ChangeHostBehavior(host);
@@ -89,8 +176,6 @@ namespace CoreWCF.NetTcp.Tests
             LdapSettings _ldapSettings = new LdapSettings("ldapserver.test.local", "test.local", "your_own_top_org");
             srvCredentials.WindowsAuthentication.LdapSetting = _ldapSettings;
             host.Description.Behaviors.Add(srvCredentials);
-            var customPolicy = new CustomAuthorizationPolicy(new Claim(ClaimTypes.Role, "CoreWCFGroupAdmin", Rights.Identity));
-            host.Authorization.ExternalAuthorizationPolicies = new List<IAuthorizationPolicy> { customPolicy }.AsReadOnly();
         }
     }
 }

--- a/src/CoreWCF.NetTcp/tests/Helpers/AuthorizeClaimsSetterOperationBehavior.cs
+++ b/src/CoreWCF.NetTcp/tests/Helpers/AuthorizeClaimsSetterOperationBehavior.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using CoreWCF.Channels;
+using CoreWCF.Description;
+using CoreWCF.Dispatcher;
+using CoreWCF.IdentityModel.Claims;
+using System.Collections.Generic;
+
+namespace Helpers
+{
+    internal class AuthorizeClaimsSetterOperationBehavior : IOperationBehavior
+    {
+        private Dictionary<string, List<Claim>> _authorizeClaims;
+        private bool _clearExisting;
+
+        public AuthorizeClaimsSetterOperationBehavior(Dictionary<string, List<Claim>> authorizeClaims, bool clearExisting)
+        {
+            _authorizeClaims = authorizeClaims;
+            _clearExisting = clearExisting;
+        }
+
+        public void AddBindingParameters(OperationDescription operationDescription, BindingParameterCollection bindingParameters) { }
+
+        public void ApplyClientBehavior(OperationDescription operationDescription, ClientOperation clientOperation) { }
+
+
+        public void ApplyDispatchBehavior(OperationDescription operationDescription, DispatchOperation dispatchOperation)
+        {
+            if (_clearExisting)
+            {
+                dispatchOperation.AuthorizeClaims.Clear();
+            }
+
+            foreach (var claims in _authorizeClaims)
+            {
+                dispatchOperation.AuthorizeClaims.TryAdd(claims.Key, claims.Value);
+            }
+        }
+
+        public void Validate(OperationDescription operationDescription) { }
+
+    }
+}

--- a/src/CoreWCF.NetTcp/tests/Helpers/CustomAuthorizationPolicy.cs
+++ b/src/CoreWCF.NetTcp/tests/Helpers/CustomAuthorizationPolicy.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CoreWCF.IdentityModel.Claims;
+using CoreWCF.IdentityModel.Policy;
+
+namespace Helpers
+{
+    internal class CustomAuthorizationPolicy : IAuthorizationPolicy
+    {
+        private List<Claim> _claimsToAdd;
+
+        public CustomAuthorizationPolicy(params Claim[] claims)
+        {
+            _claimsToAdd = claims.ToList();
+        }
+
+        public ClaimSet Issuer => ClaimSet.System;
+
+        public string Id { get; } = Guid.NewGuid().ToString();
+
+        public bool Evaluate(EvaluationContext evaluationContext, ref object state)
+        {
+            bool result = false;
+            CustomAuthState customState = null;
+
+            // If the state is null, then this has not been called before so
+            // set up a custom state.
+            if (state == null)
+            {
+                customState = new CustomAuthState();
+                state = customState;
+            }
+            else
+            {
+                customState = (CustomAuthState)state;
+            }
+
+            // If claims have not been added yet...
+            if (!customState.ClaimsAdded)
+            {
+                // Add claims to the evaluation context.
+                evaluationContext.AddClaimSet(this, new DefaultClaimSet(Issuer, _claimsToAdd));
+
+                // Record that claims were added.
+                customState.ClaimsAdded = true;
+
+                // Return true, indicating that this method does not need to be called again.
+                result = true;
+            }
+
+            return result;
+        }
+
+        // Internal class for keeping track of state.
+        private class CustomAuthState
+        {
+            public CustomAuthState()
+            {
+                ClaimsAdded = false;
+            }
+
+            public bool ClaimsAdded { get; set; }
+        }
+    }
+}

--- a/src/CoreWCF.NetTcp/tests/Helpers/ServiceHelper.cs
+++ b/src/CoreWCF.NetTcp/tests/Helpers/ServiceHelper.cs
@@ -103,6 +103,7 @@ namespace Helpers
                 logging.AddProvider(new ExceptionCapturingLoggerProvider(new XunitLoggerProvider(outputHelper, callerMethodName)));
                 logging.AddFilter("Default", LogLevel.Debug);
                 logging.AddFilter("Microsoft", LogLevel.Debug);
+                logging.AddFilter("Microsoft.AspNetCore.DataProtection", LogLevel.None);
                 logging.SetMinimumLevel(LogLevel.Debug);
             })
 #else

--- a/src/CoreWCF.NetTcp/tests/ServiceContract/ITestService.cs
+++ b/src/CoreWCF.NetTcp/tests/ServiceContract/ITestService.cs
@@ -9,11 +9,24 @@ namespace ServiceContract
     {
         public const string NS = "http://tempuri.org/";
         public const string TESTSERVICE_NAME = nameof(ITestService);
+        public const string AUTHORIZATION_SERVICE_NAME = nameof(ITestAuthorizationService);
         public const string OPERATION_BASE = NS + TESTSERVICE_NAME + "/";
     }
 
+    [ServiceContract(Namespace = Constants.NS, Name = Constants.AUTHORIZATION_SERVICE_NAME)]
+    public interface ITestAuthorizationService
+    {
+        [OperationContract(Name = "EchoForAuthorizarionOneRole", Action = Constants.OPERATION_BASE + "EchoForAuthorizarionOneRole",
+        ReplyAction = Constants.OPERATION_BASE + "EchoForAuthorizarionOneRoleResponse")]
+        string EchoForAuthorizarionOneRole(string echo);
+
+        [OperationContract(Name = "EchoForAuthorizarionNoRole", Action = Constants.OPERATION_BASE + "EchoForAuthorizarionNoRole",
+        ReplyAction = Constants.OPERATION_BASE + "EchoForAuthorizarionNoRoleResponse")]
+        string EchoForAuthorizarionNoRole(string echo);
+    }
+
     [ServiceContract(Namespace = Constants.NS, Name = Constants.TESTSERVICE_NAME)]
-    public interface ITestService
+    public interface ITestService : ITestAuthorizationService
     {
         [OperationContract(Name = "Echo", Action = Constants.OPERATION_BASE + "Echo",
             ReplyAction = Constants.OPERATION_BASE + "EchoResponse")]
@@ -46,13 +59,5 @@ namespace ServiceContract
         [OperationContract(Name = "EchoForImpersonation", Action = Constants.OPERATION_BASE + "EchoForImpersonation",
         ReplyAction = Constants.OPERATION_BASE + "EchoForImpersonationResponse")]
         string EchoForImpersonation(string echo);
-
-        [OperationContract(Name = "EchoForAuthorizarionOneRole", Action = Constants.OPERATION_BASE + "EchoForAuthorizarionOneRole",
-        ReplyAction = Constants.OPERATION_BASE + "EchoForAuthorizarionOneRoleResponse")]
-        string EchoForAuthorizarionOneRole(string echo);
-
-        [OperationContract(Name = "EchoForAuthorizarionNoRole", Action = Constants.OPERATION_BASE + "EchoForAuthorizarionNoRole",
-        ReplyAction = Constants.OPERATION_BASE + "EchoForAuthorizarionNoRoleResponse")]
-        string EchoForAuthorizarionNoRole(string echo);
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilderExtensions.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceBuilderExtensions.cs
@@ -36,10 +36,9 @@ namespace CoreWCF.Configuration
 
         public static void ConfigureAllServiceHostBase(this IServiceBuilder builder, Action<ServiceHostBase> func)
         {
-            foreach (Type service in builder.Services)
-            {
-                builder.ConfigureServiceHostBase(service, func);
-            }
+            var serviceBuilder = builder as ServiceBuilder;
+            AllServicesConfigurationDelegateHolder holder = serviceBuilder.ServiceProvider.GetRequiredService<AllServicesConfigurationDelegateHolder>();
+            holder.AddConfigDelegate(func);
         }
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceConfigurationDelegateHolder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceConfigurationDelegateHolder.cs
@@ -40,9 +40,12 @@ namespace CoreWCF.Configuration
         }
     }
 
+    // Used by ConfigureAllServiceHostBase
+    internal class AllServicesConfigurationDelegateHolder : ServiceConfigurationDelegateHolder { }
+
     internal class ServiceConfigurationDelegateHolder<TService> : ServiceConfigurationDelegateHolder
         where TService : class
     {
-        
+
     }
 }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceModelServiceCollectionExtensions.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Configuration/ServiceModelServiceCollectionExtensions.cs
@@ -88,6 +88,7 @@ namespace CoreWCF.Configuration
             services.TryAddSingleton(typeof(IServiceConfiguration<>), typeof(ServiceConfiguration<>));
             services.TryAddSingleton<IDispatcherBuilder, DispatcherBuilderImpl>();
             services.AddSingleton(typeof(ServiceConfigurationDelegateHolder<>));
+            services.AddSingleton<AllServicesConfigurationDelegateHolder>();
             services.AddScoped<ReplyChannelBinder>();
             services.AddScoped<DuplexChannelBinder>();
             services.AddScoped<InputChannelBinder>();

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/DispatcherBuilder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/DispatcherBuilder.cs
@@ -681,15 +681,18 @@ namespace CoreWCF.Description
 
                     if (dispatchOperation != null)
                     {
-                        for (int j = 0; j < operation.Behaviors.Count; j++)
-                        {
-                            IOperationBehavior behavior = operation.Behaviors[j];
-                            behavior.ApplyDispatchBehavior(operation, dispatchOperation);
-                        }
+                        // Applying authorizations before behaviors so that behaviors can be used validate or customize
+                        // any claims that have been applied.
                         for (int k = 0; k < operation.AuthorizeOperation.Count; k++)
                         {
                             IAuthorizeOperation authorizeOperation = operation.AuthorizeOperation[k];
                             authorizeOperation.BuildClaim(operation, dispatchOperation);
+                        }
+
+                        for (int j = 0; j < operation.Behaviors.Count; j++)
+                        {
+                            IOperationBehavior behavior = operation.Behaviors[j];
+                            behavior.ApplyDispatchBehavior(operation, dispatchOperation);
                         }
                     }
                 }
@@ -717,6 +720,7 @@ namespace CoreWCF.Description
             ServiceHostObjectModel<TService> serviceHost;
             serviceHost = services.GetRequiredService<ServiceHostObjectModel<TService>>();
 
+            AllServicesConfigurationDelegateHolder allServicesConfigDelegate = services.GetService<AllServicesConfigurationDelegateHolder>();
             ServiceConfigurationDelegateHolder<TService> configDelegate = services.GetService<ServiceConfigurationDelegateHolder<TService>>();
             var options = new ServiceOptions<TService>(serviceHost);
             foreach (var serverUriAddress in serverUriAddresses)
@@ -750,6 +754,7 @@ namespace CoreWCF.Description
             }
 
             configDelegate?.Configure(serviceHost);
+            allServicesConfigDelegate?.Configure(serviceHost);
             InitializeServiceHost(serviceHost, services);
 
             // TODO: Add error checking to make sure property chain is correctly populated with objects

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/TypeLoader.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/TypeLoader.cs
@@ -212,6 +212,11 @@ namespace CoreWCF.Description
             for(int i=0; i< contractDesc.Operations.Count; i++)
             {
                 OperationDescription opDesc = contractDesc.Operations[i];
+                if (opDesc.DeclaringContract != contractDesc)
+                {
+                    continue;
+                }
+
                 Type targetIface = implIsCallback ? opDesc.DeclaringContract.CallbackContractType : opDesc.DeclaringContract.ContractType;
                 ApplyServiceInheritance(
                     opDesc.AuthorizeOperation,
@@ -221,6 +226,10 @@ namespace CoreWCF.Description
                         GetIOperationAttributesFromType<IAuthorizeOperation>(opDesc, targetIface, currentType);
                         for (int j = 0; j < toAdd.Count; j++)
                         {
+                            // Do not add to the passed in behaviors as that will drop any duplicates
+                            // which we do not want. If there are multiple conflicting instances on the
+                            // same operation, we need to fail, otherwise there's a risk of the intended
+                            // security authorization constraints silently being ignored.
                             opDesc.AuthorizeOperation.Add(toAdd[j]);
                         }
                     });

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/DispatchOperation.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/DispatchOperation.cs
@@ -127,7 +127,7 @@ namespace CoreWCF.Dispatcher
             }
         }
 
-        public ConcurrentDictionary<string,List<Claim>> AuthorizeClaims //need help with naming
+        public ConcurrentDictionary<string,List<Claim>> AuthorizeClaims
         {
             get { return _authorizeClaims; }
             set

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/DispatchOperationRuntime.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/DispatchOperationRuntime.cs
@@ -547,8 +547,11 @@ namespace CoreWCF.Dispatcher
         private void ValidateAuthorizedClaims(MessageRpc rpc)
         {
             if (AuthorizeClaims.IsEmpty || AuthorizeClaims.Keys.Count == 0)
+            {
                 return;
-            if (rpc.OperationContext?.ServiceSecurityContext.AuthorizationPolicies == null)
+            }
+
+            if (rpc.OperationContext?.ServiceSecurityContext.AuthorizationContext == null)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(AuthorizationBehavior.CreateAccessDeniedFaultException());
             }
@@ -556,32 +559,28 @@ namespace CoreWCF.Dispatcher
             foreach (var eachAuthClaim in AuthorizeClaims)
             {
                 List<Claim> allClaims = eachAuthClaim.Value;
-                if(!IsClaimFound(rpc.OperationContext?.ServiceSecurityContext.AuthorizationPolicies, allClaims))
+                if(IsClaimFound(rpc.OperationContext?.ServiceSecurityContext.AuthorizationContext.ClaimSets, allClaims))
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(AuthorizationBehavior.CreateAccessDeniedFaultException());
+                    return;
                 }
             }
+
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(AuthorizationBehavior.CreateAccessDeniedFaultException());
         }
 
-        private bool IsClaimFound(ReadOnlyCollection<IAuthorizationPolicy> policies, List<Claim> anyClaims)
+        private bool IsClaimFound(ReadOnlyCollection<IdentityModel.Claims.ClaimSet> claimSets, List<Claim> anyClaims)
         {
-            foreach (var policy in policies)
+            foreach (var claim in anyClaims)
             {
-                if(policy is UnconditionalPolicy)
+                foreach (var claimSet in claimSets)
                 {
-                    var claimSets = ((UnconditionalPolicy)policy).Issuances;
-                    foreach (var claim in anyClaims)
+                    if (claimSet.ContainsClaim(claim))
                     {
-                        foreach (var claimSet in claimSets)
-                        {
-                            if (claimSet.ContainsClaim(claim))
-                            {
-                                return true;
-                            }
-                        }
+                        return true;
                     }
                 }
             }
+
             return false;
         }
     }

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/DispatchOperationRuntime.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/DispatchOperationRuntime.cs
@@ -551,7 +551,7 @@ namespace CoreWCF.Dispatcher
                 return;
             }
 
-            if (rpc.OperationContext?.ServiceSecurityContext.AuthorizationContext == null)
+            if (rpc.OperationContext?.ServiceSecurityContext?.AuthorizationContext == null)
             {
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(AuthorizationBehavior.CreateAccessDeniedFaultException());
             }
@@ -559,13 +559,11 @@ namespace CoreWCF.Dispatcher
             foreach (var eachAuthClaim in AuthorizeClaims)
             {
                 List<Claim> allClaims = eachAuthClaim.Value;
-                if(IsClaimFound(rpc.OperationContext?.ServiceSecurityContext.AuthorizationContext.ClaimSets, allClaims))
+                if(!IsClaimFound(rpc.OperationContext?.ServiceSecurityContext.AuthorizationContext.ClaimSets, allClaims))
                 {
-                    return;
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(AuthorizationBehavior.CreateAccessDeniedFaultException());
                 }
             }
-
-            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(AuthorizationBehavior.CreateAccessDeniedFaultException());
         }
 
         private bool IsClaimFound(ReadOnlyCollection<IdentityModel.Claims.ClaimSet> claimSets, List<Claim> anyClaims)


### PR DESCRIPTION
Fixed use of custom authorization policies when using AuthorizeRoleAttribute
Fixed AuthorizeRoleAttribute tests to run in CI regularly
Fixes #1339