### PR TITLE
Fix template tests on Windows and isolate from inherited CPM

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF.Primitives.targets
+++ b/src/CoreWCF.Primitives/src/CoreWCF.Primitives.targets
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <EnableCoreWCFOperationInvokerGenerator Condition="'$(EnableCoreWCFOperationInvokerGenerator)'==''">true</EnableCoreWCFOperationInvokerGenerator>
+    <!-- Default the OperationInvokerGenerator to enabled only on TFMs where the SDK's default C#
+         language version is >= 11 (the version required by the generator's emitted 'file' types and
+         '[ModuleInitializer]'). That is .NETCoreApp 7.0 and later. .NETFramework, .NETStandard, and
+         older .NETCoreApp targets remain off-by-default and use the reflection-based fallback at
+         runtime. Consumers on those targets can still opt in by explicitly setting
+         EnableCoreWCFOperationInvokerGenerator=true and raising LangVersion to 11 or higher. -->
+    <EnableCoreWCFOperationInvokerGenerator Condition="'$(EnableCoreWCFOperationInvokerGenerator)'=='' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion.TrimStart('v')), '7.0'))">true</EnableCoreWCFOperationInvokerGenerator>
+    <EnableCoreWCFOperationInvokerGenerator Condition="'$(EnableCoreWCFOperationInvokerGenerator)'==''">false</EnableCoreWCFOperationInvokerGenerator>
   </PropertyGroup>
   <ItemGroup>
     <!-- Exposes EnableCoreWCFOperationInvokerGenerator to the source generator at build time -->

--- a/src/CoreWCF.Templates/Clean-Run.ps1
+++ b/src/CoreWCF.Templates/Clean-Run.ps1
@@ -4,6 +4,19 @@ $TestTemplatesPath = [IO.Path]::Combine($SourceDir, 'TestTemplates')
 if (Test-Path $TestTemplatesPath) {
   Remove-Item -Path $TestTemplatesPath -Recurse -Force -ErrorAction Ignore 
 }
+# Remove the sentinel MSBuild files dropped by Prepare-Run.ps1 to isolate the template source from the
+# repo-root Directory.Build.props/targets/Packages.props during packing.
+$TemplatesRoot = [IO.Path]::Combine($PSScriptRoot, 'src', 'templates')
+$TemplateSentinels = @(
+  [IO.Path]::Combine($TemplatesRoot, 'Directory.Build.props'),
+  [IO.Path]::Combine($TemplatesRoot, 'Directory.Build.targets'),
+  [IO.Path]::Combine($TemplatesRoot, 'Directory.Packages.props')
+)
+foreach ($sentinel in $TemplateSentinels) {
+  if (Test-Path $sentinel) {
+    Remove-Item -Path $sentinel -Force -ErrorAction Ignore
+  }
+}
 # Uninstall CoreWCF.Templates
 dotnet new uninstall CoreWCF.Templates
 # Delete the temporary feed added above

--- a/src/CoreWCF.Templates/Prepare-Run.ps1
+++ b/src/CoreWCF.Templates/Prepare-Run.ps1
@@ -86,4 +86,4 @@ Set-Location $PSScriptRoot
 Invoke-Checked { dotnet build $SourceDir/src/CoreWCF.Templates/src/CoreWCF.Templates.csproj } 'Failed to build CoreWCF.Templates'
 Invoke-Checked { dotnet pack $SourceDir/src/CoreWCF.Templates/src/CoreWCF.Templates.csproj -o $ArtifactsPath /p:IncludeSymbols=false } 'Failed to pack CoreWCF.Templates'
 # Install CoreWCF.Templates locally
-Invoke-Checked { dotnet new install CoreWCF.Templates::$version --nuget-source $ArtifactsPath } 'Failed to install CoreWCF.Templates'
+Invoke-Checked { dotnet new install CoreWCF.Templates@$version --nuget-source $ArtifactsPath } 'Failed to install CoreWCF.Templates'

