### PR TITLE
fix vulnerable package Microsoft.AspNetCore.Server.Kestrel.Core

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.WebSockets" Version="2.3.0" />
     <!-- Once we are building for .NET and not netstandard, WebUtilities should be updated to 8.x+ -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
+    <!--version <= 2.3.0 is vulnerable: https://github.com/advisories/GHSA-5rrx-jjjq-q2r5-->
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.WebSockets" Version="2.3.0" />


### PR DESCRIPTION
Microsoft.AspNetCore.Server.Kestrel.Core is vulnerable on versions <= 2.3.0: https://github.com/advisories/GHSA-5rrx-jjjq-q2r5