### PR TITLE
Provide opt-out switch for EnableCoreWCFOperationInvokerGenerator attribute

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.targets
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.targets
@@ -16,7 +16,7 @@
       <Visible>false</Visible>
     </Compile>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(_CoreWCFSuppressOperationInvokerGeneratorAttribute)'!='true'">
       <!-- Exposes EnableCoreWCFOperationInvokerGenerator at runtime -->
     	<AssemblyAttribute Include="CoreWCF.EnableCoreWCFOperationInvokerGenerator">
 	      <_Parameter1>$(EnableCoreWCFOperationInvokerGenerator)</_Parameter1>


### PR DESCRIPTION
An internal team in Microsoft has a custom build setup which suppresses the build and lib folder from transitively applying to projects that depend on another project that depends on CoreWCF. They aren't suppressing the buildtransitive folder which results in transitive projects adding the attribute to their project but not referencing our assembly to know about the type `CoreWCF.EnableCoreWCFOperationInvokerGenerator`. This is a simple opt-out switch so that they, or anyone else who doesn't want this applying can set a property to prevent it from being added to their assembly.