--- a/src/CoreWCF.Templates/Prepare-Run.ps1
+++ b/src/CoreWCF.Templates/Prepare-Run.ps1
@@ -1,3 +1,13 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Checked {
+  param([Parameter(Mandatory)][scriptblock] $Action, [string] $Message)
+  & $Action
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Message (exit code $LASTEXITCODE)"
+  }
+}
+
 # Create required files & folders hierarchy
 $SourceDir = [IO.Path]::GetFullPath([IO.Path]::Combine($PSScriptRoot, '..', '..'))
 $TestTemplatesPath = [IO.Path]::Combine($SourceDir, 'TestTemplates')
@@ -10,29 +20,52 @@ New-Item -Path $ArtifactsPath -ItemType "directory" -Force
 $DirectoryBuildPropsContent = '<Project></Project>'
 $DirectoryBuildPropsContent | Out-File $TestTemplatesPath/Directory.Build.props
 $DirectoryBuildTargetsContent = '<Project></Project>'
-$DirectoryBuildTargetsContent | Out-File $TestTemplatesPath/Directory.Build.target
+$DirectoryBuildTargetsContent | Out-File $TestTemplatesPath/Directory.Build.targets
 $DirectoryPackagesPropsContent = '<Project></Project>'
 $DirectoryPackagesPropsContent | Out-File $TestTemplatesPath/Directory.Packages.props
 $NuGetConfigPath = [IO.Path]::Combine($SourceDir, 'NuGet.config')
 Copy-Item $NuGetConfigPath -Destination $TestTemplatesPath
-# Add a local nuget feed to publish current code packages
+
+# Drop sentinel MSBuild files alongside the in-repo template csproj so that `dotnet add package` and
+# `dotnet pack` operate on the template as if it were an independent project, isolated from the repo's
+# Directory.Build.props/targets and (most importantly) Directory.Packages.props. Without this, Central
+# Package Management inherited from the repo root rejects `dotnet add package -v <version>` and the
+# template ships referencing `1.*` from nuget.org instead of the locally-built pre-release packages.
+$TemplatesRoot = [IO.Path]::Combine($PSScriptRoot, 'src', 'templates')
+$TemplateSentinels = @(
+  [IO.Path]::Combine($TemplatesRoot, 'Directory.Build.props'),
+  [IO.Path]::Combine($TemplatesRoot, 'Directory.Build.targets'),
+  [IO.Path]::Combine($TemplatesRoot, 'Directory.Packages.props')
+)
+foreach ($sentinel in $TemplateSentinels) {
+  '<Project></Project>' | Out-File -FilePath $sentinel -Encoding utf8
+}
+
+# Add a local nuget feed to publish current code packages. Remove first in case a prior interrupted
+# run left it registered (the script now fails fast on errors, so we make this step idempotent).
 $NugetFeedName = 'CoreWCFTemplates-Feed'
-dotnet nuget add source $ArtifactsPath -n $NugetFeedName
+dotnet nuget remove source $NugetFeedName 2>$null | Out-Null
+$global:LASTEXITCODE = 0
+Invoke-Checked { dotnet nuget add source $ArtifactsPath -n $NugetFeedName } 'Failed to add CoreWCFTemplates-Feed nuget source'
 # Store current code version in $version
-dotnet tool install --tool-path . nbgv
+Invoke-Checked { dotnet tool install --tool-path . nbgv } 'Failed to install nbgv tool'
 $version = ./nbgv get-version -v NugetPackageVersion
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($version)) {
+  throw "nbgv failed to produce a NugetPackageVersion (exit code $LASTEXITCODE)"
+}
 # package current runtime code in local nuget feed
-dotnet pack $SourceDir/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj -o $ArtifactsPath /p:IncludeSymbols=false
-dotnet pack $SourceDir/src/CoreWCF.Http/src/CoreWCF.Http.csproj -o $ArtifactsPath /p:IncludeSymbols=false
-# install runtime assemblies in TemplatedProject
+Invoke-Checked { dotnet pack $SourceDir/src/CoreWCF.Primitives/src/CoreWCF.Primitives.csproj -o $ArtifactsPath /p:IncludeSymbols=false } 'Failed to pack CoreWCF.Primitives'
+Invoke-Checked { dotnet pack $SourceDir/src/CoreWCF.Http/src/CoreWCF.Http.csproj -o $ArtifactsPath /p:IncludeSymbols=false } 'Failed to pack CoreWCF.Http'
+# install runtime assemblies in TemplatedProject. The CoreWCFTemplates-Feed source added above is
+# globally registered in the user's NuGet config, so 'dotnet add package' can resolve the locally
+# packed pre-release versions while still pulling transitive dependencies from upstream feeds.
 $TemplatedProjectPath = [IO.Path]::Combine($PSScriptRoot, 'src', 'templates', 'CoreWCFService')
 Set-Location $TemplatedProjectPath
