### PR TITLE
Fix multiple test failures

### DIFF
--- a/src/CoreWCF.Kafka/tests/DeadLetterQueueTests.cs
+++ b/src/CoreWCF.Kafka/tests/DeadLetterQueueTests.cs
@@ -67,10 +67,17 @@ public class DeadLetterQueueTests : IntegrationTest
             Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(3)));
             Assert.True(testService.CountdownEvent.Wait(TimeSpan.FromSeconds(10)));
             Assert.Single(testService.Names);
-        }
 
-        await AssertEx.RetryAsync(() => Assert.Equal(0, KafkaEx.GetConsumerLag(Output, ConsumerGroup, Topic)));
-        await AssertEx.RetryAsync(() => Assert.Equal(1, KafkaEx.GetMessageCount(Output, DeadLetterQueueTopic)));
+            // Verify DLQ delivery and that all messages have been committed before
+            // leaving the using block (which disposes the host). The Throw handler
+            // does not signal CountdownEvent, so the second message may still be in
+            // flight when CountdownEvent.Wait returns; on a heavily loaded CI host
+            // it can still be mid-dispatch when the host begins shutdown. Waiting
+            // here keeps the host alive until the pipeline has finished processing
+            // the second message and produced it to the DLQ.
+            await AssertEx.RetryAsync(() => Assert.Equal(1, KafkaEx.GetMessageCount(Output, DeadLetterQueueTopic)));
+            await AssertEx.RetryAsync(() => Assert.Equal(0, KafkaEx.GetConsumerLag(Output, ConsumerGroup, Topic)));
+        }
     }
 
     [LinuxWhenCIOnlyFact]
@@ -98,10 +105,17 @@ public class DeadLetterQueueTests : IntegrationTest
             Assert.Contains(name, testService.Names);
 
             await Task.Factory.FromAsync(((System.ServiceModel.ICommunicationObject)(channel)).BeginClose(null, null), new Action<IAsyncResult>(((System.ServiceModel.ICommunicationObject)(channel)).EndClose));
-        }
 
-        await AssertEx.RetryAsync(() => Assert.Equal(0, KafkaEx.GetConsumerLag(Output, ConsumerGroup, Topic)));
-        await AssertEx.RetryAsync(() => Assert.Equal(1, KafkaEx.GetMessageCount(Output, DeadLetterQueueTopic)));
+            // Verify DLQ delivery and that all messages have been committed before
+            // leaving the using block (which disposes the host). The Throw handler
+            // does not signal CountdownEvent, so the second message may still be in
+            // flight when CountdownEvent.Wait returns; on a heavily loaded CI host
+            // it can still be mid-dispatch when the host begins shutdown. Waiting
+            // here keeps the host alive until the pipeline has finished processing
+            // the second message and produced it to the DLQ.
+            await AssertEx.RetryAsync(() => Assert.Equal(1, KafkaEx.GetMessageCount(Output, DeadLetterQueueTopic)));
+            await AssertEx.RetryAsync(() => Assert.Equal(0, KafkaEx.GetConsumerLag(Output, ConsumerGroup, Topic)));
+        }
     }
 
     private class Startup

--- a/src/CoreWCF.Primitives/tests/TelemetryTests.cs
+++ b/src/CoreWCF.Primitives/tests/TelemetryTests.cs
@@ -29,15 +29,24 @@ public class TelemetryTests
         var startedActivities = new ConcurrentBag<Activity>();
         var stoppedActivities = new ConcurrentBag<Activity>();
 
+        // ShouldListenTo must be set to its final predicate before AddActivityListener is called.
+        // ActivitySource attaches a listener at AddActivityListener time (for existing sources) and at
+        // ActivitySource construction time (for sources created later). In both cases ShouldListenTo is
+        // evaluated only once per (listener, source) pair; mutating ShouldListenTo afterwards does NOT
+        // retroactively attach the listener to an already-existing source. The static
+        // WcfInstrumentationActivitySource.ActivitySource may be initialized by a concurrent test
+        // (e.g. DispatchBuilderTests in the default xUnit collection) before this test reaches
+        // AddActivityListener, so a "_ => false" predicate at that moment would permanently prevent
+        // attachment regardless of subsequent updates. Filtering by the unique DisplayName below
+        // ensures activities created by concurrent tests do not interfere with the assertions.
         using var listener = new ActivityListener
         {
-            ShouldListenTo = _ => false,
+            ShouldListenTo = activitySource => activitySource.Name == "CoreWCF.Primitives",
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
             ActivityStarted = activity => startedActivities.Add(activity),
             ActivityStopped = activity => stoppedActivities.Add(activity)
         };
 
-        string actionSuffix = "TelemetryTest";
         string serviceAddress = "http://localhost/dummy";
         var services = new ServiceCollection();
         services.AddLogging();
@@ -67,22 +76,31 @@ public class TelemetryTests
         var requestContext = TestRequestContext.Create(serviceAddress, telemetryEchoAction);
 
         ActivitySource.AddActivityListener(listener);
-        listener.ShouldListenTo = activitySource => activitySource.Name == "CoreWCF.Primitives";
         await dispatcher.DispatchAsync(requestContext);
