### PR TITLE
Fix streamed BasicHttpBinding with TransportWithMessageCredential

### DIFF
--- a/src/CoreWCF.Http/tests/Helpers/ClientHelper.cs
+++ b/src/CoreWCF.Http/tests/Helpers/ClientHelper.cs
@@ -124,6 +124,16 @@ namespace Helpers
             return binding;
         }
 
+        public static BasicHttpBinding GetStreamedModeBinding(BasicHttpSecurityMode mode)
+        {
+            var binding = new BasicHttpBinding(mode)
+            {
+                TransferMode = TransferMode.Streamed
+            };
+            ApplyDebugTimeouts(binding);
+            return binding;
+        }
+
         public static BasicHttpBinding GetMtomStreamedModeBinding()
         {
             var binding = new BasicHttpBinding

--- a/src/CoreWCF.Primitives/src/CoreWCF/Security/SecurityAppliedMessage.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Security/SecurityAppliedMessage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 using System.Xml;
 using CoreWCF.Channels;
 using CoreWCF.IdentityModel.Tokens;
@@ -145,6 +146,12 @@ namespace CoreWCF.Security
                 default:
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateBadStateException(nameof(OnWriteBodyContents)));
             }
+        }
+
+        public override Task OnWriteMessageAsync(XmlDictionaryWriter writer)
+        {
+            OnWriteMessage(writer);
+            return Task.CompletedTask;
         }
 
         protected override void OnWriteMessage(XmlDictionaryWriter writer)


### PR DESCRIPTION
Fixes issue: #1582 

The issue appears to be specific to streamed and secured messages, as can be seen in `HttpChannelHelper.SendAsync`. When `TransferMode` is set to `Streamed`, the method ends up calling `MessageEncoder.WriteMessageAsync` instead of the synchronous `WriteMessage`. 
This leads us to the `SecurityAppliedMessage`, where only the synchronous `OnWriteMessage` method is implemented — this is where the security header is added to the SOAP message. However, the asynchronous counterpart, `OnWriteMessageAsync` - which is the one that ends up being invokned, still uses the base `Message.OnWriteMessageAsync` implementation which doesn't handle anything security-related.

This appears to be an oversight dating back to when asynchronous methods were introduced. The fix here is to just call the the synchronous implementation.