-dotnet nuget add source $ArtifactsPath -n $NugetFeedName
-dotnet add package CoreWCF.Primitives -v $version
-dotnet add package CoreWCF.Http -v $version
+Invoke-Checked { dotnet add package CoreWCF.Primitives -v $version } 'Failed to add CoreWCF.Primitives package reference to template'
+Invoke-Checked { dotnet add package CoreWCF.Http -v $version } 'Failed to add CoreWCF.Http package reference to template'
 Set-Location $PSScriptRoot
 # Pack current code (templates) into the nuget feed
-dotnet build $SourceDir/src/CoreWCF.Templates/src/CoreWCF.Templates.csproj
-dotnet pack $SourceDir/src/CoreWCF.Templates/src/CoreWCF.Templates.csproj -o $ArtifactsPath /p:IncludeSymbols=false
+Invoke-Checked { dotnet build $SourceDir/src/CoreWCF.Templates/src/CoreWCF.Templates.csproj } 'Failed to build CoreWCF.Templates'
+Invoke-Checked { dotnet pack $SourceDir/src/CoreWCF.Templates/src/CoreWCF.Templates.csproj -o $ArtifactsPath /p:IncludeSymbols=false } 'Failed to pack CoreWCF.Templates'
 # Install CoreWCF.Templates locally
-dotnet new install CoreWCF.Templates::$version --nuget-source $ArtifactsPath
+Invoke-Checked { dotnet new install CoreWCF.Templates::$version --nuget-source $ArtifactsPath } 'Failed to install CoreWCF.Templates'

--- a/src/CoreWCF.Templates/Prepare-Run.ps1
+++ b/src/CoreWCF.Templates/Prepare-Run.ps1
@@ -23,8 +23,26 @@ $DirectoryBuildTargetsContent = '<Project></Project>'
 $DirectoryBuildTargetsContent | Out-File $TestTemplatesPath/Directory.Build.targets
 $DirectoryPackagesPropsContent = '<Project></Project>'
 $DirectoryPackagesPropsContent | Out-File $TestTemplatesPath/Directory.Packages.props
-$NuGetConfigPath = [IO.Path]::Combine($SourceDir, 'NuGet.config')
-Copy-Item $NuGetConfigPath -Destination $TestTemplatesPath
+# Write a NuGet.config that exposes the locally-built CoreWCF packages alongside the upstream feeds.
+# We deliberately do not copy the repo's NuGet.config because it <clear />s sources without re-adding
+# the local Artifacts feed - so any restore that relies on the inherited config would miss the
+# pre-release packages we just packed. The test harness used to compensate by passing `-s` flags to
+# `dotnet restore`, but mixing a local Windows path with HTTPS URLs in `dotnet restore -s` is broken
+# on Windows (NuGet treats the URLs as relative paths -> NU1301). Putting all sources here lets every
+# `dotnet new`/`dotnet restore` invocation pick them up via the inherited config instead.
+$ArtifactsPathForXml = [System.Security.SecurityElement]::Escape($ArtifactsPath)
+$NuGetConfigContent = @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="CoreWCFTemplates-LocalArtifacts" value="$ArtifactsPathForXml" />
+    <add key="CoreWCF-AzureDevOps" value="https://pkgs.dev.azure.com/dotnet/CoreWCF/_packaging/CoreWCF/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+"@
+$NuGetConfigContent | Out-File -FilePath ([IO.Path]::Combine($TestTemplatesPath, 'NuGet.config')) -Encoding utf8
 
 # Drop sentinel MSBuild files alongside the in-repo template csproj so that `dotnet add package` and
 # `dotnet pack` operate on the template as if it were an independent project, isolated from the repo's

