### PR TITLE
Make default ServiceContract namespace explicit

### DIFF
--- a/src/CoreWCF.Templates/src/templates/CoreWCFService/IService.cs
+++ b/src/CoreWCF.Templates/src/templates/CoreWCFService/IService.cs
@@ -6,7 +6,7 @@ using System.Runtime.Serialization;
 
 namespace CoreWCFService
 {
-    [ServiceContract]
+    [ServiceContract(Namespace="http://tempuri.org")]
     public interface IService
     {
         [OperationContract]


### PR DESCRIPTION
Changing the default tempuri.org namespace can be difficult because it is not mentioned anywhere explicitly...except in generated client code. Making this namespace explicit does not change the generated WCF client at all, but makes it much easier for developers to change "http://tempuri.org" to "http://contoso.com" (for example).