### PR TITLE
Fix issue with implicit metadata Https url using the Http base address

### DIFF
--- a/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
+++ b/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.2.0" />
+    <PackageReference Include="AngleSharp.Diffing" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.10.3" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.3" />
@@ -41,6 +43,12 @@
 
   <ItemGroup>
     <None Update="Wsdls\*.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="HelpPages\*.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/CoreWCF.Metadata/tests/DiscoTests.cs
+++ b/src/CoreWCF.Metadata/tests/DiscoTests.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using CoreWCF.Channels;
+using CoreWCF.Metadata.Tests.Helpers;
+using ServiceContract;
+using Services;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreWCF.Metadata.Tests
+{
+    public class DiscoTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public DiscoTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task HttpGetDiscoDocument()
+        {
+            await TestHelper.RunDiscoTestAsync<SimpleEchoService, IEchoService>(new BasicHttpBinding(BasicHttpSecurityMode.None), _output);
+        }
+
+        [Fact]
+        public async Task HttpsGetDiscoDocument()
+        {
+            await TestHelper.RunDiscoTestAsync<SimpleEchoService, IEchoService>(new BasicHttpBinding(BasicHttpSecurityMode.Transport), _output);
+        }
+    }
+}

--- a/src/CoreWCF.Metadata/tests/HelpPageTests.cs
+++ b/src/CoreWCF.Metadata/tests/HelpPageTests.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using CoreWCF.Metadata.Tests.Helpers;
+using CoreWCF.Channels;
+using ServiceContract;
+using Services;
+using Xunit;
+using Xunit.Abstractions;
+using System.Collections.Generic;
+using System;
+
+namespace CoreWCF.Metadata.Tests
+{
+    public class HelpPageTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public HelpPageTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task HttpOnlyEndpointGetHttpHelpPage()
+        {
+            await TestHelper.RunHelpPageTestAsync<SimpleEchoService, IEchoService>(new BasicHttpBinding(BasicHttpSecurityMode.None), _output);
+        }
+
+        [Fact]
+        public async Task HttpsOnlyEndpointGetHttpsHelpPage()
+        {
+            await TestHelper.RunHelpPageTestAsync<SimpleEchoService, IEchoService>(new BasicHttpBinding(BasicHttpSecurityMode.Transport), _output);
+        }
+
+        [Fact]
+        public async Task HttpAndHttpsEndpointsGetHelpPages()
+        {
+            var bindingEndpointMap = new Dictionary<string, Binding>
+            {
+                ["insecure"] = new BasicHttpBinding(BasicHttpSecurityMode.None),
+                ["secure"] = new BasicHttpBinding(BasicHttpSecurityMode.Transport)
+            };
+            await TestHelper.RunMultipleEndpointsHelpPageTestAsync<SimpleEchoService, IEchoService>(bindingEndpointMap, new Uri[] { new Uri("http://localhost/wsHttp"), new Uri("https://localhost/wsHttp") }, _output);
+        }
+    }
+}

