### PR TITLE
TimeoutException on claim lock operation

### DIFF
--- a/src/Common/src/DuplexChannels/CoreWCF/Channels/SynchronizedMessageSource.cs
+++ b/src/Common/src/DuplexChannels/CoreWCF/Channels/SynchronizedMessageSource.cs
@@ -31,10 +31,7 @@ namespace CoreWCF.Channels
             }
             catch (OperationCanceledException)
             {
-                // TODO: Fix the timeout value reported
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new TimeoutException(
-                                                SR.Format(SR.WaitForMessageTimedOut, TimeSpan.Zero),
-                                                TimeoutHelper.CreateEnterTimedOutException(TimeSpan.Zero)));
+                return null;
             }
             finally
             {


### PR DESCRIPTION

Added a 1s timeout.

That is needed for the EnsureInputClosedAsync. Otherwise, the SynchronizedMessageSource will acquire one lock, sit waiting for messages forever. Then a second call won't be able to acquire one lock (because the previous never reached the finally block). That will make it throw:
"System.TimeoutException: Cannot claim lock within the allotted timeout of 00:00:00. The time allotted to this operation may have been a portion of a longer timeout."

Also changed the WaitForMessageAsync catch block to just return null, instead of this TimeoutException.