### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,24 +13,24 @@
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="IsExternalInit" Version="1.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore" Version="2.1.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.12" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="2.1.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
-    <PackageVErsion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.25" />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.40" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebSockets" Version="2.1.7" />
+    <PackageVersion Include="Microsoft.AspNetCore" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Hosting" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebSockets" Version="2.3.0" />
     <!-- Once we are building for .NET and not netstandard, WebUtilities should be updated to 8.x+ -->
-    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="2.3.0" />
     <!-- The minor version of Microsoft.Build can't be updated at 17.12.x doesn't support .net8.0, so we must stay on 17.11.x -->
     <PackageVersion Include="Microsoft.Build" Version="17.11.4" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
@@ -51,15 +51,15 @@
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols.WsFederation" Version="8.3.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.3.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens.Saml" Version="8.3.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.WsFederation" Version="8.6.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.6.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens.Saml" Version="8.6.1" />
     <PackageVersion Include="MSMQ.Messaging" Version="1.0.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="7.2.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="7.3.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
-    <PackageVersion Include="System.Buffers" Version="4.5.1" />
+    <PackageVersion Include="System.Buffers" Version="4.6.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
     <PackageVersion Include="System.DirectoryServices" Version="8.0.0" />
     <PackageVersion Include="System.DirectoryServices.Protocols" Version="8.0.0" />
@@ -67,47 +67,37 @@
     <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <PackageVersion Include="System.Reflection.DispatchProxy" Version="4.7.1" />
+    <PackageVersion Include="System.Reflection.DispatchProxy" Version="4.8.2" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.2" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="Xunit.StaFact" Version="1.2.69" />
-    <PackageVersion Include="System.Web.Services.Description" Version="8.1.1" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+    <PackageVersion Include="System.Web.Services.Description" Version="8.1.2" />
     <!-- Test dependencies -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageVersion Include="Xunit.StaFact" Version="1.2.69" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.1" />
+    <PackageVersion Include="System.ServiceModel.Primitives" Version="8.1.2" />
+    <PackageVersion Include="System.ServiceModel.NetTcp" Version="8.1.2" />
+    <PackageVersion Include="System.ServiceModel.Http" Version="8.1.2" />
+    <PackageVersion Include="System.ServiceModel.NetNamedPipe" Version="8.1.2" />
+    <PackageVersion Include="System.ServiceModel.UnixDomainSocket" Version="8.1.2" />
+    <PackageVersion Include="System.ServiceModel.Federation" Version="8.1.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
-    <PackageVersion Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.3" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(NeedsOlderServiceModel)' != 'true'">
-    <PackageVersion Include="System.ServiceModel.Primitives" Version="8.1.1" />
-    <PackageVersion Include="System.ServiceModel.NetTcp" Version="8.1.1" />
-    <PackageVersion Include="System.ServiceModel.Http" Version="8.1.1" />
-    <PackageVersion Include="System.ServiceModel.NetNamedPipe" Version="8.1.1" />
-    <PackageVersion Include="System.ServiceModel.UnixDomainSocket" Version="8.1.1" />
-    <PackageVersion Include="System.ServiceModel.Federation" Version="8.1.1" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(NeedsOlderServiceModel)' == 'true'">
-    <PackageVersion Include="System.ServiceModel.Primitives" Version="4.10.3" />
-    <PackageVersion Include="System.ServiceModel.NetTcp" Version="4.10.3" />
-    <PackageVersion Include="System.ServiceModel.Http" Version="4.10.3" />
-    <PackageVersion Include="System.ServiceModel.Duplex" Version="4.10.3" />
-    <PackageVersion Include="System.ServiceModel.Security" Version="4.10.3" />
-    <PackageVersion Include="System.ServiceModel.Federation" Version="4.10.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net472'">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'!='net472'">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.14" />
   </ItemGroup>
   <PropertyGroup Condition="('$(IsTestProject)' == 'true') AND ('$(TargetFramework)' != 'net472') AND ('$(TargetFramework)' != 'netstandard2.0')">
     <AspNetCoreVersion>$([System.Text.RegularExpressions.Regex]::Match($(TargetFramework), 'net(\d+\.\d+)').Groups[1].Value)</AspNetCoreVersion>
