### PR TITLE
Return bad request instead of throwing null reference exception (#701)

### DIFF
--- a/src/CoreWCF.Http/src/CoreWCF/Channels/RequestDelegateHandler.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/RequestDelegateHandler.cs
@@ -125,6 +125,13 @@ namespace CoreWCF.Channels
 
             if (!context.WebSockets.IsWebSocketRequest)
             {
+                if (WebSocketOptions != null && _replyChannelDispatcher == null && _replyChannelDispatcherTask == null)
+                {
+                    context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                    context.Features.Get<IHttpResponseFeature>().ReasonPhrase = SR.WebSocketEndpointOnlySupportWebSocketError;
+                    return;
+                }
+
                 if (_replyChannelDispatcher == null)
                 {
                     _replyChannelDispatcher = await _replyChannelDispatcherTask;


### PR DESCRIPTION
Return bad request instead of throwing null reference exception.

Fixes: #701, #756 
