### PR TITLE
Prevent IOThreadTimer from delaying process exit on Linux (#1122)

### DIFF
--- a/src/Common/src/CoreWCF/Runtime/IOThreadScheduler.cs
+++ b/src/Common/src/CoreWCF/Runtime/IOThreadScheduler.cs
@@ -680,7 +680,16 @@ namespace CoreWCF.Runtime
 
             private void PostNewThread()
             {
-                var thread = new Thread(new ThreadStart(Callback));
+                // The waiter thread used on non-Windows platforms must be a background thread,
+                // otherwise it keeps the process alive until WaitAny returns, which can take
+                // up to the longest IOThreadTimer due time (default session idle timeout is
+                // measured in minutes). Background threads are torn down by the runtime when
+                // the process exits, mirroring the Windows IOCP behavior where the equivalent
+                // work runs on thread-pool threads (which are background by default).
+                var thread = new Thread(new ThreadStart(Callback))
+                {
+                    IsBackground = true,
+                };
                 thread.Start();
             }
 


### PR DESCRIPTION
On non-Windows, IOThreadScheduler hosts its waiter on a managed thread created with `new Thread(...)`, which defaults to a foreground thread. IOThreadTimer.TimerManager.OnWaitCallback runs on that thread and blocks in WaitableTimer.WaitAny for up to the longest scheduled timer (e.g. the default 60s session idle timeout). On Linux this keeps the process alive long after Main returns and the host has stopped.

Mark the waiter thread as a background thread so the runtime tears it down at process exit, matching the Windows IOCP path where the equivalent work runs on thread-pool threads (which are background by default).

No unit test is added: the symptom is process-exit timing, which the xUnit host can't observe, and concurrent tests share the process so we would never get a clean measurement. Verified manually with a WSL repro: post-MAIN_RETURN lingering dropped from ~59,500ms to a few ms.

Fixes #1361