@@ -121,7 +111,5 @@
   </PropertyGroup>
   <ItemGroup Condition="('$(IsTestProject)' == 'true') AND ('$(TargetFramework)' != 'net472') AND ('$(TargetFramework)' != 'netstandard2.0')">
     <PackageVersion Include="Microsoft.AspNetCore.Connections.Abstractions" Version="$(AspNetCoreVersion)" />
-    <!--<PackageVersion Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(AspNetCoreVersion)"/>-->
-    <!--<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />-->
   </ItemGroup>
 </Project>

--- a/src/CoreWCF.BuildTools/tests/OperationInvokerGeneratorTests.cs
+++ b/src/CoreWCF.BuildTools/tests/OperationInvokerGeneratorTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using VerifyGenerator = CSharpGeneratorVerifier<CoreWCF.BuildTools.OperationInvokerGenerator>;

--- a/src/CoreWCF.BuildTools/tests/ReferenceAssembliesHelper.cs
+++ b/src/CoreWCF.BuildTools/tests/ReferenceAssembliesHelper.cs
@@ -27,11 +27,11 @@ internal static class ReferenceAssembliesHelper
             .Union(ParsePackageReferences(coreWcfWebHttpCsprojPath))
             .Union(new[]
             {
-                new PackageIdentity("System.ServiceModel.Primitives", "4.10.0"),
-                new PackageIdentity("Microsoft.AspNetCore.Mvc", "2.1.3"),
-                new PackageIdentity("Microsoft.AspNetCore.Authorization", "2.1.2")
+                new PackageIdentity("System.ServiceModel.Primitives", "8.1.2"),
+                new PackageIdentity("Microsoft.AspNetCore.Mvc", "2.3.0"),
+                new PackageIdentity("Microsoft.AspNetCore.Authorization", "2.3.0")
             }).ToImmutableArray();
-        return ReferenceAssemblies.Default.AddPackages(packages);
+        return ReferenceAssemblies.Net.Net80.AddPackages(packages);
     });
 
     private static IEnumerable<PackageIdentity> ParsePackageReferences(string csprojPath)

--- a/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.proj
+++ b/src/CoreWCF.Http/tests/CoreWCF.Http.Tests.proj
@@ -9,8 +9,6 @@
     <OutputType>Exe</OutputType>
     <GenerateProgramFile>false</GenerateProgramFile>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <!-- This is due to a problem with using System.ServiceModel.Federation 8.x on .NET Framework -->
-    <NeedsOlderServiceModel>true</NeedsOlderServiceModel>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="IsExternalInit">

--- a/src/CoreWCF.UnixDomainSocket/src/CoreWCF.UnixDomainSocket.csproj
+++ b/src/CoreWCF.UnixDomainSocket/src/CoreWCF.UnixDomainSocket.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" VersionOverride="8.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" VersionOverride="8.0.14" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 </Project>

--- a/src/CoreWCF.WebHttp/tests/CoreWCF.WebHttp.Tests.csproj
+++ b/src/CoreWCF.WebHttp/tests/CoreWCF.WebHttp.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="NewtonSoft.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net472'">


### PR DESCRIPTION
AspNetCore 2.1 has been republished as 2.3 to deal with the problem of tooling trying to update to 2.2.  
Includes other random updates.
WCF Client packages now fully compatible to be used on .NET Framework so removed the special handling for some tests needing to use the 4.3.x packages.  
Some dependency dropped a transitive dependency of Newtonsoft.Json so needed to add to WebHttp test project.
Bumped the ReferenceAssemblies for build tools tests from `.Default` to `.Net.Net80` as the default was incompatible with moving to AspNetCore 2.3.0 packages (default was netcoreapp3.0).