--- a/src/CoreWCF.Templates/Run-Templates-UnitTests.ps1
+++ b/src/CoreWCF.Templates/Run-Templates-UnitTests.ps1
@@ -1,5 +1,5 @@
-Invoke-Expression -Command $PSScriptRoot/Prepare-Run.ps1
 try {
+  Invoke-Expression -Command $PSScriptRoot/Prepare-Run.ps1
   # Run unit tests
   dotnet test $PSScriptRoot/tests/CoreWCF.Templates.Tests.csproj
   Exit $LastExitCode

--- a/src/CoreWCF.Templates/src/CoreWCF.Templates.csproj
+++ b/src/CoreWCF.Templates/src/CoreWCF.Templates.csproj
@@ -17,6 +17,7 @@
     <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" CopyToOutputDirectory="Always" />
     <Content Remove="templates\Directory.Build.props"/>
     <Content Remove="templates\Directory.Build.targets"/>
+    <Content Remove="templates\Directory.Packages.props"/>
     <Content Remove="templates\.editorconfig"/>
   </ItemGroup>
   <!-- Do not compile the templated code -->

--- a/src/CoreWCF.Templates/src/templates/CoreWCFService/CoreWCFService.csproj
+++ b/src/CoreWCF.Templates/src/templates/CoreWCFService/CoreWCFService.csproj
@@ -9,6 +9,11 @@
     <!--#endif-->
     <!--#if(enableOperationInvokerGenerator)-->
     <EnableCoreWCFOperationInvokerGenerator>true</EnableCoreWCFOperationInvokerGenerator>
+    <!--#endif-->
+    <!--#if(isNetFramework)-->
+    <!-- The CoreWCF OperationInvokerGenerator emits C# 11 ('file' types) and C# 9 ('module initializers')
+         code. The .NET SDK defaults LangVersion to 7.3 when targeting .NET Framework, so raise it here so
+         the generated code compiles on net4xx targets. -->
     <LangVersion>Latest</LangVersion>
     <!--#endif-->
   </PropertyGroup>

--- a/src/CoreWCF.Templates/src/templates/CoreWCFService/CoreWCFService.csproj
+++ b/src/CoreWCF.Templates/src/templates/CoreWCFService/CoreWCFService.csproj
@@ -30,7 +30,7 @@
   <!--#endif-->
   <ItemGroup>
     <!--#if(isNetFramework)-->
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.3.9" />
     <!--#endif-->
     <PackageReference Include="CoreWCF.Primitives" Version="1.*" />
     <PackageReference Include="CoreWCF.Http" Version="1.*" />

--- a/src/CoreWCF.Templates/tests/Shared/Project.cs
+++ b/src/CoreWCF.Templates/tests/Shared/Project.cs
@@ -119,9 +119,19 @@ public class Project : IDisposable
     {
         Output.WriteLine("Restoring packages...");
 
-        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $@"restore -v detailed --force --force-evaluate -s https://pkgs.dev.azure.com/dotnet/CoreWCF/_packaging/CoreWCF/nuget/v3/index.json -s https://api.nuget.org/v3/index.json");
+        // Include the local Artifacts feed (populated by Prepare-Run.ps1) alongside the upstream feeds so
+        // the locally-built CoreWCF pre-release packages referenced by the generated csproj are restorable.
+        var localFeed = GetLocalArtifactsFeedPath();
+        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $@"restore -v detailed --force --force-evaluate -s ""{localFeed}"" -s https://pkgs.dev.azure.com/dotnet/CoreWCF/_packaging/CoreWCF/nuget/v3/index.json -s https://api.nuget.org/v3/index.json");
         await result.Exited;
         return new ProcessResult(result);
+    }
+
+    private static string GetLocalArtifactsFeedPath()
+    {
+        var testTemplatesPath = typeof(Project).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(a => a.Key == "TestTemplatesPath").Value;
+        return Path.Combine(testTemplatesPath, "Artifacts");
     }
 
     internal async Task<ProcessResult> RunDotNetPublishAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool noRestore = true)

