### PR TITLE
Update the expected *.wsdl's for net10.0+ to include dateOnly/timeOnly

### DIFF
--- a/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
+++ b/src/CoreWCF.Metadata/tests/CoreWCF.Metadata.Tests.csproj
@@ -36,6 +36,9 @@
     <None Update="Wsdls\*.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Wsdls\net10.0\*.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreWCF.Metadata/tests/Helpers/WsdlHelper.cs
+++ b/src/CoreWCF.Metadata/tests/Helpers/WsdlHelper.cs
@@ -38,12 +38,20 @@ namespace CoreWCF.Metadata.Tests.Helpers
             }
 
             Assert.StartsWith(XmlDeclaration, generatedWsdlTxt);
+#if NET10_0_OR_GREATER
+            var xmlFileName = Path.Combine("Wsdls", "net10.0", Path.GetFileNameWithoutExtension(sourceFilePath) + "." + callerMethodName + ".xml");
+#else
             var xmlFileName = Path.Combine("Wsdls", Path.GetFileNameWithoutExtension(sourceFilePath) + "." + callerMethodName + ".xml");
+#endif
             if (!File.Exists(xmlFileName))
             {
                 // If sourceFilename.methodname.xml doesn't exist, then look for sourceFilename.xml. This enables use of a single expected wsdl file
                 // for multiple tests in a single test class.
+#if NET10_0_OR_GREATER
+                var classXmlFileName = Path.Combine("Wsdls", "net10.0", Path.GetFileNameWithoutExtension(sourceFilePath) + ".xml");
+#else
                 var classXmlFileName = Path.Combine("Wsdls", Path.GetFileNameWithoutExtension(sourceFilePath) + ".xml");
+#endif
                 if (!File.Exists(classXmlFileName))
                 {
                     Assert.Fail($"Unable to find expected wsdl file at {xmlFileName} or {classXmlFileName}");
@@ -84,12 +92,20 @@ namespace CoreWCF.Metadata.Tests.Helpers
                 generatedWsdlTxt = await response.Content.ReadAsStringAsync();
             }
 
+#if NET10_0_OR_GREATER
+            var xmlFileName = Path.Combine("Wsdls", "net10.0", Path.GetFileNameWithoutExtension(sourceFilePath) + "." + callerMethodName + ".xml");
+#else
             var xmlFileName = Path.Combine("Wsdls", Path.GetFileNameWithoutExtension(sourceFilePath) + "." + callerMethodName + ".xml");
+#endif
             if (!File.Exists(xmlFileName))
             {
                 // If sourceFilename.methodname.xml doesn't exist, then look for sourceFilename.xml. This enables use of a single expected wsdl file
                 // for multiple tests in a single test class.
+#if NET10_0_OR_GREATER
+                var classXmlFileName = Path.Combine("Wsdls", "net10.0", Path.GetFileNameWithoutExtension(sourceFilePath) + ".xml");
+#else
                 var classXmlFileName = Path.Combine("Wsdls", Path.GetFileNameWithoutExtension(sourceFilePath) + ".xml");
+#endif
                 if (!File.Exists(classXmlFileName))
                 {
                     Assert.Fail($"Unable to find expected wsdl file at {xmlFileName} or {classXmlFileName}");

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/BasicHttpSimpleServiceTest.BasicHttpRequestReplyEchoString.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/BasicHttpSimpleServiceTest.BasicHttpRequestReplyEchoString.xml
@@ -1,0 +1,362 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SimpleEchoService"
+                  targetNamespace="http://tempuri.org/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy"
+                  xmlns:wsa10="http://www.w3.org/2005/08/addressing"
+                  xmlns:tns="http://tempuri.org/"
+                  xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract"
+                  xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+                  xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata"
+                  xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+                  xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"
+                  xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+                  xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+                  xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified"
+		           targetNamespace="http://tempuri.org/"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoStringResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo"
+						            type="q1:StreamBody"
+						            xmlns:q1="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamResult"
+						            type="q2:StreamBody"
+						            xmlns:q2="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoStringAsyncResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo"
+						            type="q3:StreamBody"
+						            xmlns:q3="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamAsyncResult"
+						            type="q4:StreamBody"
+						            xmlns:q4="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoToFailResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified"
+		           elementFormDefault="qualified"
+		           targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		           xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType"
+			            nillable="true"
+			            type="xs:anyType"/>
+      <xs:element name="anyURI"
+			            nillable="true"
+			            type="xs:anyURI"/>
+      <xs:element name="base64Binary"
+			            nillable="true"
+			            type="xs:base64Binary"/>
+      <xs:element name="boolean"
+			            nillable="true"
+			            type="xs:boolean"/>
+      <xs:element name="byte"
+			            nillable="true"
+			            type="xs:byte"/>
+      <xs:element name="dateTime"
+			            nillable="true"
+			            type="xs:dateTime"/>
+      <xs:element name="decimal"
+			            nillable="true"
+			            type="xs:decimal"/>
+      <xs:element name="double"
+			            nillable="true"
+			            type="xs:double"/>
+      <xs:element name="float"
+			            nillable="true"
+			            type="xs:float"/>
+      <xs:element name="int"
+			            nillable="true"
+			            type="xs:int"/>
+      <xs:element name="long"
+			            nillable="true"
+			            type="xs:long"/>
+      <xs:element name="QName"
+			            nillable="true"
+			            type="xs:QName"/>
+      <xs:element name="short"
+			            nillable="true"
+			            type="xs:short"/>
+      <xs:element name="string"
+			            nillable="true"
+			            type="xs:string"/>
+      <xs:element name="unsignedByte"
+			            nillable="true"
+			            type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt"
+			            nillable="true"
+			            type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong"
+			            nillable="true"
+			            type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort"
+			            nillable="true"
+			            type="xs:unsignedShort"/>
+      <xs:element name="char"
+			            nillable="true"
+			            type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration"
+			            nillable="true"
+			            type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid"
+			            nillable="true"
+			            type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType"
+			              type="xs:QName"/>
+      <xs:attribute name="Id"
+			              type="xs:ID"/>
+      <xs:attribute name="Ref"
+			              type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified"
+		           targetNamespace="http://schemas.microsoft.com/Message"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		           xmlns:tns="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString"
+			            message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse"
+			             message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream"
+			            message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse"
+			             message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync"
+			            message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse"
+			             message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync"
+			            message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse"
+			             message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail"
+			            message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse"
+			             message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_IEchoService"
+	              type="tns:IEchoService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoString"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStream"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoToFail"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="BasicHttpBinding_IEchoService"
+		           binding="tns:BasicHttpBinding_IEchoService">
+      <soap:address location="http://localhost/TestSite/BasicHttpBinding.svc/basicHttp"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/DataTypesTest.CollectionOfKeyValuePairDataContract.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/DataTypesTest.CollectionOfKeyValuePairDataContract.xml
@@ -1,0 +1,175 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="CollectionOfKeyValuePairDataService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+      <xs:element name="EchoKeyValueWithArray">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q1:KeyValueContainingArray" xmlns:q1="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoKeyValueWithArrayResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoKeyValueWithArrayResult" nillable="true" type="q2:KeyValueContainingArray" xmlns:q2="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoKeyValueWithList">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q3:KeyValueContainingList" xmlns:q3="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoKeyValueWithListResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoKeyValueWithListResult" nillable="true" type="q4:KeyValueContainingList" xmlns:q4="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.datacontract.org/2004/07/ServiceContract" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.datacontract.org/2004/07/ServiceContract">
+      <xs:import namespace="http://schemas.datacontract.org/2004/07/System.Collections.Generic"/>
+      <xs:complexType name="KeyValueContainingArray">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="KeyValueArray" nillable="true" type="q1:ArrayOfKeyValuePairOfstringint" xmlns:q1="http://schemas.datacontract.org/2004/07/System.Collections.Generic"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="KeyValueContainingArray" nillable="true" type="tns:KeyValueContainingArray"/>
+      <xs:complexType name="KeyValueContainingList">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="KeyValueList" nillable="true" type="q2:ArrayOfKeyValuePairOfstringint" xmlns:q2="http://schemas.datacontract.org/2004/07/System.Collections.Generic"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="KeyValueContainingList" nillable="true" type="tns:KeyValueContainingList"/>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.datacontract.org/2004/07/System.Collections.Generic" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.datacontract.org/2004/07/System.Collections.Generic">
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/"/>
+      <xs:complexType name="ArrayOfKeyValuePairOfstringint">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="KeyValuePairOfstringint" type="tns:KeyValuePairOfstringint"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfKeyValuePairOfstringint" nillable="true" type="tns:ArrayOfKeyValuePairOfstringint"/>
+      <xs:complexType name="KeyValuePairOfstringint">
+        <xs:annotation>
+          <xs:appinfo>
+            <GenericType Name="KeyValuePairOf{0}{1}{#}" Namespace="http://schemas.datacontract.org/2004/07/System.Collections.Generic" xmlns="http://schemas.microsoft.com/2003/10/Serialization/">
+              <GenericParameter Name="string" Namespace="http://www.w3.org/2001/XMLSchema"/>
+              <GenericParameter Name="int" Namespace="http://www.w3.org/2001/XMLSchema"/>
+            </GenericType>
+            <IsValueType xmlns="http://schemas.microsoft.com/2003/10/Serialization/">true</IsValueType>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:element name="key" nillable="true" type="xs:string"/>
+          <xs:element name="value" type="xs:int"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="KeyValuePairOfstringint" nillable="true" type="tns:KeyValuePairOfstringint"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="CollectionOfKeyValuePairDataService_EchoKeyValueWithArray_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoKeyValueWithArray"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionOfKeyValuePairDataService_EchoKeyValueWithArray_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoKeyValueWithArrayResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionOfKeyValuePairDataService_EchoKeyValueWithList_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoKeyValueWithList"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionOfKeyValuePairDataService_EchoKeyValueWithList_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoKeyValueWithListResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="CollectionOfKeyValuePairDataService">
+    <wsdl:operation name="EchoKeyValueWithArray">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionOfKeyValuePairDataService/EchoKeyValueWithArray" message="tns:CollectionOfKeyValuePairDataService_EchoKeyValueWithArray_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionOfKeyValuePairDataService/EchoKeyValueWithArrayResponse" message="tns:CollectionOfKeyValuePairDataService_EchoKeyValueWithArray_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoKeyValueWithList">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionOfKeyValuePairDataService/EchoKeyValueWithList" message="tns:CollectionOfKeyValuePairDataService_EchoKeyValueWithList_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionOfKeyValuePairDataService/EchoKeyValueWithListResponse" message="tns:CollectionOfKeyValuePairDataService_EchoKeyValueWithList_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_CollectionOfKeyValuePairDataService" type="tns:CollectionOfKeyValuePairDataService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoKeyValueWithArray">
+      <soap:operation soapAction="http://tempuri.org/CollectionOfKeyValuePairDataService/EchoKeyValueWithArray" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoKeyValueWithList">
+      <soap:operation soapAction="http://tempuri.org/CollectionOfKeyValuePairDataService/EchoKeyValueWithList" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="CollectionOfKeyValuePairDataService">
+    <wsdl:port name="BasicHttpBinding_CollectionOfKeyValuePairDataService" binding="tns:BasicHttpBinding_CollectionOfKeyValuePairDataService">
+      <soap:address location="http://localhost/TestService/api"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/DataTypesTest.CollectionsDataContract.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/DataTypesTest.CollectionsDataContract.xml
@@ -1,0 +1,260 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="CollectionsService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+      <xs:element name="EchoStringList">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q1:ArrayOfstring" xmlns:q1="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringListResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringListResult" nillable="true" type="q2:ArrayOfstring" xmlns:q2="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringEnumerable">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q3:ArrayOfstring" xmlns:q3="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringEnumerableResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringEnumerableResult" nillable="true" type="q4:ArrayOfstring" xmlns:q4="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringArray">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q5:ArrayOfstring" xmlns:q5="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringArrayResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringArrayResult" nillable="true" type="q6:ArrayOfstring" xmlns:q6="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDictionary">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q7:ArrayOfKeyValueOfstringstring" xmlns:q7="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDictionaryResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoDictionaryResult" nillable="true" type="q8:ArrayOfKeyValueOfstringstring" xmlns:q8="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoIDictionary">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q9:ArrayOfKeyValueOfstringstring" xmlns:q9="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoIDictionaryResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoIDictionaryResult" nillable="true" type="q10:ArrayOfKeyValueOfstringstring" xmlns:q10="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+      <xs:complexType name="ArrayOfstring">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="string" nillable="true" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfstring" nillable="true" type="tns:ArrayOfstring"/>
+      <xs:complexType name="ArrayOfKeyValueOfstringstring">
+        <xs:annotation>
+          <xs:appinfo>
+            <IsDictionary xmlns="http://schemas.microsoft.com/2003/10/Serialization/">true</IsDictionary>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="KeyValueOfstringstring">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="Key" nillable="true" type="xs:string"/>
+                <xs:element name="Value" nillable="true" type="xs:string"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfKeyValueOfstringstring" nillable="true" type="tns:ArrayOfKeyValueOfstringstring"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="CollectionsService_EchoStringList_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringList"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringList_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringListResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringEnumerable_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringEnumerable"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringEnumerable_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringEnumerableResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringArray_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringArray"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringArray_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringArrayResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoDictionary_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDictionary"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoDictionary_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDictionaryResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoIDictionary_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoIDictionary"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoIDictionary_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoIDictionaryResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="CollectionsService">
+    <wsdl:operation name="EchoStringList">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringList" message="tns:CollectionsService_EchoStringList_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringListResponse" message="tns:CollectionsService_EchoStringList_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringEnumerable">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringEnumerable" message="tns:CollectionsService_EchoStringEnumerable_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringEnumerableResponse" message="tns:CollectionsService_EchoStringEnumerable_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringArray">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringArray" message="tns:CollectionsService_EchoStringArray_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringArrayResponse" message="tns:CollectionsService_EchoStringArray_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDictionary">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoDictionary" message="tns:CollectionsService_EchoDictionary_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoDictionaryResponse" message="tns:CollectionsService_EchoDictionary_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoIDictionary">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoIDictionary" message="tns:CollectionsService_EchoIDictionary_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoIDictionaryResponse" message="tns:CollectionsService_EchoIDictionary_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_CollectionsService" type="tns:CollectionsService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoStringList">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringList" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringEnumerable">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringEnumerable" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringArray">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringArray" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDictionary">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoDictionary" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoIDictionary">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoIDictionary" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="CollectionsService">
+    <wsdl:port name="BasicHttpBinding_CollectionsService" binding="tns:BasicHttpBinding_CollectionsService">
+      <soap:address location="http://localhost/TestService/api"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/DataTypesTest.ComplexTypesWithCollectionsDataContract.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/DataTypesTest.ComplexTypesWithCollectionsDataContract.xml
@@ -1,0 +1,158 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="ComplexTypesWithCollectionsService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+      <xs:element name="EchoComplexTypeWithList">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q1:DataContainingList" xmlns:q1="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoComplexTypeWithListResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoComplexTypeWithListResult" nillable="true" type="q2:DataContainingList" xmlns:q2="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoComplexTypeWithArray">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q3:DataContainingArray" xmlns:q3="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoComplexTypeWithArrayResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoComplexTypeWithArrayResult" nillable="true" type="q4:DataContainingArray" xmlns:q4="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.datacontract.org/2004/07/ServiceContract" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.datacontract.org/2004/07/ServiceContract">
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+      <xs:complexType name="DataContainingList">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="StringDataList" nillable="true" type="q1:ArrayOfstring" xmlns:q1="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="DataContainingList" nillable="true" type="tns:DataContainingList"/>
+      <xs:complexType name="DataContainingArray">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="StringDataArray" nillable="true" type="q2:ArrayOfstring" xmlns:q2="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="DataContainingArray" nillable="true" type="tns:DataContainingArray"/>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+      <xs:complexType name="ArrayOfstring">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="string" nillable="true" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfstring" nillable="true" type="tns:ArrayOfstring"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="ComplexTypesWithCollectionsService_EchoComplexTypeWithList_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoComplexTypeWithList"/>
+  </wsdl:message>
+  <wsdl:message name="ComplexTypesWithCollectionsService_EchoComplexTypeWithList_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoComplexTypeWithListResponse"/>
+  </wsdl:message>
+  <wsdl:message name="ComplexTypesWithCollectionsService_EchoComplexTypeWithArray_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoComplexTypeWithArray"/>
+  </wsdl:message>
+  <wsdl:message name="ComplexTypesWithCollectionsService_EchoComplexTypeWithArray_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoComplexTypeWithArrayResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="ComplexTypesWithCollectionsService">
+    <wsdl:operation name="EchoComplexTypeWithList">
+      <wsdl:input wsaw:Action="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithList" message="tns:ComplexTypesWithCollectionsService_EchoComplexTypeWithList_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithListResponse" message="tns:ComplexTypesWithCollectionsService_EchoComplexTypeWithList_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoComplexTypeWithArray">
+      <wsdl:input wsaw:Action="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithArray" message="tns:ComplexTypesWithCollectionsService_EchoComplexTypeWithArray_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithArrayResponse" message="tns:ComplexTypesWithCollectionsService_EchoComplexTypeWithArray_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_ComplexTypesWithCollectionsService" type="tns:ComplexTypesWithCollectionsService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoComplexTypeWithList">
+      <soap:operation soapAction="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithList" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoComplexTypeWithArray">
+      <soap:operation soapAction="http://tempuri.org/ComplexTypesWithCollectionsService/EchoComplexTypeWithArray" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="ComplexTypesWithCollectionsService">
+    <wsdl:port name="BasicHttpBinding_ComplexTypesWithCollectionsService" binding="tns:BasicHttpBinding_ComplexTypesWithCollectionsService">
+      <soap:address location="http://localhost/TestService/api"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/DataTypesTest.PrimitivesDataContract.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/DataTypesTest.PrimitivesDataContract.xml
@@ -1,0 +1,672 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="PrimitivesService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/"/>
+      <xs:element name="EchoUri">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" nillable="true" type="xs:anyURI"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUriResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoUriResult" nillable="true" type="xs:anyURI"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoSbyte">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" nillable="true" type="q1:ArrayOfbyte" xmlns:q1="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoSbyteResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoSbyteResult" nillable="true" type="q2:ArrayOfbyte" xmlns:q2="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoBool">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:boolean"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoBoolResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoBoolResult" type="xs:boolean"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDateTime">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:dateTime"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDateTimeResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoDateTimeResult" type="xs:dateTime"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDecimal">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:decimal"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDecimalResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoDecimalResult" type="xs:decimal"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDouble">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:double"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDoubleResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoDoubleResult" type="xs:double"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoFloat">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:float"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoFloatResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoFloatResult" type="xs:float"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoInt">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:int"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoIntResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoIntResult" type="xs:int"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoLong">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:long"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoLongResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoLongResult" type="xs:long"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoShort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:short"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoShortResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoShortResult" type="xs:short"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoByte">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:unsignedByte"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoByteResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoByteResult" type="xs:unsignedByte"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUint">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:unsignedInt"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUintResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoUintResult" type="xs:unsignedInt"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUlong">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:unsignedLong"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUlongResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoUlongResult" type="xs:unsignedLong"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUshort">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="xs:unsignedShort"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoUshortResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoUshortResult" type="xs:unsignedShort"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoChar">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="q3:char" xmlns:q3="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoCharResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoCharResult" type="q4:char" xmlns:q4="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoTimeSpan">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="q5:duration" xmlns:q5="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoTimeSpanResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoTimeSpanResult" type="q6:duration" xmlns:q6="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoGuid">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="data" type="q7:guid" xmlns:q7="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoGuidResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoGuidResult" type="q8:guid" xmlns:q8="http://schemas.microsoft.com/2003/10/Serialization/"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+      <xs:complexType name="ArrayOfbyte">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="byte" type="xs:byte"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfbyte" nillable="true" type="tns:ArrayOfbyte"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="PrimitivesService_EchoUri_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUri"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUri_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUriResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoSbyte_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoSbyte"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoSbyte_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoSbyteResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoBool_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoBool"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoBool_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoBoolResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDateTime_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDateTime"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDateTime_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDateTimeResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDecimal_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDecimal"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDecimal_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDecimalResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDouble_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDouble"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoDouble_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDoubleResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoFloat_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoFloat"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoFloat_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoFloatResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoInt_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoInt"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoInt_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoIntResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoLong_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoLong"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoLong_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoLongResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoShort_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoShort"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoShort_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoShortResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoString_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoString_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoByte_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoByte"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoByte_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoByteResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUint_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUint"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUint_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUintResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUlong_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUlong"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUlong_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUlongResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUshort_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUshort"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoUshort_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoUshortResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoChar_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoChar"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoChar_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoCharResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoTimeSpan_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoTimeSpan"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoTimeSpan_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoTimeSpanResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoGuid_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoGuid"/>
+  </wsdl:message>
+  <wsdl:message name="PrimitivesService_EchoGuid_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoGuidResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="PrimitivesService">
+    <wsdl:operation name="EchoUri">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoUri" message="tns:PrimitivesService_EchoUri_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoUriResponse" message="tns:PrimitivesService_EchoUri_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoSbyte">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoSbyte" message="tns:PrimitivesService_EchoSbyte_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoSbyteResponse" message="tns:PrimitivesService_EchoSbyte_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoBool">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoBool" message="tns:PrimitivesService_EchoBool_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoBoolResponse" message="tns:PrimitivesService_EchoBool_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDateTime">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoDateTime" message="tns:PrimitivesService_EchoDateTime_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoDateTimeResponse" message="tns:PrimitivesService_EchoDateTime_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDecimal">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoDecimal" message="tns:PrimitivesService_EchoDecimal_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoDecimalResponse" message="tns:PrimitivesService_EchoDecimal_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDouble">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoDouble" message="tns:PrimitivesService_EchoDouble_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoDoubleResponse" message="tns:PrimitivesService_EchoDouble_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoFloat">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoFloat" message="tns:PrimitivesService_EchoFloat_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoFloatResponse" message="tns:PrimitivesService_EchoFloat_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoInt">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoInt" message="tns:PrimitivesService_EchoInt_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoIntResponse" message="tns:PrimitivesService_EchoInt_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoLong">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoLong" message="tns:PrimitivesService_EchoLong_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoLongResponse" message="tns:PrimitivesService_EchoLong_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoShort">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoShort" message="tns:PrimitivesService_EchoShort_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoShortResponse" message="tns:PrimitivesService_EchoShort_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoString" message="tns:PrimitivesService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoStringResponse" message="tns:PrimitivesService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoByte">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoByte" message="tns:PrimitivesService_EchoByte_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoByteResponse" message="tns:PrimitivesService_EchoByte_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUint">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoUint" message="tns:PrimitivesService_EchoUint_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoUintResponse" message="tns:PrimitivesService_EchoUint_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUlong">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoUlong" message="tns:PrimitivesService_EchoUlong_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoUlongResponse" message="tns:PrimitivesService_EchoUlong_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUshort">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoUshort" message="tns:PrimitivesService_EchoUshort_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoUshortResponse" message="tns:PrimitivesService_EchoUshort_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoChar">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoChar" message="tns:PrimitivesService_EchoChar_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoCharResponse" message="tns:PrimitivesService_EchoChar_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoTimeSpan">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoTimeSpan" message="tns:PrimitivesService_EchoTimeSpan_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoTimeSpanResponse" message="tns:PrimitivesService_EchoTimeSpan_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoGuid">
+      <wsdl:input wsaw:Action="http://tempuri.org/PrimitivesService/EchoGuid" message="tns:PrimitivesService_EchoGuid_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/PrimitivesService/EchoGuidResponse" message="tns:PrimitivesService_EchoGuid_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_PrimitivesService" type="tns:PrimitivesService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoUri">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoUri" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoSbyte">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoSbyte" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoBool">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoBool" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDateTime">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoDateTime" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDecimal">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoDecimal" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDouble">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoDouble" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoFloat">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoFloat" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoInt">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoInt" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoLong">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoLong" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoShort">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoShort" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoString">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoByte">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoByte" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUint">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoUint" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUlong">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoUlong" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoUshort">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoUshort" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoChar">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoChar" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoTimeSpan">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoTimeSpan" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoGuid">
+      <soap:operation soapAction="http://tempuri.org/PrimitivesService/EchoGuid" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PrimitivesService">
+    <wsdl:port name="BasicHttpBinding_PrimitivesService" binding="tns:BasicHttpBinding_PrimitivesService">
+      <soap:address location="http://localhost/TestService/api"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/EnumTest.BasicHttpRequestEnumType.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/EnumTest.BasicHttpRequestEnumType.xml
@@ -1,0 +1,173 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="EnumService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+      <xs:element name="AcceptWrapped">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="accept" nillable="true" type="q1:TestWrappedEnum" xmlns:q1="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="AcceptWrappedResponse">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="RequestWrapped">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="RequestWrappedResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="RequestWrappedResult" nillable="true" type="q2:TestWrappedEnum" xmlns:q2="http://schemas.datacontract.org/2004/07/ServiceContract"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.datacontract.org/2004/07/ServiceContract" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.datacontract.org/2004/07/ServiceContract">
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/"/>
+      <xs:complexType name="TestWrappedEnum">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="Enum" type="tns:TestEnum"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="TestWrappedEnum" nillable="true" type="tns:TestWrappedEnum"/>
+      <xs:simpleType name="TestEnum">
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="One">
+            <xs:annotation>
+              <xs:appinfo>
+                <EnumerationValue xmlns="http://schemas.microsoft.com/2003/10/Serialization/">1</EnumerationValue>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:enumeration>
+          <xs:enumeration value="Two">
+            <xs:annotation>
+              <xs:appinfo>
+                <EnumerationValue xmlns="http://schemas.microsoft.com/2003/10/Serialization/">2</EnumerationValue>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:enumeration>
+          <xs:enumeration value="Three">
+            <xs:annotation>
+              <xs:appinfo>
+                <EnumerationValue xmlns="http://schemas.microsoft.com/2003/10/Serialization/">3</EnumerationValue>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:enumeration>
+          <xs:enumeration value="Five">
+            <xs:annotation>
+              <xs:appinfo>
+                <EnumerationValue xmlns="http://schemas.microsoft.com/2003/10/Serialization/">5</EnumerationValue>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:enumeration>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="TestEnum" nillable="true" type="tns:TestEnum"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="EnumService_AcceptWrapped_InputMessage">
+    <wsdl:part name="parameters" element="tns:AcceptWrapped"/>
+  </wsdl:message>
+  <wsdl:message name="EnumService_AcceptWrapped_OutputMessage">
+    <wsdl:part name="parameters" element="tns:AcceptWrappedResponse"/>
+  </wsdl:message>
+  <wsdl:message name="EnumService_RequestWrapped_InputMessage">
+    <wsdl:part name="parameters" element="tns:RequestWrapped"/>
+  </wsdl:message>
+  <wsdl:message name="EnumService_RequestWrapped_OutputMessage">
+    <wsdl:part name="parameters" element="tns:RequestWrappedResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="EnumService">
+    <wsdl:operation name="AcceptWrapped">
+      <wsdl:input wsaw:Action="http://tempuri.org/EnumService/AcceptWrapped" message="tns:EnumService_AcceptWrapped_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/EnumService/AcceptWrappedResponse" message="tns:EnumService_AcceptWrapped_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="RequestWrapped">
+      <wsdl:input wsaw:Action="http://tempuri.org/EnumService/RequestWrapped" message="tns:EnumService_RequestWrapped_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/EnumService/RequestWrappedResponse" message="tns:EnumService_RequestWrapped_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_EnumService" type="tns:EnumService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="AcceptWrapped">
+      <soap:operation soapAction="http://tempuri.org/EnumService/AcceptWrapped" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="RequestWrapped">
+      <soap:operation soapAction="http://tempuri.org/EnumService/RequestWrapped" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="EnumService">
+    <wsdl:port name="BasicHttpBinding_EnumService" binding="tns:BasicHttpBinding_EnumService">
+      <soap:address location="http://localhost/TestService/api"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/MetadataEndpointAddressServiceBehaviorTests.XForwardedHeaders.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/MetadataEndpointAddressServiceBehaviorTests.XForwardedHeaders.xml
@@ -1,0 +1,362 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SimpleEchoService"
+                  targetNamespace="http://tempuri.org/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy"
+                  xmlns:wsa10="http://www.w3.org/2005/08/addressing"
+                  xmlns:tns="http://tempuri.org/"
+                  xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract"
+                  xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+                  xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata"
+                  xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+                  xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"
+                  xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+                  xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+                  xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified"
+		           targetNamespace="http://tempuri.org/"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoStringResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo"
+						            type="q1:StreamBody"
+						            xmlns:q1="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamResult"
+						            type="q2:StreamBody"
+						            xmlns:q2="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoStringAsyncResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo"
+						            type="q3:StreamBody"
+						            xmlns:q3="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamAsyncResult"
+						            type="q4:StreamBody"
+						            xmlns:q4="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoToFailResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified"
+		           elementFormDefault="qualified"
+		           targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		           xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType"
+			            nillable="true"
+			            type="xs:anyType"/>
+      <xs:element name="anyURI"
+			            nillable="true"
+			            type="xs:anyURI"/>
+      <xs:element name="base64Binary"
+			            nillable="true"
+			            type="xs:base64Binary"/>
+      <xs:element name="boolean"
+			            nillable="true"
+			            type="xs:boolean"/>
+      <xs:element name="byte"
+			            nillable="true"
+			            type="xs:byte"/>
+      <xs:element name="dateTime"
+			            nillable="true"
+			            type="xs:dateTime"/>
+      <xs:element name="decimal"
+			            nillable="true"
+			            type="xs:decimal"/>
+      <xs:element name="double"
+			            nillable="true"
+			            type="xs:double"/>
+      <xs:element name="float"
+			            nillable="true"
+			            type="xs:float"/>
+      <xs:element name="int"
+			            nillable="true"
+			            type="xs:int"/>
+      <xs:element name="long"
+			            nillable="true"
+			            type="xs:long"/>
+      <xs:element name="QName"
+			            nillable="true"
+			            type="xs:QName"/>
+      <xs:element name="short"
+			            nillable="true"
+			            type="xs:short"/>
+      <xs:element name="string"
+			            nillable="true"
+			            type="xs:string"/>
+      <xs:element name="unsignedByte"
+			            nillable="true"
+			            type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt"
+			            nillable="true"
+			            type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong"
+			            nillable="true"
+			            type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort"
+			            nillable="true"
+			            type="xs:unsignedShort"/>
+      <xs:element name="char"
+			            nillable="true"
+			            type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration"
+			            nillable="true"
+			            type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid"
+			            nillable="true"
+			            type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType"
+			              type="xs:QName"/>
+      <xs:attribute name="Id"
+			              type="xs:ID"/>
+      <xs:attribute name="Ref"
+			              type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified"
+		           targetNamespace="http://schemas.microsoft.com/Message"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		           xmlns:tns="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString"
+			            message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse"
+			             message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream"
+			            message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse"
+			             message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync"
+			            message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse"
+			             message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync"
+			            message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse"
+			             message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail"
+			            message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse"
+			             message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_IEchoService"
+	              type="tns:IEchoService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoString"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStream"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoToFail"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="BasicHttpBinding_IEchoService"
+		           binding="tns:BasicHttpBinding_IEchoService">
+      <soap:address location="http://localhost/TestSite/BasicHttpBinding.svc/basicHttp"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/MultipleServicesTest.BasicHttpRequestReplyEchoString_1.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/MultipleServicesTest.BasicHttpRequestReplyEchoString_1.xml
@@ -1,0 +1,239 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SimpleEchoService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q1:StreamBody" xmlns:q1="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamResult" type="q2:StreamBody" xmlns:q2="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringAsyncResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q3:StreamBody" xmlns:q3="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamAsyncResult" type="q4:StreamBody" xmlns:q4="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoToFailResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/Message" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString" message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse" message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream" message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse" message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync" message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse" message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync" message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse" message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail" message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse" message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_IEchoService" type="tns:IEchoService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="BasicHttpBinding_IEchoService" binding="tns:BasicHttpBinding_IEchoService">
+      <soap:address location="http://localhost/TestService/1/http"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/MultipleServicesTest.BasicHttpRequestReplyEchoString_2.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/MultipleServicesTest.BasicHttpRequestReplyEchoString_2.xml
@@ -1,0 +1,260 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="CollectionsService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+      <xs:element name="EchoStringList">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q1:ArrayOfstring" xmlns:q1="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringListResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringListResult" nillable="true" type="q2:ArrayOfstring" xmlns:q2="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringEnumerable">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q3:ArrayOfstring" xmlns:q3="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringEnumerableResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringEnumerableResult" nillable="true" type="q4:ArrayOfstring" xmlns:q4="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringArray">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q5:ArrayOfstring" xmlns:q5="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringArrayResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringArrayResult" nillable="true" type="q6:ArrayOfstring" xmlns:q6="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDictionary">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q7:ArrayOfKeyValueOfstringstring" xmlns:q7="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoDictionaryResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoDictionaryResult" nillable="true" type="q8:ArrayOfKeyValueOfstringstring" xmlns:q8="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoIDictionary">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="q9:ArrayOfKeyValueOfstringstring" xmlns:q9="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoIDictionaryResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoIDictionaryResult" nillable="true" type="q10:ArrayOfKeyValueOfstringstring" xmlns:q10="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+      <xs:complexType name="ArrayOfstring">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="string" nillable="true" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfstring" nillable="true" type="tns:ArrayOfstring"/>
+      <xs:complexType name="ArrayOfKeyValueOfstringstring">
+        <xs:annotation>
+          <xs:appinfo>
+            <IsDictionary xmlns="http://schemas.microsoft.com/2003/10/Serialization/">true</IsDictionary>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="KeyValueOfstringstring">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="Key" nillable="true" type="xs:string"/>
+                <xs:element name="Value" nillable="true" type="xs:string"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ArrayOfKeyValueOfstringstring" nillable="true" type="tns:ArrayOfKeyValueOfstringstring"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="CollectionsService_EchoStringList_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringList"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringList_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringListResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringEnumerable_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringEnumerable"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringEnumerable_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringEnumerableResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringArray_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringArray"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoStringArray_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringArrayResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoDictionary_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDictionary"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoDictionary_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoDictionaryResponse"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoIDictionary_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoIDictionary"/>
+  </wsdl:message>
+  <wsdl:message name="CollectionsService_EchoIDictionary_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoIDictionaryResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="CollectionsService">
+    <wsdl:operation name="EchoStringList">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringList" message="tns:CollectionsService_EchoStringList_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringListResponse" message="tns:CollectionsService_EchoStringList_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringEnumerable">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringEnumerable" message="tns:CollectionsService_EchoStringEnumerable_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringEnumerableResponse" message="tns:CollectionsService_EchoStringEnumerable_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringArray">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoStringArray" message="tns:CollectionsService_EchoStringArray_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoStringArrayResponse" message="tns:CollectionsService_EchoStringArray_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDictionary">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoDictionary" message="tns:CollectionsService_EchoDictionary_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoDictionaryResponse" message="tns:CollectionsService_EchoDictionary_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoIDictionary">
+      <wsdl:input wsaw:Action="http://tempuri.org/CollectionsService/EchoIDictionary" message="tns:CollectionsService_EchoIDictionary_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/CollectionsService/EchoIDictionaryResponse" message="tns:CollectionsService_EchoIDictionary_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_CollectionsService" type="tns:CollectionsService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoStringList">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringList" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringEnumerable">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringEnumerable" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringArray">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoStringArray" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoDictionary">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoDictionary" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoIDictionary">
+      <soap:operation soapAction="http://tempuri.org/CollectionsService/EchoIDictionary" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="CollectionsService">
+    <wsdl:port name="BasicHttpBinding_CollectionsService" binding="tns:BasicHttpBinding_CollectionsService">
+      <soap:address location="http://localhost/TestService/2/http"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/NetNamedPipeSimpleServiceTest.NetNamedPipeBindingSecurityNoneRequestReplyEchoString.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/NetNamedPipeSimpleServiceTest.NetNamedPipeBindingSecurityNoneRequestReplyEchoString.xml
@@ -1,0 +1,250 @@
+﻿<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="SimpleEchoService" targetNamespace="http://tempuri.org/">
+  <wsp:Policy wsu:Id="NetNamedPipeBinding_IEchoService_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <msb:BinaryEncoding xmlns:msb="http://schemas.microsoft.com/ws/06/2004/mspolicy/netbinary1"/>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsdl:types>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q1="http://schemas.microsoft.com/Message" name="echo" type="q1:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q2="http://schemas.microsoft.com/Message" name="EchoStreamResult" type="q2:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringAsyncResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q3="http://schemas.microsoft.com/Message" name="echo" type="q3:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q4="http://schemas.microsoft.com/Message" name="EchoStreamAsyncResult" type="q4:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoToFailResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/Message" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString" message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse" message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream" message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse" message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync" message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse" message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync" message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse" message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail" message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse" message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="NetNamedPipeBinding_IEchoService" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#NetNamedPipeBinding_IEchoService_policy"/>
+    <soap12:binding transport="http://schemas.microsoft.com/soap/named-pipe"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="NetNamedPipeBinding_IEchoService" binding="tns:NetNamedPipeBinding_IEchoService">
+      <soap12:address location="net.pipe://localhost/MyService/MyServiceEndpoint"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>net.pipe://localhost/MyService/MyServiceEndpoint</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/NetNamedPipeSimpleServiceTest.NetNamedPipeBindingSecurityTransportExplicitUpnRequestReplyEchoString.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/NetNamedPipeSimpleServiceTest.NetNamedPipeBindingSecurityTransportExplicitUpnRequestReplyEchoString.xml
@@ -1,0 +1,274 @@
+﻿<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="SimpleEchoService" targetNamespace="http://tempuri.org/">
+  <wsp:Policy wsu:Id="NetNamedPipeBinding_IEchoService_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <msb:BinaryEncoding xmlns:msb="http://schemas.microsoft.com/ws/06/2004/mspolicy/netbinary1"/>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <msf:WindowsTransportSecurity xmlns:msf="http://schemas.microsoft.com/ws/2006/05/framing/policy">
+                  <msf:ProtectionLevel>EncryptAndSign</msf:ProtectionLevel>
+                </msf:WindowsTransportSecurity>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsdl:types>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q1="http://schemas.microsoft.com/Message" name="echo" type="q1:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q2="http://schemas.microsoft.com/Message" name="EchoStreamResult" type="q2:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringAsyncResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q3="http://schemas.microsoft.com/Message" name="echo" type="q3:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q4="http://schemas.microsoft.com/Message" name="EchoStreamAsyncResult" type="q4:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoToFailResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/Message" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString" message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse" message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream" message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse" message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync" message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse" message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync" message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse" message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail" message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse" message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="NetNamedPipeBinding_IEchoService" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#NetNamedPipeBinding_IEchoService_policy"/>
+    <soap12:binding transport="http://schemas.microsoft.com/soap/named-pipe"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="NetNamedPipeBinding_IEchoService" binding="tns:NetNamedPipeBinding_IEchoService">
+      <soap12:address location="net.pipe://localhost/MyService/MyServiceEndpoint"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>net.pipe://localhost/MyService/MyServiceEndpoint</wsa10:Address>
+        <Identity xmlns="http://schemas.xmlsoap.org/ws/2006/02/addressingidentity">
+          <Upn>user@corewcf.net</Upn>
+        </Identity>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/NetNamedPipeSimpleServiceTest.NetNamedPipeBindingSecurityTransportRequestReplyEchoString.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/NetNamedPipeSimpleServiceTest.NetNamedPipeBindingSecurityTransportRequestReplyEchoString.xml
@@ -1,0 +1,274 @@
+﻿<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="SimpleEchoService" targetNamespace="http://tempuri.org/">
+  <wsp:Policy wsu:Id="NetNamedPipeBinding_IEchoService_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <msb:BinaryEncoding xmlns:msb="http://schemas.microsoft.com/ws/06/2004/mspolicy/netbinary1"/>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <msf:WindowsTransportSecurity xmlns:msf="http://schemas.microsoft.com/ws/2006/05/framing/policy">
+                  <msf:ProtectionLevel>EncryptAndSign</msf:ProtectionLevel>
+                </msf:WindowsTransportSecurity>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsdl:types>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q1="http://schemas.microsoft.com/Message" name="echo" type="q1:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q2="http://schemas.microsoft.com/Message" name="EchoStreamResult" type="q2:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringAsyncResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q3="http://schemas.microsoft.com/Message" name="echo" type="q3:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:q4="http://schemas.microsoft.com/Message" name="EchoStreamAsyncResult" type="q4:StreamBody"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoToFailResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/Message" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString" message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse" message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream" message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse" message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync" message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse" message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync" message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse" message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail" message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse" message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="NetNamedPipeBinding_IEchoService" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#NetNamedPipeBinding_IEchoService_policy"/>
+    <soap12:binding transport="http://schemas.microsoft.com/soap/named-pipe"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="NetNamedPipeBinding_IEchoService" binding="tns:NetNamedPipeBinding_IEchoService">
+      <soap12:address location="net.pipe://localhost/MyService/MyServiceEndpoint"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>net.pipe://localhost/MyService/MyServiceEndpoint</wsa10:Address>
+        <Identity xmlns="http://schemas.xmlsoap.org/ws/2006/02/addressingidentity">
+          <Upn>PLACE\holder</Upn>
+        </Identity>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/NetTcpSimpleServiceTest.NetTcpBindingSecurityNoneRequestReplyEchoString.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/NetTcpSimpleServiceTest.NetTcpBindingSecurityNoneRequestReplyEchoString.xml
@@ -1,0 +1,251 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SimpleEchoService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsp:Policy wsu:Id="NetTcpBinding_IEchoService_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <msb:BinaryEncoding xmlns:msb="http://schemas.microsoft.com/ws/06/2004/mspolicy/netbinary1"/>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q1:StreamBody" xmlns:q1="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamResult" type="q2:StreamBody" xmlns:q2="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringAsyncResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q3:StreamBody" xmlns:q3="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamAsyncResult" type="q4:StreamBody" xmlns:q4="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoToFailResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/Message" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString" message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse" message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream" message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse" message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync" message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse" message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync" message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse" message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail" message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse" message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="NetTcpBinding_IEchoService" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#NetTcpBinding_IEchoService_policy"/>
+    <soap12:binding transport="http://schemas.microsoft.com/soap/tcp"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="NetTcpBinding_IEchoService" binding="tns:NetTcpBinding_IEchoService">
+      <soap12:address location="net.tcp://localhost:8808/TestSite/NetTcpBinding.svc/netTcp"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>net.tcp://localhost:8808/TestSite/NetTcpBinding.svc/netTcp</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/UseRequestHeadersForMetadataAddressBehaviorTests.WithHostHeader.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/UseRequestHeadersForMetadataAddressBehaviorTests.WithHostHeader.xml
@@ -1,0 +1,362 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SimpleEchoService"
+                  targetNamespace="http://tempuri.org/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy"
+                  xmlns:wsa10="http://www.w3.org/2005/08/addressing"
+                  xmlns:tns="http://tempuri.org/"
+                  xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract"
+                  xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+                  xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata"
+                  xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+                  xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"
+                  xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+                  xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+                  xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified"
+		           targetNamespace="http://tempuri.org/"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoStringResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo"
+						            type="q1:StreamBody"
+						            xmlns:q1="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamResult"
+						            type="q2:StreamBody"
+						            xmlns:q2="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoStringAsyncResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo"
+						            type="q3:StreamBody"
+						            xmlns:q3="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamAsyncResult"
+						            type="q4:StreamBody"
+						            xmlns:q4="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoToFailResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified"
+		           elementFormDefault="qualified"
+		           targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		           xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType"
+			            nillable="true"
+			            type="xs:anyType"/>
+      <xs:element name="anyURI"
+			            nillable="true"
+			            type="xs:anyURI"/>
+      <xs:element name="base64Binary"
+			            nillable="true"
+			            type="xs:base64Binary"/>
+      <xs:element name="boolean"
+			            nillable="true"
+			            type="xs:boolean"/>
+      <xs:element name="byte"
+			            nillable="true"
+			            type="xs:byte"/>
+      <xs:element name="dateTime"
+			            nillable="true"
+			            type="xs:dateTime"/>
+      <xs:element name="decimal"
+			            nillable="true"
+			            type="xs:decimal"/>
+      <xs:element name="double"
+			            nillable="true"
+			            type="xs:double"/>
+      <xs:element name="float"
+			            nillable="true"
+			            type="xs:float"/>
+      <xs:element name="int"
+			            nillable="true"
+			            type="xs:int"/>
+      <xs:element name="long"
+			            nillable="true"
+			            type="xs:long"/>
+      <xs:element name="QName"
+			            nillable="true"
+			            type="xs:QName"/>
+      <xs:element name="short"
+			            nillable="true"
+			            type="xs:short"/>
+      <xs:element name="string"
+			            nillable="true"
+			            type="xs:string"/>
+      <xs:element name="unsignedByte"
+			            nillable="true"
+			            type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt"
+			            nillable="true"
+			            type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong"
+			            nillable="true"
+			            type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort"
+			            nillable="true"
+			            type="xs:unsignedShort"/>
+      <xs:element name="char"
+			            nillable="true"
+			            type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration"
+			            nillable="true"
+			            type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid"
+			            nillable="true"
+			            type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType"
+			              type="xs:QName"/>
+      <xs:attribute name="Id"
+			              type="xs:ID"/>
+      <xs:attribute name="Ref"
+			              type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified"
+		           targetNamespace="http://schemas.microsoft.com/Message"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		           xmlns:tns="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString"
+			            message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse"
+			             message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream"
+			            message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse"
+			             message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync"
+			            message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse"
+			             message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync"
+			            message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse"
+			             message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail"
+			            message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse"
+			             message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_IEchoService"
+	              type="tns:IEchoService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoString"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStream"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoToFail"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="BasicHttpBinding_IEchoService"
+		           binding="tns:BasicHttpBinding_IEchoService">
+      <soap:address location="http://localhost/TestSite/BasicHttpBinding.svc/basicHttp"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/UseRequestHeadersForMetadataAddressBehaviorTests.WithoutHostHeader.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/UseRequestHeadersForMetadataAddressBehaviorTests.WithoutHostHeader.xml
@@ -1,0 +1,362 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SimpleEchoService"
+                  targetNamespace="http://tempuri.org/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy"
+                  xmlns:wsa10="http://www.w3.org/2005/08/addressing"
+                  xmlns:tns="http://tempuri.org/"
+                  xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract"
+                  xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+                  xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata"
+                  xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+                  xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"
+                  xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+                  xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+                  xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified"
+		           targetNamespace="http://tempuri.org/"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoStringResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo"
+						            type="q1:StreamBody"
+						            xmlns:q1="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamResult"
+						            type="q2:StreamBody"
+						            xmlns:q2="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoStringAsyncResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo"
+						            type="q3:StreamBody"
+						            xmlns:q3="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamAsyncResult"
+						            type="q4:StreamBody"
+						            xmlns:q4="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="echo"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0"
+						            name="EchoToFailResult"
+						            nillable="true"
+						            type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified"
+		           elementFormDefault="qualified"
+		           targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		           xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType"
+			            nillable="true"
+			            type="xs:anyType"/>
+      <xs:element name="anyURI"
+			            nillable="true"
+			            type="xs:anyURI"/>
+      <xs:element name="base64Binary"
+			            nillable="true"
+			            type="xs:base64Binary"/>
+      <xs:element name="boolean"
+			            nillable="true"
+			            type="xs:boolean"/>
+      <xs:element name="byte"
+			            nillable="true"
+			            type="xs:byte"/>
+      <xs:element name="dateTime"
+			            nillable="true"
+			            type="xs:dateTime"/>
+      <xs:element name="decimal"
+			            nillable="true"
+			            type="xs:decimal"/>
+      <xs:element name="double"
+			            nillable="true"
+			            type="xs:double"/>
+      <xs:element name="float"
+			            nillable="true"
+			            type="xs:float"/>
+      <xs:element name="int"
+			            nillable="true"
+			            type="xs:int"/>
+      <xs:element name="long"
+			            nillable="true"
+			            type="xs:long"/>
+      <xs:element name="QName"
+			            nillable="true"
+			            type="xs:QName"/>
+      <xs:element name="short"
+			            nillable="true"
+			            type="xs:short"/>
+      <xs:element name="string"
+			            nillable="true"
+			            type="xs:string"/>
+      <xs:element name="unsignedByte"
+			            nillable="true"
+			            type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt"
+			            nillable="true"
+			            type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong"
+			            nillable="true"
+			            type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort"
+			            nillable="true"
+			            type="xs:unsignedShort"/>
+      <xs:element name="char"
+			            nillable="true"
+			            type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration"
+			            nillable="true"
+			            type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid"
+			            nillable="true"
+			            type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType"
+			              type="xs:QName"/>
+      <xs:attribute name="Id"
+			              type="xs:ID"/>
+      <xs:attribute name="Ref"
+			              type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified"
+		           targetNamespace="http://schemas.microsoft.com/Message"
+		           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		           xmlns:tns="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters"
+		           element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString"
+			            message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse"
+			             message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream"
+			            message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse"
+			             message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync"
+			            message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse"
+			             message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync"
+			            message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse"
+			             message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail"
+			            message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse"
+			             message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_IEchoService"
+	              type="tns:IEchoService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoString"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStream"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap:operation soapAction="http://tempuri.org/IEchoService/EchoToFail"
+			                style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="BasicHttpBinding_IEchoService"
+		           binding="tns:BasicHttpBinding_IEchoService">
+      <soap:address location="http://localhost/TestSite/BasicHttpBinding.svc/basicHttp"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/WSHttpBindingTest.TransportWithMessageCredentials_CertAuth_MultiSecurityAlgo.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/WSHttpBindingTest.TransportWithMessageCredentials_CertAuth_MultiSecurityAlgo.xml
@@ -1,0 +1,1160 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SimpleEchoService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsp:Policy wsu:Id="WSHttpBinding_IEchoService_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic128/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:SecureConversationToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:BootstrapPolicy>
+                  <wsp:Policy>
+                    <sp:SignedParts>
+                      <sp:Body/>
+                      <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing"/>
+                    </sp:SignedParts>
+                    <sp:EncryptedParts>
+                      <sp:Body/>
+                    </sp:EncryptedParts>
+                    <sp:TransportBinding>
+                      <wsp:Policy>
+                        <sp:TransportToken>
+                          <wsp:Policy>
+                            <sp:HttpsToken RequireClientCertificate="false"/>
+                          </wsp:Policy>
+                        </sp:TransportToken>
+                        <sp:AlgorithmSuite>
+                          <wsp:Policy>
+                            <sp:Basic128/>
+                          </wsp:Policy>
+                        </sp:AlgorithmSuite>
+                        <sp:Layout>
+                          <wsp:Policy>
+                            <sp:Strict/>
+                          </wsp:Policy>
+                        </sp:Layout>
+                        <sp:IncludeTimestamp/>
+                      </wsp:Policy>
+                    </sp:TransportBinding>
+                    <sp:EndorsingSupportingTokens>
+                      <wsp:Policy>
+                        <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                          <wsp:Policy>
+                            <sp:RequireThumbprintReference/>
+                            <sp:WssX509V3Token10/>
+                          </wsp:Policy>
+                        </sp:X509Token>
+                        <sp:SignedParts>
+                          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                        </sp:SignedParts>
+                      </wsp:Policy>
+                    </sp:EndorsingSupportingTokens>
+                    <sp:Wss11>
+                      <wsp:Policy>
+                        <sp:MustSupportRefThumbprint/>
+                      </wsp:Policy>
+                    </sp:Wss11>
+                    <sp:Trust10>
+                      <wsp:Policy>
+                        <sp:MustSupportIssuedTokens/>
+                        <sp:RequireClientEntropy/>
+                        <sp:RequireServerEntropy/>
+                      </wsp:Policy>
+                    </sp:Trust10>
+                  </wsp:Policy>
+                </sp:BootstrapPolicy>
+              </wsp:Policy>
+            </sp:SecureConversationToken>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSHttpBinding_IEchoService1_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic128Sha256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:SecureConversationToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:BootstrapPolicy>
+                  <wsp:Policy>
+                    <sp:SignedParts>
+                      <sp:Body/>
+                      <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing"/>
+                    </sp:SignedParts>
+                    <sp:EncryptedParts>
+                      <sp:Body/>
+                    </sp:EncryptedParts>
+                    <sp:TransportBinding>
+                      <wsp:Policy>
+                        <sp:TransportToken>
+                          <wsp:Policy>
+                            <sp:HttpsToken RequireClientCertificate="false"/>
+                          </wsp:Policy>
+                        </sp:TransportToken>
+                        <sp:AlgorithmSuite>
+                          <wsp:Policy>
+                            <sp:Basic128Sha256/>
+                          </wsp:Policy>
+                        </sp:AlgorithmSuite>
+                        <sp:Layout>
+                          <wsp:Policy>
+                            <sp:Strict/>
+                          </wsp:Policy>
+                        </sp:Layout>
+                        <sp:IncludeTimestamp/>
+                      </wsp:Policy>
+                    </sp:TransportBinding>
+                    <sp:EndorsingSupportingTokens>
+                      <wsp:Policy>
+                        <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                          <wsp:Policy>
+                            <sp:RequireThumbprintReference/>
+                            <sp:WssX509V3Token10/>
+                          </wsp:Policy>
+                        </sp:X509Token>
+                        <sp:SignedParts>
+                          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                        </sp:SignedParts>
+                      </wsp:Policy>
+                    </sp:EndorsingSupportingTokens>
+                    <sp:Wss11>
+                      <wsp:Policy>
+                        <sp:MustSupportRefThumbprint/>
+                      </wsp:Policy>
+                    </sp:Wss11>
+                    <sp:Trust10>
+                      <wsp:Policy>
+                        <sp:MustSupportIssuedTokens/>
+                        <sp:RequireClientEntropy/>
+                        <sp:RequireServerEntropy/>
+                      </wsp:Policy>
+                    </sp:Trust10>
+                  </wsp:Policy>
+                </sp:BootstrapPolicy>
+              </wsp:Policy>
+            </sp:SecureConversationToken>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSHttpBinding_IEchoService2_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic192/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:SecureConversationToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:BootstrapPolicy>
+                  <wsp:Policy>
+                    <sp:SignedParts>
+                      <sp:Body/>
+                      <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing"/>
+                    </sp:SignedParts>
+                    <sp:EncryptedParts>
+                      <sp:Body/>
+                    </sp:EncryptedParts>
+                    <sp:TransportBinding>
+                      <wsp:Policy>
+                        <sp:TransportToken>
+                          <wsp:Policy>
+                            <sp:HttpsToken RequireClientCertificate="false"/>
+                          </wsp:Policy>
+                        </sp:TransportToken>
+                        <sp:AlgorithmSuite>
+                          <wsp:Policy>
+                            <sp:Basic192/>
+                          </wsp:Policy>
+                        </sp:AlgorithmSuite>
+                        <sp:Layout>
+                          <wsp:Policy>
+                            <sp:Strict/>
+                          </wsp:Policy>
+                        </sp:Layout>
+                        <sp:IncludeTimestamp/>
+                      </wsp:Policy>
+                    </sp:TransportBinding>
+                    <sp:EndorsingSupportingTokens>
+                      <wsp:Policy>
+                        <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                          <wsp:Policy>
+                            <sp:RequireThumbprintReference/>
+                            <sp:WssX509V3Token10/>
+                          </wsp:Policy>
+                        </sp:X509Token>
+                        <sp:SignedParts>
+                          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                        </sp:SignedParts>
+                      </wsp:Policy>
+                    </sp:EndorsingSupportingTokens>
+                    <sp:Wss11>
+                      <wsp:Policy>
+                        <sp:MustSupportRefThumbprint/>
+                      </wsp:Policy>
+                    </sp:Wss11>
+                    <sp:Trust10>
+                      <wsp:Policy>
+                        <sp:MustSupportIssuedTokens/>
+                        <sp:RequireClientEntropy/>
+                        <sp:RequireServerEntropy/>
+                      </wsp:Policy>
+                    </sp:Trust10>
+                  </wsp:Policy>
+                </sp:BootstrapPolicy>
+              </wsp:Policy>
+            </sp:SecureConversationToken>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSHttpBinding_IEchoService3_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic192Sha256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:SecureConversationToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:BootstrapPolicy>
+                  <wsp:Policy>
+                    <sp:SignedParts>
+                      <sp:Body/>
+                      <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing"/>
+                    </sp:SignedParts>
+                    <sp:EncryptedParts>
+                      <sp:Body/>
+                    </sp:EncryptedParts>
+                    <sp:TransportBinding>
+                      <wsp:Policy>
+                        <sp:TransportToken>
+                          <wsp:Policy>
+                            <sp:HttpsToken RequireClientCertificate="false"/>
+                          </wsp:Policy>
+                        </sp:TransportToken>
+                        <sp:AlgorithmSuite>
+                          <wsp:Policy>
+                            <sp:Basic192Sha256/>
+                          </wsp:Policy>
+                        </sp:AlgorithmSuite>
+                        <sp:Layout>
+                          <wsp:Policy>
+                            <sp:Strict/>
+                          </wsp:Policy>
+                        </sp:Layout>
+                        <sp:IncludeTimestamp/>
+                      </wsp:Policy>
+                    </sp:TransportBinding>
+                    <sp:EndorsingSupportingTokens>
+                      <wsp:Policy>
+                        <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                          <wsp:Policy>
+                            <sp:RequireThumbprintReference/>
+                            <sp:WssX509V3Token10/>
+                          </wsp:Policy>
+                        </sp:X509Token>
+                        <sp:SignedParts>
+                          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                        </sp:SignedParts>
+                      </wsp:Policy>
+                    </sp:EndorsingSupportingTokens>
+                    <sp:Wss11>
+                      <wsp:Policy>
+                        <sp:MustSupportRefThumbprint/>
+                      </wsp:Policy>
+                    </sp:Wss11>
+                    <sp:Trust10>
+                      <wsp:Policy>
+                        <sp:MustSupportIssuedTokens/>
+                        <sp:RequireClientEntropy/>
+                        <sp:RequireServerEntropy/>
+                      </wsp:Policy>
+                    </sp:Trust10>
+                  </wsp:Policy>
+                </sp:BootstrapPolicy>
+              </wsp:Policy>
+            </sp:SecureConversationToken>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSHttpBinding_IEchoService4_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:SecureConversationToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:BootstrapPolicy>
+                  <wsp:Policy>
+                    <sp:SignedParts>
+                      <sp:Body/>
+                      <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing"/>
+                    </sp:SignedParts>
+                    <sp:EncryptedParts>
+                      <sp:Body/>
+                    </sp:EncryptedParts>
+                    <sp:TransportBinding>
+                      <wsp:Policy>
+                        <sp:TransportToken>
+                          <wsp:Policy>
+                            <sp:HttpsToken RequireClientCertificate="false"/>
+                          </wsp:Policy>
+                        </sp:TransportToken>
+                        <sp:AlgorithmSuite>
+                          <wsp:Policy>
+                            <sp:Basic256/>
+                          </wsp:Policy>
+                        </sp:AlgorithmSuite>
+                        <sp:Layout>
+                          <wsp:Policy>
+                            <sp:Strict/>
+                          </wsp:Policy>
+                        </sp:Layout>
+                        <sp:IncludeTimestamp/>
+                      </wsp:Policy>
+                    </sp:TransportBinding>
+                    <sp:EndorsingSupportingTokens>
+                      <wsp:Policy>
+                        <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                          <wsp:Policy>
+                            <sp:RequireThumbprintReference/>
+                            <sp:WssX509V3Token10/>
+                          </wsp:Policy>
+                        </sp:X509Token>
+                        <sp:SignedParts>
+                          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                        </sp:SignedParts>
+                      </wsp:Policy>
+                    </sp:EndorsingSupportingTokens>
+                    <sp:Wss11>
+                      <wsp:Policy>
+                        <sp:MustSupportRefThumbprint/>
+                      </wsp:Policy>
+                    </sp:Wss11>
+                    <sp:Trust10>
+                      <wsp:Policy>
+                        <sp:MustSupportIssuedTokens/>
+                        <sp:RequireClientEntropy/>
+                        <sp:RequireServerEntropy/>
+                      </wsp:Policy>
+                    </sp:Trust10>
+                  </wsp:Policy>
+                </sp:BootstrapPolicy>
+              </wsp:Policy>
+            </sp:SecureConversationToken>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSHttpBinding_IEchoService5_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256Sha256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:SecureConversationToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:BootstrapPolicy>
+                  <wsp:Policy>
+                    <sp:SignedParts>
+                      <sp:Body/>
+                      <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing"/>
+                    </sp:SignedParts>
+                    <sp:EncryptedParts>
+                      <sp:Body/>
+                    </sp:EncryptedParts>
+                    <sp:TransportBinding>
+                      <wsp:Policy>
+                        <sp:TransportToken>
+                          <wsp:Policy>
+                            <sp:HttpsToken RequireClientCertificate="false"/>
+                          </wsp:Policy>
+                        </sp:TransportToken>
+                        <sp:AlgorithmSuite>
+                          <wsp:Policy>
+                            <sp:Basic256Sha256/>
+                          </wsp:Policy>
+                        </sp:AlgorithmSuite>
+                        <sp:Layout>
+                          <wsp:Policy>
+                            <sp:Strict/>
+                          </wsp:Policy>
+                        </sp:Layout>
+                        <sp:IncludeTimestamp/>
+                      </wsp:Policy>
+                    </sp:TransportBinding>
+                    <sp:EndorsingSupportingTokens>
+                      <wsp:Policy>
+                        <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                          <wsp:Policy>
+                            <sp:RequireThumbprintReference/>
+                            <sp:WssX509V3Token10/>
+                          </wsp:Policy>
+                        </sp:X509Token>
+                        <sp:SignedParts>
+                          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                        </sp:SignedParts>
+                      </wsp:Policy>
+                    </sp:EndorsingSupportingTokens>
+                    <sp:Wss11>
+                      <wsp:Policy>
+                        <sp:MustSupportRefThumbprint/>
+                      </wsp:Policy>
+                    </sp:Wss11>
+                    <sp:Trust10>
+                      <wsp:Policy>
+                        <sp:MustSupportIssuedTokens/>
+                        <sp:RequireClientEntropy/>
+                        <sp:RequireServerEntropy/>
+                      </wsp:Policy>
+                    </sp:Trust10>
+                  </wsp:Policy>
+                </sp:BootstrapPolicy>
+              </wsp:Policy>
+            </sp:SecureConversationToken>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q1:StreamBody" xmlns:q1="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamResult" type="q2:StreamBody" xmlns:q2="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringAsyncResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q3:StreamBody" xmlns:q3="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamAsyncResult" type="q4:StreamBody" xmlns:q4="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoToFailResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/Message" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString" message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse" message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream" message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse" message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync" message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse" message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync" message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse" message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail" message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse" message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WSHttpBinding_IEchoService" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#WSHttpBinding_IEchoService_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="WSHttpBinding_IEchoService1" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#WSHttpBinding_IEchoService1_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="WSHttpBinding_IEchoService2" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#WSHttpBinding_IEchoService2_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="WSHttpBinding_IEchoService3" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#WSHttpBinding_IEchoService3_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="WSHttpBinding_IEchoService4" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#WSHttpBinding_IEchoService4_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="WSHttpBinding_IEchoService5" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#WSHttpBinding_IEchoService5_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="WSHttpBinding_IEchoService" binding="tns:WSHttpBinding_IEchoService">
+      <soap12:address location="https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic128"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic128</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="WSHttpBinding_IEchoService1" binding="tns:WSHttpBinding_IEchoService1">
+      <soap12:address location="https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic128Sha256"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic128Sha256</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="WSHttpBinding_IEchoService2" binding="tns:WSHttpBinding_IEchoService2">
+      <soap12:address location="https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic192"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic192</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="WSHttpBinding_IEchoService3" binding="tns:WSHttpBinding_IEchoService3">
+      <soap12:address location="https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic192Sha256"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic192Sha256</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="WSHttpBinding_IEchoService4" binding="tns:WSHttpBinding_IEchoService4">
+      <soap12:address location="https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic256"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic256</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="WSHttpBinding_IEchoService5" binding="tns:WSHttpBinding_IEchoService5">
+      <soap12:address location="https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic256Sha256"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>https://localhost/TestSite/endpointAddress.svc/wsHttp/Basic256Sha256</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/WSHttpBindingTest.TransportWithMessageCredentials_CertificateAuth_NoSecurityContext.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/WSHttpBindingTest.TransportWithMessageCredentials_CertificateAuth_NoSecurityContext.xml
@@ -1,0 +1,295 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SimpleEchoService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsp:Policy wsu:Id="WSHttpBinding_IEchoService_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:RequireThumbprintReference/>
+                <sp:WssX509V3Token10/>
+              </wsp:Policy>
+            </sp:X509Token>
+            <sp:SignedParts>
+              <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+            </sp:SignedParts>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportRefThumbprint/>
+          </wsp:Policy>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q1:StreamBody" xmlns:q1="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamResult" type="q2:StreamBody" xmlns:q2="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringAsyncResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q3:StreamBody" xmlns:q3="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamAsyncResult" type="q4:StreamBody" xmlns:q4="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoToFailResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/Message" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString" message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse" message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream" message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse" message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync" message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse" message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync" message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse" message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail" message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse" message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WSHttpBinding_IEchoService" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#WSHttpBinding_IEchoService_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="WSHttpBinding_IEchoService" binding="tns:WSHttpBinding_IEchoService">
+      <soap12:address location="https://localhost/TestSite/endpointAddress.svc"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>https://localhost/TestSite/endpointAddress.svc</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/WSHttpBindingTest.TransportWithMessageCredentials_MultiAuth.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/WSHttpBindingTest.TransportWithMessageCredentials_MultiAuth.xml
@@ -1,0 +1,660 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SimpleEchoService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsp:Policy wsu:Id="WSHttpBinding_IEchoService_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:SecureConversationToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:BootstrapPolicy>
+                  <wsp:Policy>
+                    <sp:SignedParts>
+                      <sp:Body/>
+                      <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing"/>
+                    </sp:SignedParts>
+                    <sp:EncryptedParts>
+                      <sp:Body/>
+                    </sp:EncryptedParts>
+                    <sp:TransportBinding>
+                      <wsp:Policy>
+                        <sp:TransportToken>
+                          <wsp:Policy>
+                            <sp:HttpsToken RequireClientCertificate="false"/>
+                          </wsp:Policy>
+                        </sp:TransportToken>
+                        <sp:AlgorithmSuite>
+                          <wsp:Policy>
+                            <sp:Basic256/>
+                          </wsp:Policy>
+                        </sp:AlgorithmSuite>
+                        <sp:Layout>
+                          <wsp:Policy>
+                            <sp:Strict/>
+                          </wsp:Policy>
+                        </sp:Layout>
+                        <sp:IncludeTimestamp/>
+                      </wsp:Policy>
+                    </sp:TransportBinding>
+                    <sp:EndorsingSupportingTokens>
+                      <wsp:Policy>
+                        <sp:SpnegoContextToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                          <wsp:Policy/>
+                        </sp:SpnegoContextToken>
+                      </wsp:Policy>
+                    </sp:EndorsingSupportingTokens>
+                    <sp:Wss11>
+                      <wsp:Policy/>
+                    </sp:Wss11>
+                    <sp:Trust10>
+                      <wsp:Policy>
+                        <sp:MustSupportIssuedTokens/>
+                        <sp:RequireClientEntropy/>
+                        <sp:RequireServerEntropy/>
+                      </wsp:Policy>
+                    </sp:Trust10>
+                  </wsp:Policy>
+                </sp:BootstrapPolicy>
+              </wsp:Policy>
+            </sp:SecureConversationToken>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSHttpBinding_IEchoService1_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:SecureConversationToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:BootstrapPolicy>
+                  <wsp:Policy>
+                    <sp:SignedParts>
+                      <sp:Body/>
+                      <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing"/>
+                    </sp:SignedParts>
+                    <sp:EncryptedParts>
+                      <sp:Body/>
+                    </sp:EncryptedParts>
+                    <sp:TransportBinding>
+                      <wsp:Policy>
+                        <sp:TransportToken>
+                          <wsp:Policy>
+                            <sp:HttpsToken RequireClientCertificate="false"/>
+                          </wsp:Policy>
+                        </sp:TransportToken>
+                        <sp:AlgorithmSuite>
+                          <wsp:Policy>
+                            <sp:Basic256/>
+                          </wsp:Policy>
+                        </sp:AlgorithmSuite>
+                        <sp:Layout>
+                          <wsp:Policy>
+                            <sp:Strict/>
+                          </wsp:Policy>
+                        </sp:Layout>
+                        <sp:IncludeTimestamp/>
+                      </wsp:Policy>
+                    </sp:TransportBinding>
+                    <sp:EndorsingSupportingTokens>
+                      <wsp:Policy>
+                        <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                          <wsp:Policy>
+                            <sp:RequireThumbprintReference/>
+                            <sp:WssX509V3Token10/>
+                          </wsp:Policy>
+                        </sp:X509Token>
+                        <sp:SignedParts>
+                          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                        </sp:SignedParts>
+                      </wsp:Policy>
+                    </sp:EndorsingSupportingTokens>
+                    <sp:Wss11>
+                      <wsp:Policy>
+                        <sp:MustSupportRefThumbprint/>
+                      </wsp:Policy>
+                    </sp:Wss11>
+                    <sp:Trust10>
+                      <wsp:Policy>
+                        <sp:MustSupportIssuedTokens/>
+                        <sp:RequireClientEntropy/>
+                        <sp:RequireServerEntropy/>
+                      </wsp:Policy>
+                    </sp:Trust10>
+                  </wsp:Policy>
+                </sp:BootstrapPolicy>
+              </wsp:Policy>
+            </sp:SecureConversationToken>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSHttpBinding_IEchoService2_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:SecureConversationToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:BootstrapPolicy>
+                  <wsp:Policy>
+                    <sp:SignedParts>
+                      <sp:Body/>
+                      <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+                      <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing"/>
+                    </sp:SignedParts>
+                    <sp:EncryptedParts>
+                      <sp:Body/>
+                    </sp:EncryptedParts>
+                    <sp:TransportBinding>
+                      <wsp:Policy>
+                        <sp:TransportToken>
+                          <wsp:Policy>
+                            <sp:HttpsToken RequireClientCertificate="false"/>
+                          </wsp:Policy>
+                        </sp:TransportToken>
+                        <sp:AlgorithmSuite>
+                          <wsp:Policy>
+                            <sp:Basic256/>
+                          </wsp:Policy>
+                        </sp:AlgorithmSuite>
+                        <sp:Layout>
+                          <wsp:Policy>
+                            <sp:Strict/>
+                          </wsp:Policy>
+                        </sp:Layout>
+                        <sp:IncludeTimestamp/>
+                      </wsp:Policy>
+                    </sp:TransportBinding>
+                    <sp:SignedSupportingTokens>
+                      <wsp:Policy>
+                        <sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                          <wsp:Policy>
+                            <sp:WssUsernameToken10/>
+                          </wsp:Policy>
+                        </sp:UsernameToken>
+                      </wsp:Policy>
+                    </sp:SignedSupportingTokens>
+                    <sp:Wss11>
+                      <wsp:Policy/>
+                    </sp:Wss11>
+                    <sp:Trust10>
+                      <wsp:Policy>
+                        <sp:MustSupportIssuedTokens/>
+                        <sp:RequireClientEntropy/>
+                        <sp:RequireServerEntropy/>
+                      </wsp:Policy>
+                    </sp:Trust10>
+                  </wsp:Policy>
+                </sp:BootstrapPolicy>
+              </wsp:Policy>
+            </sp:SecureConversationToken>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.microsoft.com/Message"/>
+      <xs:element name="EchoString">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStream">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q1:StreamBody" xmlns:q1="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamResult" type="q2:StreamBody" xmlns:q2="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStringAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoStringAsyncResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsync">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="echo" type="q3:StreamBody" xmlns:q3="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoStreamAsyncResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EchoStreamAsyncResult" type="q4:StreamBody" xmlns:q4="http://schemas.microsoft.com/Message"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFail">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="echo" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoToFailResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="EchoToFailResult" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/Message" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/Message">
+      <xs:simpleType name="StreamBody">
+        <xs:restriction base="xs:base64Binary"/>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IEchoService_EchoString_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoString"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoString_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStream"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStream_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStringAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStringAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsync"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoStreamAsync_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoStreamAsyncResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFail"/>
+  </wsdl:message>
+  <wsdl:message name="IEchoService_EchoToFail_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoToFailResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IEchoService">
+    <wsdl:operation name="EchoString">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoString" message="tns:IEchoService_EchoString_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringResponse" message="tns:IEchoService_EchoString_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStream" message="tns:IEchoService_EchoStream_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamResponse" message="tns:IEchoService_EchoStream_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsync" message="tns:IEchoService_EchoStringAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStringAsyncResponse" message="tns:IEchoService_EchoStringAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsync" message="tns:IEchoService_EchoStreamAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoStreamAsyncResponse" message="tns:IEchoService_EchoStreamAsync_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <wsdl:input wsaw:Action="http://tempuri.org/IEchoService/EchoToFail" message="tns:IEchoService_EchoToFail_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IEchoService/EchoToFailResponse" message="tns:IEchoService_EchoToFail_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WSHttpBinding_IEchoService" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#WSHttpBinding_IEchoService_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="WSHttpBinding_IEchoService1" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#WSHttpBinding_IEchoService1_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="WSHttpBinding_IEchoService2" type="tns:IEchoService">
+    <wsp:PolicyReference URI="#WSHttpBinding_IEchoService2_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="EchoString">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoString" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStream">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStream" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStringAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStringAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoStreamAsync">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoStreamAsync" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoToFail">
+      <soap12:operation soapAction="http://tempuri.org/IEchoService/EchoToFail" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SimpleEchoService">
+    <wsdl:port name="WSHttpBinding_IEchoService" binding="tns:WSHttpBinding_IEchoService">
+      <soap12:address location="https://localhost/TestSite/WSHttpBinding.svc/wsHttp/winAuth"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>https://localhost/TestSite/WSHttpBinding.svc/wsHttp/winAuth</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="WSHttpBinding_IEchoService1" binding="tns:WSHttpBinding_IEchoService1">
+      <soap12:address location="https://localhost/TestSite/WSHttpBinding.svc/wsHttp/certAuth"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>https://localhost/TestSite/WSHttpBinding.svc/wsHttp/certAuth</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="WSHttpBinding_IEchoService2" binding="tns:WSHttpBinding_IEchoService2">
+      <soap12:address location="https://localhost/TestSite/WSHttpBinding.svc/wsHttp/userNameAuth"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>https://localhost/TestSite/WSHttpBinding.svc/wsHttp/userNameAuth</wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/XmlSerializableTests.SystemDataTest.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/XmlSerializableTests.SystemDataTest.xml
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SystemDataService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:element name="GetDataSet">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="GetDataSetResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="GetDataSetResult" nillable="true">
+              <xs:complexType>
+                <xs:annotation>
+                  <xs:appinfo>
+                    <ActualType xmlns="http://schemas.microsoft.com/2003/10/Serialization/" Name="DataSet" Namespace="http://schemas.datacontract.org/2004/07/System.Data"/>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:sequence maxOccurs="unbounded">
+                  <xs:any minOccurs="0" namespace="http://www.w3.org/2001/XMLSchema" processContents="lax"/>
+                  <xs:any minOccurs="0" namespace="urn:schemas-microsoft-com:xml-diffgram-v1" processContents="lax"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+      <xs:simpleType name="dateOnly">
+        <xs:restriction base="xs:date">
+          <xs:pattern value="([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" />
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType name="timeOnly">
+        <xs:restriction base="xs:time">
+          <xs:pattern value="([01][0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9])(\.[0-9]{1,7})?)?" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:element name="DataSet" nillable="true">
+        <xs:complexType>
+          <xs:annotation>
+            <xs:appinfo>
+              <ActualType xmlns="http://schemas.microsoft.com/2003/10/Serialization/" Name="DataSet" Namespace="http://schemas.datacontract.org/2004/07/System.Data"/>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:sequence maxOccurs="unbounded">
+            <xs:any minOccurs="0" namespace="http://www.w3.org/2001/XMLSchema" processContents="lax"/>
+            <xs:any minOccurs="0" namespace="urn:schemas-microsoft-com:xml-diffgram-v1" processContents="lax"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="SystemDataService_GetDataSet_InputMessage">
+    <wsdl:part name="parameters" element="tns:GetDataSet"/>
+  </wsdl:message>
+  <wsdl:message name="SystemDataService_GetDataSet_OutputMessage">
+    <wsdl:part name="parameters" element="tns:GetDataSetResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="SystemDataService">
+    <wsdl:operation name="GetDataSet">
+      <wsdl:input wsaw:Action="http://tempuri.org/SystemDataService/GetDataSet" message="tns:SystemDataService_GetDataSet_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/SystemDataService/GetDataSetResponse" message="tns:SystemDataService_GetDataSet_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_SystemDataService" type="tns:SystemDataService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="GetDataSet">
+      <soap:operation soapAction="http://tempuri.org/SystemDataService/GetDataSet" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SystemDataService">
+    <wsdl:port name="BasicHttpBinding_SystemDataService" binding="tns:BasicHttpBinding_SystemDataService">
+      <soap:address location="http://localhost/TestService/api"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/XmlSerializerFormatSoapTest.SoapServiceTest.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/XmlSerializerFormatSoapTest.SoapServiceTest.xml
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="SoapService" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/encoded" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://tempuri.org/encoded">
+      <xs:complexType name="SoapComplexType">
+        <xs:sequence>
+          <xs:element minOccurs="1" maxOccurs="1" form="unqualified" name="BoolValue" type="xs:boolean"/>
+          <xs:element minOccurs="0" maxOccurs="1" form="unqualified" name="StringValue" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="WcfService" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="WcfService">
+      <xs:complexType name="CustomerObject">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="1" form="unqualified" name="Name" type="xs:string"/>
+          <xs:element minOccurs="0" maxOccurs="1" form="unqualified" name="Data" type="xs:anyType"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="AdditionalData">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="1" form="unqualified" name="Field" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IWcfSoapService_CombineStringXmlSerializerFormatSoap_InputMessage">
+    <wsdl:part name="message1" type="xsd:string"/>
+    <wsdl:part name="message2" type="xsd:string"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfSoapService_CombineStringXmlSerializerFormatSoap_OutputMessage">
+    <wsdl:part name="CombineStringXmlSerializerFormatSoapResult" type="xsd:string"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfSoapService_EchoComositeTypeXmlSerializerFormatSoap_InputMessage">
+    <wsdl:part name="c" type="q1:SoapComplexType" xmlns:q1="http://tempuri.org/encoded"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfSoapService_EchoComositeTypeXmlSerializerFormatSoap_OutputMessage">
+    <wsdl:part name="EchoComositeTypeXmlSerializerFormatSoapResult" type="q2:SoapComplexType" xmlns:q2="http://tempuri.org/encoded"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfSoapService_ProcessCustomerData_InputMessage">
+    <wsdl:part name="CustomerData" type="q3:CustomerObject" xmlns:q3="WcfService"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfSoapService_ProcessCustomerData_OutputMessage">
+    <wsdl:part name="ProcessCustomerDataReturn" type="xsd:string"/>
+  </wsdl:message>
+  <wsdl:message name="PingEncodedRequest">
+    <wsdl:part name="Pinginfo" type="xsd:string"/>
+  </wsdl:message>
+  <wsdl:message name="PingEncodedResponse">
+    <wsdl:part name="Return" type="xsd:int"/>
+  </wsdl:message>
+  <wsdl:portType name="IWcfSoapService">
+    <wsdl:operation name="CombineStringXmlSerializerFormatSoap" parameterOrder="message1 message2">
+      <wsdl:input wsaw:Action="http://tempuri.org/IWcfService/CombineStringXmlSerializerFormatSoap" message="tns:IWcfSoapService_CombineStringXmlSerializerFormatSoap_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IWcfService/CombineStringXmlSerializerFormatSoapResponse" message="tns:IWcfSoapService_CombineStringXmlSerializerFormatSoap_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoComositeTypeXmlSerializerFormatSoap" parameterOrder="c">
+      <wsdl:input wsaw:Action="http://tempuri.org/IWcfService/EchoComositeTypeXmlSerializerFormatSoap" message="tns:IWcfSoapService_EchoComositeTypeXmlSerializerFormatSoap_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IWcfService/EchoComositeTypeXmlSerializerFormatSoapResponse" message="tns:IWcfSoapService_EchoComositeTypeXmlSerializerFormatSoap_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="ProcessCustomerData" parameterOrder="CustomerData">
+      <wsdl:input wsaw:Action="http://tempuri.org/IWcfService/ProcessCustomerData" message="tns:IWcfSoapService_ProcessCustomerData_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IWcfSoapService/ProcessCustomerDataResponse" message="tns:IWcfSoapService_ProcessCustomerData_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="Ping">
+      <wsdl:input wsaw:Action="http://tempuri.org/IWcfService/Ping" name="PingEncodedRequest" message="tns:PingEncodedRequest"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IWcfSoapService/PingResponse" name="PingEncodedResponse" message="tns:PingEncodedResponse"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_IWcfSoapService" type="tns:IWcfSoapService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="rpc"/>
+    <wsdl:operation name="CombineStringXmlSerializerFormatSoap">
+      <soap:operation soapAction="http://tempuri.org/IWcfService/CombineStringXmlSerializerFormatSoap" style="rpc"/>
+      <wsdl:input>
+        <soap:body use="encoded" namespace="http://tempuri.org/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="encoded" namespace="http://tempuri.org/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoComositeTypeXmlSerializerFormatSoap">
+      <soap:operation soapAction="http://tempuri.org/IWcfService/EchoComositeTypeXmlSerializerFormatSoap" style="rpc"/>
+      <wsdl:input>
+        <soap:body use="encoded" namespace="http://tempuri.org/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="encoded" namespace="http://tempuri.org/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="ProcessCustomerData">
+      <soap:operation soapAction="http://tempuri.org/IWcfService/ProcessCustomerData" style="rpc"/>
+      <wsdl:input>
+        <soap:body use="encoded" namespace="http://tempuri.org/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="encoded" namespace="http://tempuri.org/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Ping">
+      <soap:operation soapAction="http://tempuri.org/IWcfService/Ping" style="rpc"/>
+      <wsdl:input name="PingEncodedRequest">
+        <soap:body use="encoded" namespace="http://tempuri.org/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:input>
+      <wsdl:output name="PingEncodedResponse">
+        <soap:body use="encoded" namespace="http://tempuri.org/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SoapService">
+    <wsdl:port name="BasicHttpBinding_IWcfSoapService" binding="tns:BasicHttpBinding_IWcfSoapService">
+      <soap:address location="http://localhost/TestSite/endpointAddress.svc/basicHttp"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/src/CoreWCF.Metadata/tests/Wsdls/net10.0/XmlSerializerFormatSoapTest.XmlGeneratedTest.xml
+++ b/src/CoreWCF.Metadata/tests/Wsdls/net10.0/XmlSerializerFormatSoapTest.XmlGeneratedTest.xml
@@ -1,0 +1,182 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="WcfServiceXmlGenerated" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:element name="EchoXmlSerializerFormat">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="message" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoXmlSerializerFormatResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="EchoXmlSerializerFormatResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoXmlSerializerFormatSupportFaults">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="message" type="xs:string"/>
+            <xs:element minOccurs="1" maxOccurs="1" name="pleaseThrowException" type="xs:boolean"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoXmlSerializerFormatSupportFaultsResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="EchoXmlSerializerFormatSupportFaultsResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="GetDataUsingXmlSerializer">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="composite" type="tns:XmlCompositeType"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:complexType name="XmlCompositeType">
+        <xs:sequence>
+          <xs:element minOccurs="1" maxOccurs="1" name="BoolValue" type="xs:boolean"/>
+          <xs:element minOccurs="0" maxOccurs="1" name="StringValue" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="GetDataUsingXmlSerializerResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="GetDataUsingXmlSerializerResult" type="tns:XmlCompositeType"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="EchoXmlVeryComplexType">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="complex" type="tns:XmlVeryComplexType"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:complexType name="XmlVeryComplexType">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="1" name="NonInstantiatedField" type="tns:NonInstantiatedType"/>
+          <xs:element minOccurs="1" maxOccurs="1" name="Id" type="xs:int"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="NonInstantiatedType"/>
+      <xs:element name="EchoXmlVeryComplexTypeResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="EchoXmlVeryComplexTypeResult" type="tns:XmlVeryComplexType"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IWcfServiceXmlGenerated_EchoXmlSerializerFormat_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoXmlSerializerFormat"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfServiceXmlGenerated_EchoXmlSerializerFormat_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoXmlSerializerFormatResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfServiceXmlGenerated_EchoXmlSerializerFormatSupportFaults_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoXmlSerializerFormatSupportFaults"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfServiceXmlGenerated_EchoXmlSerializerFormatSupportFaults_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoXmlSerializerFormatSupportFaultsResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfServiceXmlGenerated_EchoXmlSerializerFormatUsingRpc_InputMessage">
+    <wsdl:part name="message" type="xsd:string"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfServiceXmlGenerated_EchoXmlSerializerFormatUsingRpc_OutputMessage">
+    <wsdl:part name="EchoXmlSerializerFormatUsingRpcResult" type="xsd:string"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfServiceXmlGenerated_GetDataUsingXmlSerializer_InputMessage">
+    <wsdl:part name="parameters" element="tns:GetDataUsingXmlSerializer"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfServiceXmlGenerated_GetDataUsingXmlSerializer_OutputMessage">
+    <wsdl:part name="parameters" element="tns:GetDataUsingXmlSerializerResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfServiceXmlGenerated_EchoXmlVeryComplexType_InputMessage">
+    <wsdl:part name="parameters" element="tns:EchoXmlVeryComplexType"/>
+  </wsdl:message>
+  <wsdl:message name="IWcfServiceXmlGenerated_EchoXmlVeryComplexType_OutputMessage">
+    <wsdl:part name="parameters" element="tns:EchoXmlVeryComplexTypeResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IWcfServiceXmlGenerated">
+    <wsdl:operation name="EchoXmlSerializerFormat">
+      <wsdl:input wsaw:Action="http://tempuri.org/IWcfService/EchoXmlSerializerFormat" message="tns:IWcfServiceXmlGenerated_EchoXmlSerializerFormat_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IWcfService/EchoXmlSerializerFormatResponse" message="tns:IWcfServiceXmlGenerated_EchoXmlSerializerFormat_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoXmlSerializerFormatSupportFaults">
+      <wsdl:input wsaw:Action="http://tempuri.org/IWcfService/EchoXmlSerializerFormatSupportFaults" message="tns:IWcfServiceXmlGenerated_EchoXmlSerializerFormatSupportFaults_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IWcfService/EchoXmlSerializerFormatSupportFaultsResponse" message="tns:IWcfServiceXmlGenerated_EchoXmlSerializerFormatSupportFaults_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoXmlSerializerFormatUsingRpc" parameterOrder="message">
+      <wsdl:input wsaw:Action="http://tempuri.org/IWcfService/EchoXmlSerializerFormatUsingRpc" message="tns:IWcfServiceXmlGenerated_EchoXmlSerializerFormatUsingRpc_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IWcfService/EchoXmlSerializerFormatUsingRpcResponse" message="tns:IWcfServiceXmlGenerated_EchoXmlSerializerFormatUsingRpc_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetDataUsingXmlSerializer">
+      <wsdl:input wsaw:Action="http://tempuri.org/IWcfService/GetDataUsingXmlSerializer" message="tns:IWcfServiceXmlGenerated_GetDataUsingXmlSerializer_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IWcfServiceXmlGenerated/GetDataUsingXmlSerializerResponse" message="tns:IWcfServiceXmlGenerated_GetDataUsingXmlSerializer_OutputMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="EchoXmlVeryComplexType">
+      <wsdl:input wsaw:Action="http://tempuri.org/IWcfService/EchoXmlVeryComplexType" message="tns:IWcfServiceXmlGenerated_EchoXmlVeryComplexType_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IWcfServiceXmlGenerated/EchoXmlVeryComplexTypeResponse" message="tns:IWcfServiceXmlGenerated_EchoXmlVeryComplexType_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_IWcfServiceXmlGenerated" type="tns:IWcfServiceXmlGenerated">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="rpc"/>
+    <wsdl:operation name="EchoXmlSerializerFormat">
+      <soap:operation soapAction="http://tempuri.org/IWcfService/EchoXmlSerializerFormat" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoXmlSerializerFormatSupportFaults">
+      <soap:operation soapAction="http://tempuri.org/IWcfService/EchoXmlSerializerFormatSupportFaults" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoXmlSerializerFormatUsingRpc">
+      <soap:operation soapAction="http://tempuri.org/IWcfService/EchoXmlSerializerFormatUsingRpc" style="rpc"/>
+      <wsdl:input>
+        <soap:body use="literal" namespace="http://tempuri.org/"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" namespace="http://tempuri.org/"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetDataUsingXmlSerializer">
+      <soap:operation soapAction="http://tempuri.org/IWcfService/GetDataUsingXmlSerializer" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="EchoXmlVeryComplexType">
+      <soap:operation soapAction="http://tempuri.org/IWcfService/EchoXmlVeryComplexType" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="WcfServiceXmlGenerated">
+    <wsdl:port name="BasicHttpBinding_IWcfServiceXmlGenerated" binding="tns:BasicHttpBinding_IWcfServiceXmlGenerated">
+      <soap:address location="http://localhost/TestSite/endpointAddress.svc/basicHttp"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
This pull request adds support for .NET 10.0-specific WSDL test files in the metadata test suite. The main changes include updating the test project configuration to include new XML files for .NET 10.0, modifying helper methods to look for these files when running under .NET 10.0, and adding a new expected WSDL file for a test case.

**Test infrastructure updates for .NET 10.0:**

* Updated `CoreWCF.Metadata.Tests.csproj` to include `Wsdls/net10.0/*.xml` files in the test output, ensuring .NET 10.0-specific test files are available during test execution.

* Modified both `ValidateSingleWsdl` methods in `WsdlHelper.cs` to conditionally look for expected XML files in the `Wsdls/net10.0` directory when running under .NET 10.0 or greater, falling back to the legacy location for other frameworks. [[1]](diffhunk://#diff-bb6262c7085a027aa92aca4cec808b8d574b879f7c98ead467d06ce1bc283aaeR41-R54) [[2]](diffhunk://#diff-bb6262c7085a027aa92aca4cec808b8d574b879f7c98ead467d06ce1bc283aaeR95-R108)

**Test data addition:**

* Added new expected WSDL output file for the `BasicHttpSimpleServiceTest.BasicHttpRequestReplyEchoString` test, specific to .NET 10.0, under `Wsdls/net10.0/`.