### PR TITLE
Prevent unhandled exceptions during service shutdown which can kill a process

### DIFF
--- a/src/CoreWCF.NetFramingBase/src/CoreWCF/Channels/ServerFramingDuplexSessionChannel.cs
+++ b/src/CoreWCF.NetFramingBase/src/CoreWCF/Channels/ServerFramingDuplexSessionChannel.cs
@@ -64,7 +64,28 @@ namespace CoreWCF.Channels
             IApplicationLifetime appLifetime = _serviceProvider.GetRequiredService<IApplicationLifetime>();
             _applicationStoppingRegistration = appLifetime.ApplicationStopping.Register(() =>
             {
-                _ = CloseAsync();
+                // Use a discard and don't wait on the task so that multiple clients can close their channels
+                // simultaneously without waiting for each other. This prevents serializing of closing connected
+                // clients. As we're discarding the task results, we must make sure to handle any exceptions inside
+                // the task to avoid unhandled exceptions.
+                _ = Task.Run(async () =>
+                {
+                    // If the application is stopping, we should close the channel gracefully.
+                    // This will ensure that any pending messages are processed before closing.
+                    if (State == CommunicationState.Opened)
+                    {
+                        try
+                        {
+                            await CloseAsync();
+                        }
+                        catch (Exception)
+                        {
+                            // Catch any exceptions that occur during close to avoid unhandled exceptions
+                            // As we're shutting down, exceptions closing the channel have no consequences
+                            // TODO: When bringing back EventSource logging, log the exception here
+                        }
+                    }
+                });
             });
         }
 


### PR DESCRIPTION
See the later comments on #1574 for context.

Basically netnamedpipe client from NetFx still connected when closing the host causes the process to quit unexpectedly due to unhandled exception.

This fixes it 3 ways:
1. Tracks when we complete a PipeReader and tries to avoid calling ReadAsync if it's completed
2. If we do call ReadAsync on a completed PipeReader, handle the exception which is thrown and convert to a CoreWCF exception as if the connection was closed
3. At the top level application stopping event registered for the channel, don't allow any exceptions from calling CloseAsync to be unhandled