--- a/src/CoreWCF.Templates/tests/Shared/Project.cs
+++ b/src/CoreWCF.Templates/tests/Shared/Project.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Internal;
@@ -119,19 +117,14 @@ public class Project : IDisposable
     {
         Output.WriteLine("Restoring packages...");
 
-        // Include the local Artifacts feed (populated by Prepare-Run.ps1) alongside the upstream feeds so
-        // the locally-built CoreWCF pre-release packages referenced by the generated csproj are restorable.
-        var localFeed = GetLocalArtifactsFeedPath();
-        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $@"restore -v detailed --force --force-evaluate -s ""{localFeed}"" -s https://pkgs.dev.azure.com/dotnet/CoreWCF/_packaging/CoreWCF/nuget/v3/index.json -s https://api.nuget.org/v3/index.json");
+        // Sources are configured via the NuGet.config that Prepare-Run.ps1 drops at TestTemplatesPath
+        // (which the generated project under BaseFolder/<name> inherits). Do NOT pass `-s` flags here:
+        // on Windows, `dotnet restore -s <localPath> -s <https-url> ...` causes NuGet's MSBuild
+        // RestoreSources parser to treat the URLs as relative paths (NU1301), because the URL-encoded
+        // values are never decoded back to a valid Uri before path resolution kicks in.
+        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), "restore -v detailed --force --force-evaluate");
         await result.Exited;
         return new ProcessResult(result);
-    }
-
-    private static string GetLocalArtifactsFeedPath()
-    {
-        var testTemplatesPath = typeof(Project).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
-            .Single(a => a.Key == "TestTemplatesPath").Value;
-        return Path.Combine(testTemplatesPath, "Artifacts");
     }
 
     internal async Task<ProcessResult> RunDotNetPublishAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool noRestore = true)


### PR DESCRIPTION
The template tests recently regressed on Windows for net4xx variations with CS8370 errors (C# 'file types' / 'module initializers' not available in C# 7.3). Two underlying issues caused this:

1. CoreWCF.Primitives 1.9.0 began defaulting EnableCoreWCFOperationInvokerGenerator to true for all consumers. The generator emits C# 11 'file' types and '[ModuleInitializer]', but the .NET SDK defaults LangVersion to 7.3 for .NETFramework targets (and to lower-than-11 for .NETStandard, net5.0, net6.0). Default-on with no LangVersion bump produces uncompilable code for those targets.

2. Prepare-Run.ps1's `dotnet add package -v <version>` calls have been silently failing since Central Package Management was enabled at the repo root (CPM rejects versions on PackageReference items). The script ignored exit codes, so the template was packed referencing the wildcard version and the tests have been pulling whatever's on nuget.org instead of the locally-built bits.

Fixes:

- CoreWCF.Primitives.targets: Default EnableCoreWCFOperationInvokerGenerator to true only on .NETCoreApp 7.0 or later (where the SDK default LangVersion is at least 11). All other TFMs default to false and use the existing reflection-based fallback. Consumers can still opt in explicitly on older targets by raising LangVersion themselves.

- CoreWCFService.csproj template: emit <LangVersion>Latest</LangVersion>
  whenever isNetFramework is true (was previously gated on enableOperationInvokerGenerator), so net4xx projects created from the template can compile generator output when the user opts in.

- Prepare-Run.ps1:
  * Add fail-fast error handling ($ErrorActionPreference='Stop' plus an Invoke-Checked wrapper around every dotnet call).
  * Drop empty sentinel Directory.Build.props/targets/Packages.props files at src/CoreWCF.Templates/src/templates/ before mutating the template csproj, so MSBuild stops walking upward and doesn't inherit the repo-root CPM. This unblocks `dotnet add package -v`.
  * Make `dotnet nuget add source` idempotent.
  * Remove the duplicate `dotnet nuget add source` call that was erroring.
  * Fix pre-existing typo: Directory.Build.target -> .targets.

- Clean-Run.ps1: remove the new template-source sentinel files.

- Run-Templates-UnitTests.ps1: move Prepare-Run inside the try block so Clean-Run still runs if Prepare-Run throws partway through.

- CoreWCF.Templates.csproj: exclude the new Directory.Packages.props sentinel from template package content.

- Project.cs (test helper): include the local Artifacts feed in the test's `dotnet restore -s` invocation so the locally-built pre-release packages referenced by the generated csproj can be resolved.