### PR TITLE
Prevent duplicate AuthorizeRoleAttribute instances from being added to inherited operations

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/AuthorizeRoleAttribute.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/AuthorizeRoleAttribute.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using CoreWCF.Description;
 using CoreWCF.Dispatcher;
 using CoreWCF.IdentityModel.Claims;
@@ -19,6 +19,8 @@ namespace CoreWCF
         {
             _allowedRoles = allowedRoles;
         }
+
+        public IReadOnlyList<string> AllowedRoles => _allowedRoles?.ToArray() ?? Array.Empty<string>();
 
         public void BuildClaim(OperationDescription operationDescription, DispatchOperation dispatchOperation)
         {

--- a/src/CoreWCF.Primitives/src/CoreWCF/AuthorizeRoleAttribute.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/AuthorizeRoleAttribute.cs
@@ -20,7 +20,7 @@ namespace CoreWCF
             _allowedRoles = allowedRoles;
         }
 
-        public IReadOnlyList<string> AllowedRoles => _allowedRoles?.ToArray() ?? Array.Empty<string>();
+        public IReadOnlyList<string> AllowedRoles => _allowedRoles ?? Array.Empty<string>();
 
         public void BuildClaim(OperationDescription operationDescription, DispatchOperation dispatchOperation)
         {

--- a/src/CoreWCF.Primitives/src/CoreWCF/Description/TypeLoader.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Description/TypeLoader.cs
@@ -237,7 +237,8 @@ namespace CoreWCF.Description
                                 if (existingRoleAttr != null)
                                 {
                                     // Compare allowed roles
-                                    bool rolesMatch = newRoleAttr.AllowedRoles.SequenceEqual(existingRoleAttr.AllowedRoles);
+                                    // Since the order of allowed roles does not matter, use an order-insensitive comparison
+                                    bool rolesMatch = new HashSet<string>(newRoleAttr.AllowedRoles).SetEquals(new HashSet<string>(existingRoleAttr.AllowedRoles));
                                     if (rolesMatch)
                                     {
                                         // Skip duplicate

--- a/src/CoreWCF.Primitives/tests/ContractDescriptionTests.cs
+++ b/src/CoreWCF.Primitives/tests/ContractDescriptionTests.cs
@@ -15,6 +15,12 @@ namespace CoreWCF.Primitives.Tests
             ContractDescription.GetContract<MessagePropertyService>(typeof(IMessagePropertyService));
         }
 
+        [Fact]
+        public void ValidateContractCanBeConstructed_WhenUsingInheritance()
+        {
+            ContractDescription.GetContract<WhenUsingInheritance.ServiceV2>(typeof(WhenUsingInheritance.IServiceV2));
+        }
+
         public class MessagePropertyService : IMessagePropertyService
         {
             public SimpleResponse Request(SimpleRequest request)
@@ -59,6 +65,33 @@ namespace CoreWCF.Primitives.Tests
             public string stringParam;
             [System.ServiceModel.MessageProperty(Name = PropertyName)]
             public string stringProperty;
+        }
+    }
+
+    internal class WhenUsingInheritance
+    {
+        [ServiceContract]
+        public interface IService
+        {
+            [OperationContract]
+            void Operation1();
+        }
+
+        public class Service : IService
+        {
+            [AuthorizeRole("RoleName")]
+            public void Operation1()
+            {
+            }
+        }
+
+        [ServiceContract]
+        public interface IServiceV2 : IService
+        {
+        }
+
+        public class ServiceV2 : Service, IServiceV2
+        {
         }
     }
 }


### PR DESCRIPTION
Fixes #1339