### PR TITLE
Ignore preview tfm when running in non-preview VS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,8 +34,14 @@
   </PropertyGroup>
 
   <!-- UT -->
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <IsVSPreviewVersion Condition=" '$(DevEnvDir)' != '' and $(DevEnvDir.Contains('Preview')) ">true</IsVSPreviewVersion>
+  </PropertyGroup>
+  
   <PropertyGroup>
-    <TestTargetFrameworks>net8.0;net9.0;net10.0</TestTargetFrameworks>
+    <PreviewDotNetTfm>net10.0</PreviewDotNetTfm>
+    <TestTargetFrameworks>net8.0;net9.0</TestTargetFrameworks>
+    <TestTargetFrameworks Condition="('$(BuildingInsideVisualStudio)' != 'true') OR ('$(IsVSPreviewVersion)' == 'true')">$(TestTargetFrameworks);$(PreviewDotNetTfm)</TestTargetFrameworks>
     <TestTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TestTargetFrameworks);net472</TestTargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
With net10.0 enabled, loading the solution in the non-preview version of Visual Studio results in a warning message about the preview dotnet version isn't supported. This change dynamically adds the preview tfm only at the command line or when using the preview version of Visual Studio.