### PR TITLE
Add Test for DiscoResult

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceMetadataExtension.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceMetadataExtension.cs
@@ -439,7 +439,7 @@ namespace CoreWCF.Description
             }
         }
 
-        internal class HttpGetImpl
+        public class HttpGetImpl
         {
             private const string DiscoToken = "disco token";
             private const string DiscoQueryString = "disco";
@@ -1152,7 +1152,7 @@ namespace CoreWCF.Description
             #endregion static helpers
 
             #region Helper Message implementations
-            private class DiscoResult : MetadataResult
+            public class DiscoResult : MetadataResult
             {
                 private readonly string _wsdlAddress;
                 private readonly string _docAddress;
@@ -1504,7 +1504,7 @@ SR.SFxDocExt_NoMetadataSection5        ));
                 }
             }
 
-            internal abstract class MetadataResult
+            public abstract class MetadataResult
             {
                 public async Task WriteResponseAsync(HttpResponse response)
                 {

--- a/src/CoreWCF.Primitives/tests/Messages/DiscoResultTest.cs
+++ b/src/CoreWCF.Primitives/tests/Messages/DiscoResultTest.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Threading.Tasks;
+using CoreWCF.Description;
+using Xunit;
+
+namespace CoreWCF.Primitives.Tests.Messages;
+
+public class DiscoResultTest
+{
+    [Fact]
+    public async Task WriteDiscoResulTest()
+    {
+        var wsdlAddress = "http://localhost:8080/wsdl";
+        var docAddress = "http://localhost:8080/doc";
+        var discoResult = new ServiceMetadataExtension.HttpGetImpl.DiscoResult(wsdlAddress,docAddress);
+
+        var httpResponse = new MockHttpResponse();
+        await discoResult.WriteResponseAsync(httpResponse);
+
+        httpResponse.Body.Position = 0;
+
+        using var reader = new StreamReader(httpResponse.Body);
+
+        var result = reader.ReadToEnd();
+        var expected = """
+                       <?xml version="1.0" encoding="utf-8"?><discovery xmlns="http://schemas.xmlsoap.org/disco/"><contractRef ref="http://localhost:8080/wsdl" docRef="http://localhost:8080/doc" xmlns="http://schemas.xmlsoap.org/disco/scl/" /></discovery>
+                       """;
+        Assert.Equal(expected, result);
+    }
+}

--- a/src/CoreWCF.Primitives/tests/Messages/MockHttpResponse.cs
+++ b/src/CoreWCF.Primitives/tests/Messages/MockHttpResponse.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace CoreWCF.Primitives.Tests.Messages;
+
+public class MockHttpResponse : HttpResponse
+{
+    public override void OnStarting(Func<object, Task> callback, object state) => throw new NotImplementedException();
+
+    public override void OnCompleted(Func<object, Task> callback, object state) => throw new NotImplementedException();
+
+    public override void Redirect(string location, bool permanent) => throw new NotImplementedException();
+
+    public override HttpContext HttpContext { get; }
+    public override int StatusCode { get; set; }
+    public override IHeaderDictionary Headers { get; }
+    public override Stream Body { get; set; } = new MemoryStream();
+    public override long? ContentLength { get; set; }
+    public override string ContentType { get; set; }
+    public override IResponseCookies Cookies { get; }
+    public override bool HasStarted { get; }
+}


### PR DESCRIPTION
Added Test for #1516

I had to make those classes public, because I had problems accessing the DiscoResult from the TestAssembly. I did not manage to get InternalsVisibleTo working. Probably need help with that, to not make those classes public

Is this test how you wanted it to be, or should it be done in a different way?