### PR TITLE
Downgrade Microsoft.CodeAnalysis.CSharp to 4.8.0 to remove warning when using .NET 8 SDK

### DIFF
--- a/src/CoreWCF.BuildTools/src/CoreWCF.BuildTools.Roslyn4.0.csproj
+++ b/src/CoreWCF.BuildTools/src/CoreWCF.BuildTools.Roslyn4.0.csproj
@@ -10,7 +10,7 @@
     <Compile Remove="*.Roslyn3.11.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.12.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #1546 
If .NET 9 SDK isn't installed, or when using a global.json file and specifying .NET SDK 8, a build warning is emitted. The recommendation from the Roslyn team is to downgrade to 4.8.0
This fix will be back ported to 1.7