-        listener.ShouldListenTo = _ => false;
         Assert.True(await requestContext.WaitForReplyAsync(TestContext.Current.CancellationToken), "Dispatcher didn't send reply");
         requestContext.ValidateReply(telemetryEchoAction + "Response");
 
-        // Other tests running in parallel may have started activities, so we filter for the specific activity we expect
-        // and verify there's only one of the activity we expect.
-        CancellationTokenSource timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
-        using (var registration = TestContext.Current.CancellationToken.Register(() => timeoutCts.Cancel()))
+        // ActivityStarted/ActivityStopped callbacks run synchronously inside Activity.Start()/Stop(),
+        // and CoreWCF stops the activity before sending the reply, so by the time WaitForReplyAsync
+        // returns the activity should already be in the bags. Poll briefly with the test cancellation
+        // token in case there is any small async window on a heavily loaded machine. If the activity
+        // is genuinely missing this fails fast with an explicit message rather than a TaskCanceledException.
+        using var pollCts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        pollCts.CancelAfter(TimeSpan.FromSeconds(30));
+        try
         {
-            while (!startedActivities.Any(a => a.DisplayName == telemetryEchoAction) && !stoppedActivities.Any(a => a.DisplayName == telemetryEchoAction))
+            while (!stoppedActivities.Any(a => a.DisplayName == telemetryEchoAction))
             {
-                await Task.Delay(100, timeoutCts.Token);
+                await Task.Delay(50, pollCts.Token);
             }
         }
+        catch (OperationCanceledException) when (pollCts.IsCancellationRequested && !TestContext.Current.CancellationToken.IsCancellationRequested)
+        {
+            Assert.Fail($"No Activity with DisplayName '{telemetryEchoAction}' was captured within 30s. " +
+                $"Started count: {startedActivities.Count}, Stopped count: {stoppedActivities.Count}. " +
+                "This usually indicates the ActivityListener was not attached to the CoreWCF.Primitives ActivitySource.");
+        }
+
         var startedActivity = Assert.Single(startedActivities, a => a.DisplayName == telemetryEchoAction);
         var stoppedActivity = Assert.Single(stoppedActivities, a => a.DisplayName == telemetryEchoAction);
 

--- a/templates/TestStage.yml
+++ b/templates/TestStage.yml
@@ -102,7 +102,6 @@ stages:
         name: SetupIISExpressCertificates
         displayName: Setup IIS Express certificates for HTTPS tests
         condition: eq(variables.imageName, 'windows-latest')
-        continueOnError: true
         timeoutInMinutes: 2
 
       - bash: |


### PR DESCRIPTION
### Fix race condition in TelemetryTests.Basic_Telemetry_Test
The test was registering an ActivityListener with ShouldListenTo => false and updating the predicate after AddActivityListener. This relied on the static WcfInstrumentationActivitySource.ActivitySource not yet being constructed: ActivitySource only evaluates ShouldListenTo when a listener is attached (in AddActivityListener for existing sources or in the source constructor for sources created later). Mutating the predicate afterwards does not retroactively attach the listener to an already-existing source.

On slow CI machines (2 cores) with high test parallelism, a concurrent test in DispatchBuilderTests (in the default xUnit collection) could lazy-initialize the static ActivitySource before TelemetryTests reached AddActivityListener, permanently preventing the listener from attaching. The activity created by the dispatch was then never observed and the 60s wait loop timed out with TaskCanceledException.

Fix:
- Set ShouldListenTo to its final predicate before AddActivityListener so the listener attaches regardless of source initialization order. The test already filters captured activities by a unique DisplayName, so activities from concurrent dispatches do not interfere.
- Remove the post-dispatch ShouldListenTo = _ => false assignment which was misleading; it does not detach an already-attached listener.
- Replace the 60s polling loop with a 30s linked-token loop that reports an explicit Assert.Fail on timeout instead of bubbling a generic TaskCanceledException, so future regressions diagnose more easily.

---
### Make Kafka DeadLetterQueueTests robust under CPU contention
Both KafkaProducerTest and KafkaClientBindingTest send two messages: a Create message that succeeds and a Throw message that is expected to fail and end up in the dead-letter queue. The test waits on a CountdownEvent of 1, which is signalled only by the Create handler — the Throw handler just throws. Once Create finishes, the test exits the using(host) block while the Throw message can still be in flight.

On heavily-loaded CI hardware (the Azure DevOps agents are 2-core machines running many parallel test collections), the Throw message can still be mid-dispatch when host disposal begins, so the post-using `Assert.Equal(1, GetMessageCount(...))` assertion can intermittently observe 0 messages in the DLQ and time out.  

Fix the test by moving the DLQ count and consumer-lag assertions inside the using(host) block. While the host is still alive the pipeline processes the Throw message normally and produces the DLQ message before control leaves the using block to dispose the host. This eliminates the
race entirely without changing any production code.

---
### Fail Test job when IIS Express certificate setup fails
The Setup IIS Express certificates for HTTPS tests step had continueOnError: true, which means a failure to provision the localhost HTTPS certificate was downgraded to a warning and the job continued. The subsequent HTTPS tests then failed with confusing TLS errors instead of
pointing at the real cause.

Drop continueOnError so the step's exit code propagates and the job (and therefore the stage) fails fast on this prerequisite.