--- a/src/CoreWCF.Metadata/tests/HelpPages/HelpPageTests.html
+++ b/src/CoreWCF.Metadata/tests/HelpPages/HelpPageTests.html
@@ -1,0 +1,21 @@
+﻿<HTML lang="en"><HEAD><link rel="alternate" type="text/xml" href="http://localhost:8080/HttpOnlyEndpointGetHttpHelpPage?disco"/><STYLE type="text/css">#content{ FONT-SIZE: 0.7em; PADDING-BOTTOM: 2em; MARGIN-LEFT: 30px}BODY{MARGIN-TOP: 0px; MARGIN-LEFT: 0px; COLOR: #000000; FONT-FAMILY: Verdana; BACKGROUND-COLOR: white}P{MARGIN-TOP: 0px; MARGIN-BOTTOM: 12px; COLOR: #000000; FONT-FAMILY: Verdana}PRE{BORDER-RIGHT: #f0f0e0 1px solid; PADDING-RIGHT: 5px; BORDER-TOP: #f0f0e0 1px solid; MARGIN-TOP: -5px; PADDING-LEFT: 5px; FONT-SIZE: 1.2em; PADDING-BOTTOM: 5px; BORDER-LEFT: #f0f0e0 1px solid; PADDING-TOP: 5px; BORDER-BOTTOM: #f0f0e0 1px solid; FONT-FAMILY: Courier New; BACKGROUND-COLOR: #e5e5cc}.heading1{MARGIN-TOP: 0px; PADDING-LEFT: 15px; FONT-WEIGHT: normal; FONT-SIZE: 26px; MARGIN-BOTTOM: 0px; PADDING-BOTTOM: 3px; MARGIN-LEFT: -30px; WIDTH: 100%; COLOR: #ffffff; PADDING-TOP: 10px; FONT-FAMILY: Tahoma; BACKGROUND-COLOR: #003366}.intro{display: block; font-size: 1em;}</STYLE><TITLE>SimpleEchoService Service</TITLE></HEAD><BODY><DIV id="content" role="main"><h1 class="heading1">SimpleEchoService Service</h1><BR/><P class="intro">You have created a service.<P class='intro'>To test this service, you will need to create a client and use it to call the service. You can do this using the svcutil.exe tool from the command line with the following syntax:</P> <BR/><PRE>svcutil.exe <A HREF="http://localhost:8080/HttpOnlyEndpointGetHttpHelpPage?wsdl">http://localhost:8080/HttpOnlyEndpointGetHttpHelpPage?wsdl</A></PRE><P>You can also access the service description as a single file:<BR/><PRE><A HREF="http://localhost:8080/HttpOnlyEndpointGetHttpHelpPage?singleWsdl">http://localhost:8080/HttpOnlyEndpointGetHttpHelpPage?singleWsdl</A></PRE></P></P><P class="intro">This will generate a configuration file and a code file that contains the client class. Add the two files to your client application and use the generated client class to call the Service. For example:<BR/></P><h2 class='intro'>C#</h2><br /><PRE><font color="blue">class </font><font color="black">Test
+</font>{
+<font color="blue">    static void </font>Main()
+    {
+        <font color="black">EchoServiceClient</font> client = <font color="blue">new </font><font color="black">EchoServiceClient</font>();
+
+<font color="darkgreen">        // Use the 'client' variable to call operations on the service.
+
+</font><font color="darkgreen">        // Always close the client.
+</font>        client.Close();
+    }
+}
+</PRE><BR/><h2 class='intro'>Visual Basic</h2><br /><PRE><font color="blue">Class </font><font color="black">Test
+</font><font color="blue">    Shared Sub </font>Main()
+<font color="blue">        Dim </font>client As <font color="black">EchoServiceClient</font> = <font color="blue">New </font><font color="black">EchoServiceClient</font>()
+<font color="darkgreen">        ' Use the 'client' variable to call operations on the service.
+
+</font><font color="darkgreen">        ' Always close the client.
+</font>        client.Close()
+<font color="blue">    End Sub
+</font><font color="blue">End Class</font></PRE></DIV></BODY></HTML>

