### PR TITLE
Pin confluentinc images to 7.9.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,8 @@ services:
       - kafka_network
 
   zookeeper:
-    image: confluentinc/cp-zookeeper
+    image: confluentinc/cp-zookeeper:7.9.1
+
     container_name: 'zookeeper'
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
@@ -58,7 +59,7 @@ services:
       - kafka_network      
   
   broker:
-    image: confluentinc/cp-kafka
+    image: confluentinc/cp-kafka:7.9.1
     container_name: 'broker'
     depends_on:
       generate-kafka-secrets:


### PR DESCRIPTION
Latest updates to https://hub.docker.com/r/confluentinc/cp-kafka broke our test setup (see https://github.com/CoreWCF/CoreWCF/pull/1602/checks?check_run_id=44101774358)
Pin the image version to 7.9.1 for the moment to avoid being blocked.