--- a/src/CoreWCF.Metadata/tests/Helpers/DiscoHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/DiscoHelper.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using System;
+using AngleSharp.Diffing;
+using AngleSharp.Html.Dom;
+using AngleSharp.Html.Parser;
+using AngleSharp;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using System.Xml.Linq;
+using System.Security.Cryptography.Xml;
+using System.Xml;
+
+namespace CoreWCF.Metadata.Tests.Helpers
+{
+    internal static class DiscoHelper
+    {
+
+        internal static async Task ValidateDiscoDocument(string metadataBaseAddress, string callerMethodName, string sourceFilePath, Action<HttpClient> configureHttpClient)
+        {
+            string generatedDoc = string.Empty;
+            var discoAddress = metadataBaseAddress + "?disco";
+            // As a new ASP.NET Core service is started for each test, there's no benefit from
+            // cachine an HttpClient instance as a new port will be used and idle sockets will be closed.
+            var httpClientHandler = new HttpClientHandler();
+            httpClientHandler.ServerCertificateCustomValidationCallback = (request, certificate, chain, errors) => true;
+            using (var client = new HttpClient(httpClientHandler))
+            {
+                configureHttpClient?.Invoke(client);
+                var response = await client.GetAsync(discoAddress);
+                Assert.True(response.IsSuccessStatusCode, $"Response status for url {discoAddress} is {(int)response.StatusCode} {response.StatusCode} {response.ReasonPhrase}");
+                Assert.Equal("text/xml; charset=UTF-8", response.Content.Headers.ContentType.ToString());
+                generatedDoc = await response.Content.ReadAsStringAsync();
+            }
+            Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", generatedDoc);
+
+            var contractRefUrl = metadataBaseAddress + "?wsdl";
+            var docRefUrl = metadataBaseAddress;
+
+            var expectedDiscoDoc = $"""
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <discovery xmlns="http://schemas.xmlsoap.org/disco/">
+                        <contractRef ref="{contractRefUrl}" docRef="{docRefUrl}" xmlns="http://schemas.xmlsoap.org/disco/scl/"/>
+                    </discovery>
+                    """;
+
+            // Canonicalize both disco documents so that comparison is semantic and not literal. This is because things like attributes in XML
+            // are unordered unless canonicalized.
+            generatedDoc = CanonicalizeXml(generatedDoc);
+            expectedDiscoDoc = CanonicalizeXml(expectedDiscoDoc);
+            Assert.Equal(expectedDiscoDoc, generatedDoc);
+        }
+
+        private static string CanonicalizeXml(string rawXmlTxt)
+        {
+            XmlDocument xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(rawXmlTxt);
+            XmlDsigC14NTransform t = new XmlDsigC14NTransform();
+            t.LoadInput(xmlDoc);
+            Stream canonicalizedStream = (Stream)t.GetOutput();
+            StreamReader reader = new StreamReader(canonicalizedStream);
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/src/CoreWCF.Metadata/tests/Helpers/HelpPageHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/HelpPageHelper.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Helpers
 {
-    internal class HelpPageHelper
+    internal static class HelpPageHelper
     {
         internal static async Task ValidateHelpPage(string serviceMetadataPath, string callerMethodName, string sourceFilePath, Action<HttpClient> configureHttpClient = null)
         {

--- a/src/CoreWCF.Metadata/tests/Helpers/HelpPageHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/HelpPageHelper.cs
@@ -1,0 +1,143 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using AngleSharp;
+using AngleSharp.Diffing;
+using AngleSharp.Diffing.Core;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AngleSharp.Html.Parser;
+using Xunit;
+
+namespace Helpers
+{
+    internal class HelpPageHelper
+    {
+        internal static async Task ValidateHelpPage(string serviceMetadataPath, string callerMethodName, string sourceFilePath, Action<HttpClient> configureHttpClient = null)
+        {
+            string generatedHtml = string.Empty;
+            // As a new ASP.NET Core service is started for each test, there's no benefit from
+            // cachine an HttpClient instance as a new port will be used and idle sockets will be closed.
+            var httpClientHandler = new HttpClientHandler();
+            httpClientHandler.ServerCertificateCustomValidationCallback = (request, certificate, chain, errors) => true;
+            using (var client = new HttpClient(httpClientHandler))
+            {
+                configureHttpClient?.Invoke(client);
+                var response = await client.GetAsync(serviceMetadataPath);
+                Assert.True(response.IsSuccessStatusCode, $"Response status for url {serviceMetadataPath} is {(int)response.StatusCode} {response.StatusCode} {response.ReasonPhrase}");
+                Assert.Equal("text/html; charset=UTF-8", response.Content.Headers.ContentType.ToString());
+                generatedHtml = await response.Content.ReadAsStringAsync();
+            }
+
+            Assert.False(generatedHtml.StartsWith("<?xml"));
+            var expectedHtmlFileName = Path.Combine("HelpPages", Path.GetFileNameWithoutExtension(sourceFilePath) + "." + callerMethodName + ".html");
+            if (!File.Exists(expectedHtmlFileName))
+            {
+                // If sourceFilename.methodname.xml doesn't exist, then look for sourceFilename.html. This enables use of a single expected html file
+                // for multiple tests in a single test class.
+                var classHtmlFileName = Path.Combine("HelpPages", Path.GetFileNameWithoutExtension(sourceFilePath) + ".html");
+                if (!File.Exists(classHtmlFileName))
+                {
+                    Assert.Fail($"Unable to find expected help page html file at {expectedHtmlFileName} or {classHtmlFileName}");
+                }
+
+                expectedHtmlFileName = classHtmlFileName;
+            }
+
+            var expectedHtml = File.ReadAllText(expectedHtmlFileName); // Net472 doesn't have an async variant of ReadAllText
+            var diffs = DiffBuilder.Compare(expectedHtml)
+                                   .WithTest(generatedHtml)
+                                   .WithOptions(options =>
+                                   {
+                                       options.AddDefaultOptions()
+                                              .AddFilter(DiscoAlternateLinkHRefFilter)
+                                              .AddFilter(WsdlAnchorHRefFilter)
+                                              .AddFilter(WsdlAnchorTextFilter);
+                                   })
+                                   .Build();
+
+            // The three filters DiscoAlternateLinkHRefFilter, WsdlAnchorHRefFilter, and WsdlAnchorTextFilter are used to filter out
+            // the expected differences in the generated html around the wsdl url being different and the anchor text being different.
+            // This should result in diffs being empty.
+            Assert.Empty(diffs);
+
+            IConfiguration config = Configuration.Default;
+            IBrowsingContext context = BrowsingContext.New(config);
+            IHtmlParser parser = context.GetService<IHtmlParser>();
+            IHtmlDocument document = parser.ParseDocument(generatedHtml);
+
+            IHtmlLinkElement linkElement = document.QuerySelectorAll("link").Single() as IHtmlLinkElement;
+            var linkHref = linkElement.GetAttribute("href");
+            var expectedLinkHref = serviceMetadataPath + "?disco";
+            Assert.Equal(expectedLinkHref, linkHref);
+
+            IEnumerable<IHtmlAnchorElement> anchorElements = document.QuerySelectorAll("a").Cast<IHtmlAnchorElement>();
+            var wsdlAnchor = anchorElements.Single(a => a.GetAttribute("href").EndsWith("?wsdl"));
+            var expectedWsdlUrl = serviceMetadataPath + "?wsdl";
+            Assert.Equal(expectedWsdlUrl, wsdlAnchor.GetAttribute("href"));
+            Assert.Equal(expectedWsdlUrl, wsdlAnchor.Text.Trim());
+
+            var singleWsdlAnchor = anchorElements.Single(a => a.GetAttribute("href").EndsWith("?singleWsdl"));
+            var expectedSingleWsdlUrl = serviceMetadataPath + "?singleWsdl";
+            Assert.Equal(expectedSingleWsdlUrl, singleWsdlAnchor.GetAttribute("href"));
+            Assert.Equal(expectedSingleWsdlUrl, singleWsdlAnchor.Text.Trim());
+        }
+
+        internal static FilterDecision DiscoAlternateLinkHRefFilter(in AttributeComparisonSource source, FilterDecision currentDecision)
+        {
+            if (currentDecision.IsExclude())
+            {
+                return currentDecision;
+            }
+
+            if (source.Attribute.Name.Equals("href", StringComparison.OrdinalIgnoreCase))
+            {
+                if (source.Attribute.OwnerElement.NodeType == AngleSharp.Dom.NodeType.Element && source.Attribute.OwnerElement is IHtmlLinkElement)
+                {
+                    return FilterDecision.Exclude;
+                }
+            }
+
+            return currentDecision;
+        }
+
+        internal static FilterDecision WsdlAnchorHRefFilter(in AttributeComparisonSource source, FilterDecision currentDecision)
+        {
+            if (currentDecision.IsExclude())
+            {
+                return currentDecision;
+            }
+
+            if (source.Attribute.Name.Equals("href", StringComparison.OrdinalIgnoreCase))
+            {
+                if (source.Attribute.OwnerElement.NodeType == AngleSharp.Dom.NodeType.Element && source.Attribute.OwnerElement is IHtmlAnchorElement)
+                {
+                    return FilterDecision.Exclude;
+                }
+            }
+
+            return currentDecision;
+        }
+
+        internal static FilterDecision WsdlAnchorTextFilter(in ComparisonSource source, FilterDecision currentDecision)
+        {
+            if (currentDecision.IsExclude())
+            {
+                return currentDecision;
+            }
+
+            if (source.Node is IText textNode && textNode.ParentElement is IHtmlAnchorElement)
+            {
+                return FilterDecision.Exclude;
+            }
+
+            return currentDecision;
+        }
+    }
+}

--- a/src/CoreWCF.Metadata/tests/Helpers/HelpPageHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/HelpPageHelper.cs
@@ -31,7 +31,9 @@ namespace Helpers
                 configureHttpClient?.Invoke(client);
                 var response = await client.GetAsync(serviceMetadataPath);
                 Assert.True(response.IsSuccessStatusCode, $"Response status for url {serviceMetadataPath} is {(int)response.StatusCode} {response.StatusCode} {response.ReasonPhrase}");
-                Assert.Equal("text/html; charset=UTF-8", response.Content.Headers.ContentType.ToString());
+                // There's a bug in .NET 6 where it switches the charset to lower case. This is fixed in .NET 7 and later. Without ignoring the case
+                // when doing the comparison, this test fails on .NET 6
+                Assert.Equal("text/html; charset=UTF-8", response.Content.Headers.ContentType.ToString(), StringComparer.OrdinalIgnoreCase);
                 generatedHtml = await response.Content.ReadAsStringAsync();
             }
 

--- a/src/CoreWCF.Metadata/tests/Helpers/HelpPageHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/HelpPageHelper.cs
@@ -23,7 +23,7 @@ namespace Helpers
         {
             string generatedHtml = string.Empty;
             // As a new ASP.NET Core service is started for each test, there's no benefit from
-            // cachine an HttpClient instance as a new port will be used and idle sockets will be closed.
+            // caching an HttpClient instance as a new port will be used and idle sockets will be closed.
             var httpClientHandler = new HttpClientHandler();
             httpClientHandler.ServerCertificateCustomValidationCallback = (request, certificate, chain, errors) => true;
             using (var client = new HttpClient(httpClientHandler))

--- a/src/CoreWCF.Metadata/tests/Helpers/ListeningPortHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/ListeningPortHelper.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Helpers
+{
+    internal class ListeningPortHelper
+    {
+        private Dictionary<string, Func<int>> _schemeToPortDelegate = new();
+
+        public void AddSchemeToPortDelegate(string scheme, Func<int> portDelegate)
+        {
+            _schemeToPortDelegate.Add(scheme, portDelegate);
+        }
+
+        public int GetPortForScheme(string scheme)
+        {
+            if (_schemeToPortDelegate.TryGetValue(scheme, out Func<int> portDelegate))
+            {
+                return portDelegate();
+            }
+
+            return 0;
+        }
+
+        public IEnumerable<string> Schemes => _schemeToPortDelegate.Keys;
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            bool first = true;
+            foreach (var kvp in _schemeToPortDelegate)
+            {
+                if (!first)
+                {
+                    sb.Append(", ");
+                }
+
+                first = false;
+                var port = kvp.Value();
+                var portStr = port != 0 ? port.ToString() : "?";
+                sb.Append($"{kvp.Key} => {portStr}");
+
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/CoreWCF.Metadata/tests/Helpers/TestHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/TestHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using CoreWCF.Channels;
 using Helpers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace CoreWCF.Metadata.Tests.Helpers
@@ -33,23 +35,33 @@ namespace CoreWCF.Metadata.Tests.Helpers
                 output,
                 callerMethodName)
                 .Build();
-            string wsdlAddress = "http://localhost:8080" + EndpointRelativePath;
-            if ("https".Equals(binding.Scheme, StringComparison.OrdinalIgnoreCase))
-            {
-                wsdlAddress = "https://localhost:8443" + EndpointRelativePath;
-            }
+
             using (host)
             {
                 await host.StartAsync();
-                endpointAddress ??= ServiceHelper.GetEndpointBaseAddress(host, binding);
+                var portHelper = host.Services.GetRequiredService<ListeningPortHelper>();
+                string wsdlScheme = binding.Scheme.StartsWith("http") ? binding.Scheme : Uri.UriSchemeHttp;
+                int port = portHelper.GetPortForScheme(wsdlScheme);
+                if (port == 0)
+                {
+                    Assert.Fail($"No port found for {wsdlScheme} scheme, available port mappings are: {portHelper}");
+                }
+
+                string wsdlAddress = $"{wsdlScheme}://localhost:{port}" + EndpointRelativePath;
+
+                endpointAddress ??= ServiceHelper.GetEndpointBaseAddress(host, binding.Scheme);
+                if (endpointAddress.EndsWith("/"))
+                {
+                    endpointAddress = endpointAddress.Substring(0, endpointAddress.Length - 1);
+                }
                 endpointAddress += EndpointRelativePath;
                 await WsdlHelper.ValidateSingleWsdl(wsdlAddress, endpointAddress, callerMethodName, sourceFilePath, configureHttpClient);
             }
         }
 
         internal static async Task RunMultipleWsdlTestAsync<TService1, TService2, TContract1, TContract2>(Binding binding1, Binding binding2, ITestOutputHelper output,
-        [System.Runtime.CompilerServices.CallerMemberName] string callerMethodName = "",
-        [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "") where TService1 : class where TService2 : class
+                [System.Runtime.CompilerServices.CallerMemberName] string callerMethodName = "",
+                [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "") where TService1 : class where TService2 : class
         {
             IWebHost host = ServiceHelper.CreateHttpWebHostBuilderWithMetadata<TService1, TService2, TContract1, TContract2>(
                 binding1,
@@ -58,21 +70,29 @@ namespace CoreWCF.Metadata.Tests.Helpers
                 output,
                 callerMethodName)
                 .Build();
-            string wsdl1Address = "http://localhost:8080/1" + EndpointRelativePath;
-            if ("https".Equals(binding1.Scheme, StringComparison.OrdinalIgnoreCase))
-            {
-                wsdl1Address = "https://localhost:8443/1" + EndpointRelativePath;
-            }
-            string wsdl2Address = "http://localhost:8080/2" + EndpointRelativePath;
-            if ("https".Equals(binding1.Scheme, StringComparison.OrdinalIgnoreCase))
-            {
-                wsdl2Address = "https://localhost:8443/2" + EndpointRelativePath;
-            }
+
             using (host)
             {
                 await host.StartAsync();
-                var endpoint1Address = $"{ServiceHelper.GetEndpointBaseAddress(host, binding1)}/1{EndpointRelativePath}/{binding1.Scheme}";
-                var endpoint2Address = $"{ServiceHelper.GetEndpointBaseAddress(host, binding2)}/2{EndpointRelativePath}/{binding2.Scheme}";
+                var portHelper = host.Services.GetRequiredService<ListeningPortHelper>();
+                string wsdlScheme1 = binding1.Scheme.StartsWith("http") ? binding1.Scheme : Uri.UriSchemeHttp;
+                int port1 = portHelper.GetPortForScheme(wsdlScheme1);
+                if (port1 == 0)
+                {
+                    Assert.Fail($"No port found for {wsdlScheme1} scheme, available port mappings are: {portHelper}");
+                }
+                string wsdl1Address = $"{wsdlScheme1}://localhost:{port1}/1" + EndpointRelativePath;
+
+                string wsdlScheme2 = binding2.Scheme.StartsWith("http") ? binding2.Scheme : Uri.UriSchemeHttp;
+                int port2 = portHelper.GetPortForScheme(wsdlScheme2);
+                if (port2 == 0)
+                {
+                    Assert.Fail($"No port found for {wsdlScheme2} scheme, available port mappings are: {portHelper}");
+                }
+                string wsdl2Address = $"{wsdlScheme2}://localhost:{port2}/2" + EndpointRelativePath;
+
+                var endpoint1Address = $"{ServiceHelper.GetEndpointBaseAddress(host, binding1.Scheme)}1{EndpointRelativePath}/{binding1.Scheme}";
+                var endpoint2Address = $"{ServiceHelper.GetEndpointBaseAddress(host, binding2.Scheme)}2{EndpointRelativePath}/{binding2.Scheme}";
                 await WsdlHelper.ValidateSingleWsdl(wsdl1Address, endpoint1Address, callerMethodName + "_1", sourceFilePath);
                 await WsdlHelper.ValidateSingleWsdl(wsdl2Address, endpoint2Address, callerMethodName + "_2", sourceFilePath);
             }
@@ -93,9 +113,110 @@ namespace CoreWCF.Metadata.Tests.Helpers
             using (host)
             {
                 await host.StartAsync();
-                var serverListeningAddress = ServiceHelper.GetEndpointBaseAddress(host, bindingEndpointMap.Values.First());
+                // Fix the base addresses to have the correct port numbers based on the actual port numbers used by the host
+                var portHelper = host.Services.GetRequiredService<ListeningPortHelper>();
+                for (int i = 0; i < baseAddresses.Length; i++)
+                {
+                    var baseAddressScheme = baseAddresses[i].Scheme;
+                    int port = portHelper.GetPortForScheme(baseAddressScheme);
+                    if (port == 0)
+                    {
+                        Assert.Fail($"No port found for {baseAddressScheme} scheme, available port mappings are: {portHelper}");
+                    }
+
+                    var baseAddressBuilder = new UriBuilder(baseAddresses[i]);
+                    baseAddressBuilder.Port = port;
+                    baseAddresses[i] = baseAddressBuilder.Uri;
+                }
+
                 await WsdlHelper.ValidateSingleWsdl(baseAddresses, bindingEndpointMap, callerMethodName, sourceFilePath);
             }
         }
+
+        internal static async Task RunHelpPageTestAsync<TService, TContract>(Binding binding, ITestOutputHelper output,
+            Action<IServiceCollection> configureServices = null,
+            Action<HttpClient> configureHttpClient = null,
+            string endpointAddress = null,
+            [System.Runtime.CompilerServices.CallerMemberName] string callerMethodName = "",
+            [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "")
+                 where TService : class
+        {
+            IWebHost host = ServiceHelper.CreateHttpWebHostBuilderWithMetadata<TService, TContract>(
+                binding,
+                EndpointRelativePath,
+                configureServices,
+                output,
+                callerMethodName)
+                .Build();
+
+            using (host)
+            {
+                await host.StartAsync();
+                var portHelper = host.Services.GetRequiredService<ListeningPortHelper>();
+                string helpPageAddress;
+                if (Uri.UriSchemeHttps.Equals(binding.Scheme))
+                {
+                    int port = portHelper.GetPortForScheme(Uri.UriSchemeHttps);
+                    if (port == 0)
+                    {
+                        Assert.Fail($"No port found for https scheme, available port mappings are: {portHelper}");
+                    }
+                    helpPageAddress = $"https://localhost:{port}" + EndpointRelativePath;
+                }
+                else
+                {
+                    int port = portHelper.GetPortForScheme(Uri.UriSchemeHttp);
+                    if (port == 0)
+                    {
+                        Assert.Fail($"No port found for http scheme, available port mappings are: {portHelper}");
+                    }
+                    helpPageAddress = $"http://localhost:{port}" + EndpointRelativePath;
+                }
+
+                await HelpPageHelper.ValidateHelpPage(helpPageAddress, callerMethodName, sourceFilePath, configureHttpClient);
+            }
+        }
+
+        internal static async Task RunMultipleEndpointsHelpPageTestAsync<TService, TContract>(IDictionary<string, Binding> bindingEndpointMap, Uri[] baseAddresses, ITestOutputHelper output,
+                [System.Runtime.CompilerServices.CallerMemberName] string callerMethodName = "",
+                [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "") where TService : class
+        {
+            IWebHost host = ServiceHelper.CreateHttpWebHostBuilderWithMetadata<TService, TContract>(
+                bindingEndpointMap,
+                baseAddresses,
+                output,
+                callerMethodName)
+                .Build();
+
+            using (host)
+            {
+                await host.StartAsync();
+                var baseAddressSchemes = baseAddresses.Select(uri => uri.Scheme).Distinct().ToArray();
+                var portHelper = host.Services.GetRequiredService<ListeningPortHelper>();
+                string helpPageAddress;
+                foreach (var scheme in new[] { Uri.UriSchemeHttp, Uri.UriSchemeHttps } )
+                {
+                    if (!baseAddressSchemes.Contains(scheme))
+                    {
+                        continue;
+                    }
+
+                    int port = portHelper.GetPortForScheme(scheme);
+                    if (port == 0)
+                    {
+                        Assert.Fail($"No port found for {scheme} scheme, available port mappings are: {portHelper}");
+                    }
+
+                    var helpPageAddressBuilder = new UriBuilder(baseAddresses.First(uri => uri.Scheme.Equals(scheme)));
+                    helpPageAddressBuilder.Port = port;
+                    var endpointRelativePath = bindingEndpointMap.Where(entry => entry.Value.Scheme.Equals(scheme)).Select(entry => entry.Key).First();
+                    helpPageAddressBuilder.Path = Path.Combine(helpPageAddressBuilder.Path, endpointRelativePath);
+
+                    helpPageAddress = helpPageAddressBuilder.Uri.ToString();
+                    await HelpPageHelper.ValidateHelpPage(helpPageAddress, callerMethodName, sourceFilePath);
+                }
+            }
+        }
+
     }
 }

--- a/src/CoreWCF.Metadata/tests/Helpers/WsdlHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/WsdlHelper.cs
@@ -24,7 +24,7 @@ namespace CoreWCF.Metadata.Tests.Helpers
             var singleWsdlPath = serviceMetadataPath + "?singleWsdl";
             string generatedWsdlTxt = string.Empty;
             // As a new ASP.NET Core service is started for each test, there's no benefit from
-            // cachine an HttpClient instance as idle sockets will be closed.
+            // cachine an HttpClient instance as a new port will be used and idle sockets will be closed.
             var httpClientHandler = new HttpClientHandler();
             httpClientHandler.ServerCertificateCustomValidationCallback = (request, certificate, chain, errors) => true;
             using (var client = new HttpClient(httpClientHandler))
@@ -68,8 +68,6 @@ namespace CoreWCF.Metadata.Tests.Helpers
         {
             var serviceBaseAddress = serviceBaseAddresses.Where(uri => uri.Scheme == Uri.UriSchemeHttp).Single();
             var singleWsdlUriBuilder = new UriBuilder(serviceBaseAddress);
-            singleWsdlUriBuilder.Host = serviceBaseAddress.Host;
-            singleWsdlUriBuilder.Port = serviceBaseAddress.Port;
             singleWsdlUriBuilder.Query = "singleWsdl";
             var singleWsdlPath = singleWsdlUriBuilder.ToString();
             string generatedWsdlTxt = string.Empty;

--- a/src/CoreWCF.Metadata/tests/WSHttpBindingTest.cs
+++ b/src/CoreWCF.Metadata/tests/WSHttpBindingTest.cs
@@ -63,7 +63,7 @@ namespace CoreWCF.Metadata.Tests
                 ["Basic256"] = CreateBindingUsingAglgorithmSuite(SecurityAlgorithmSuite.Basic256),
                 ["Basic256Sha256"] = CreateBindingUsingAglgorithmSuite(SecurityAlgorithmSuite.Basic256Sha256)
             };
-            await TestHelper.RunSingleWsdlTestAsync<SimpleEchoService, IEchoService>(bindingEndpointMap, new Uri[] { new Uri("http://localhost:8080/wsHttp"), new Uri("https://localhost:8443/wsHttp") }, _output);
+            await TestHelper.RunSingleWsdlTestAsync<SimpleEchoService, IEchoService>(bindingEndpointMap, new Uri[] { new Uri("http://localhost/wsHttp"), new Uri("https://localhost/wsHttp") }, _output);
         }
 
         private Binding CreateBindingUsingAglgorithmSuite(SecurityAlgorithmSuite suite)

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Channels/TcpListenOptions.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Channels/TcpListenOptions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Net;
 using System.Security.Policy;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 namespace CoreWCF.Channels
 {
@@ -21,6 +23,11 @@ namespace CoreWCF.Channels
         }
 
         public override IServiceProvider ApplicationServices => NetTcpServerOptions?.ApplicationServices;
+
+        // This is the Kestrel ListenOptions which will be used to create the listener, and can be used to get the IPEndpoint
+        internal ListenOptions ListenOptions { get; set; }
+
+        public IPEndPoint IPEndpoint => ListenOptions?.IPEndPoint;
 
         public NetTcpOptions NetTcpServerOptions { get; internal set; }
     }

--- a/src/CoreWCF.NetTcp/src/CoreWCF/Configuration/ServiceModelWebHostBuilderExtensions.cs
+++ b/src/CoreWCF.NetTcp/src/CoreWCF/Configuration/ServiceModelWebHostBuilderExtensions.cs
@@ -166,6 +166,9 @@ namespace CoreWCF.Configuration
                     builder.UseConnectionHandler<NetMessageFramingConnectionHandler>();
                     // Save the ListenOptions to be able to get final port number for adding BaseAddresses later
                     ListenOptions.Add(builder);
+                    // Save the Kestrel ListenOptions in the TcpListenOptions to enable getting the final listening IPEndpoint
+                    // This helps to get the port number being used if specified as 0, after the server has started.
+                    tcpListenOptions.ListenOptions = builder;
                 });
             }
             //foreach (IPEndPoint endpoint in _options.EndPoints)

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceMetadataBehavior.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceMetadataBehavior.cs
@@ -137,7 +137,7 @@ namespace CoreWCF.Description
             mex.HttpsGetEnabled = HttpsGetEnabled;
 
             mex.HttpGetUrl = host.GetVia(Uri.UriSchemeHttp, GetFirstEndpointUriForScheme(Uri.UriSchemeHttp, _httpGetUrl, description));
-            mex.HttpsGetUrl = host.GetVia(Uri.UriSchemeHttps, GetFirstEndpointUriForScheme(Uri.UriSchemeHttp, _httpsGetUrl, description));
+            mex.HttpsGetUrl = host.GetVia(Uri.UriSchemeHttps, GetFirstEndpointUriForScheme(Uri.UriSchemeHttps, _httpsGetUrl, description));
 
             foreach (ChannelDispatcherBase dispatcherBase in host.ChannelDispatchers)
             {

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceMetadataExtension.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/ServiceMetadataExtension.cs
@@ -14,9 +14,7 @@ using System.Xml.Schema;
 using CoreWCF.Channels;
 using CoreWCF.Configuration;
 using CoreWCF.Runtime;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Primitives;
 using WsdlNS = System.Web.Services.Description;
 
 namespace CoreWCF.Description
@@ -1165,12 +1163,14 @@ namespace CoreWCF.Description
 
                 protected override void Write(XmlWriter writer)
                 {
+                    writer.WriteStartDocument();
                     writer.WriteStartElement("discovery", "http://schemas.xmlsoap.org/disco/");
                     writer.WriteStartElement("contractRef", "http://schemas.xmlsoap.org/disco/scl/");
                     writer.WriteAttributeString("ref", _wsdlAddress);
                     writer.WriteAttributeString("docRef", _docAddress);
                     writer.WriteEndElement(); // </contractRef>
                     writer.WriteEndElement(); // </discovery>
+                    writer.WriteEndDocument();
                 }
             }
 
@@ -1512,14 +1512,9 @@ SR.SFxDocExt_NoMetadataSection5        ));
                     using (var memoryStream = new MemoryStream())
                     {
                         var utf8NoBomEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
-                        using (var textWriter = new StreamWriter(memoryStream, encoding: utf8NoBomEncoding, bufferSize: 1024, leaveOpen: true))
+                        using (var xmlTextWriter = XmlDictionaryWriter.CreateTextWriter(memoryStream, utf8NoBomEncoding, false))
                         {
-                            using (var xmlTextWriter = XmlWriter.Create(textWriter, new XmlWriterSettings { Indent = false, OmitXmlDeclaration = false }))
-                            {
-                                xmlTextWriter.WriteStartDocument();
-                                Write(xmlTextWriter);
-                                xmlTextWriter.WriteEndDocument();
-                            }
+                            Write(xmlTextWriter);
                         }
                         memoryStream.Position = 0;
                         await memoryStream.CopyToAsync(response.Body);


### PR DESCRIPTION
Fixed Metadata behavior using the wrong type of XmlWriter

Fixed unnecessary call to XmlWriter.WriteStartDocument for all metadata documents which was causing the xml declaration to be output for HTML

Added unit tests for Html help page, and made all tests use dynamic ports

Addresses issue found in #1521
Fixes #1516