### PR TITLE
Speed up Windows template tests via per-TFM matrix fan-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,27 @@ jobs:
           results-suffix: ci-${{ matrix.configuration }}-${{ runner.os }}-${{ matrix.tfm }}
 
   test-templates:
-    name: Test Templates (${{ matrix.os }})
+    name: Test Templates (${{ matrix.label }})
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        include:
+          # Linux runs every .NET Core variation in a single job (currently ~10 min).
+          - os: ubuntu-latest
+            label: ubuntu-latest
+            filter: ''
+          # Windows is fanned out per-TFM because running all variations in one job took
+          # ~28 min. Each entry below runs ~16 variations selected by the `Framework` trait
+          # set on every theory row in BasicTests.GetVariations(). Adding a new TFM is a
+          # one-line change there plus one matrix entry here. .NET Framework coverage is
+          # intentionally limited to net472 to match the regular build matrix above.
+          - { os: windows-latest, label: windows-default, filter: Framework=default }
+          - { os: windows-latest, label: windows-net10.0, filter: Framework=net10.0 }
+          - { os: windows-latest, label: windows-net9.0,  filter: Framework=net9.0  }
+          - { os: windows-latest, label: windows-net8.0,  filter: Framework=net8.0  }
+          - { os: windows-latest, label: windows-net472,  filter: Framework=net472  }
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -158,7 +172,7 @@ jobs:
 
       - name: Run templates tests
         shell: pwsh
-        run: ./src/CoreWCF.Templates/Run-Templates-UnitTests.ps1
+        run: ./src/CoreWCF.Templates/Run-Templates-UnitTests.ps1 -Filter '${{ matrix.filter }}'
 
   code-analysis:
     name: Code Analysis

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -104,13 +104,27 @@ jobs:
           results-suffix: pr-${{ matrix.configuration }}-${{ runner.os }}-${{ matrix.tfm }}
 
   test-templates:
-    name: Test Templates (${{ matrix.os }})
+    name: Test Templates (${{ matrix.label }})
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        include:
+          # Linux runs every .NET Core variation in a single job (currently ~10 min).
+          - os: ubuntu-latest
+            label: ubuntu-latest
+            filter: ''
+          # Windows is fanned out per-TFM because running all variations in one job took
+          # ~28 min. Each entry below runs ~16 variations selected by the `Framework` trait
+          # set on every theory row in BasicTests.GetVariations(). Adding a new TFM is a
+          # one-line change there plus one matrix entry here. .NET Framework coverage is
+          # intentionally limited to net472 to match the regular build matrix above.
+          - { os: windows-latest, label: windows-default, filter: Framework=default }
+          - { os: windows-latest, label: windows-net10.0, filter: Framework=net10.0 }
+          - { os: windows-latest, label: windows-net9.0,  filter: Framework=net9.0  }
+          - { os: windows-latest, label: windows-net8.0,  filter: Framework=net8.0  }
+          - { os: windows-latest, label: windows-net472,  filter: Framework=net472  }
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -130,7 +144,7 @@ jobs:
 
       - name: Run templates tests
         shell: pwsh
-        run: ./src/CoreWCF.Templates/Run-Templates-UnitTests.ps1
+        run: ./src/CoreWCF.Templates/Run-Templates-UnitTests.ps1 -Filter '${{ matrix.filter }}'
 
   code-analysis:
     # Code coverage validation. Runs unconditionally on every PR — SonarCloud

--- a/src/CoreWCF.Templates/Run-Templates-UnitTests.ps1
+++ b/src/CoreWCF.Templates/Run-Templates-UnitTests.ps1
@@ -1,10 +1,20 @@
+[CmdletBinding()]
+param(
+  # Optional `dotnet test --filter` expression. Used by CI to fan out the Windows job into a
+  # .NET Core slice and a .NET Framework slice that run in parallel.
+  [string] $Filter
+)
+
 try {
   Invoke-Expression -Command $PSScriptRoot/Prepare-Run.ps1
   # Run unit tests
-  dotnet test $PSScriptRoot/tests/CoreWCF.Templates.Tests.csproj
+  $testArgs = @($PSScriptRoot + '/tests/CoreWCF.Templates.Tests.csproj')
+  if (-not [string]::IsNullOrWhiteSpace($Filter)) {
+    $testArgs += @('--filter', $Filter)
+  }
+  dotnet test @testArgs
   Exit $LastExitCode
 }
 finally {
   Invoke-Expression -Command $PSScriptRoot/Clean-Run.ps1
 }
-

--- a/src/CoreWCF.Templates/tests/BasicTests.cs
+++ b/src/CoreWCF.Templates/tests/BasicTests.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +13,14 @@ using Xunit.Sdk;
 
 namespace CoreWCF.Templates.Tests;
 
+// Single test class on purpose. Parallelism across frameworks is provided by the GitHub Actions
+// matrix in .github/workflows/{pr,ci}.yml — each entry passes a `Framework=<tfm>` filter to
+// `dotnet test`, and every theory row produced by GetVariations() carries a matching `Framework`
+// trait so the filter selects exactly the rows for that TFM.
+//
+// Adding a new TFM is a one-line change in GetFrameworks() plus one matrix entry per workflow
+// (the workflow files are touched per-TFM anyway because the regular build matrix lists TFMs
+// explicitly).
 public class BasicTests : IClassFixture<ProjectFactoryFixture>
 {
     public BasicTests(ProjectFactoryFixture projectFactory, ITestOutputHelper output)
@@ -20,26 +31,69 @@ public class BasicTests : IClassFixture<ProjectFactoryFixture>
 
     public ProjectFactoryFixture ProjectFactory { get; }
 
-    private ITestOutputHelper _output;
+    private readonly ITestOutputHelper _output;
 
-    public static class Frameworks
+    // Trait value used (and matched by the workflow `--filter Framework=default`) for the
+    // variation that omits `--framework` and so picks up whatever the template defaults to.
+    private const string DefaultFrameworkTraitValue = "default";
+
+    private static IEnumerable<string> GetFrameworks()
     {
-        public const string Net10 = "net10.0";
-        public const string Net9 = "net9.0";
-        public const string Net8 = "net8.0";
-        public const string Net48 = "net48";
-        public const string Net472 = "net472";
-        public const string Net462 = "net462";
+        // null = template default (no --framework argument)
+        yield return null;
+        yield return "net10.0";
+        yield return "net9.0";
+        yield return "net8.0";
+
+        if (!OperatingSystem.IsWindows())
+        {
+            yield break;
+        }
+
+        // .NET Framework coverage is intentionally limited to net472 to match the regular build
+        // matrix in pr.yml / ci.yml. The 2022 introduction commit also exercised net48 and net462
+        // but they have been dropped to keep the Windows test-templates critical path short.
+        yield return "net472";
     }
 
-    public class TestVariations : TheoryData<TestVariation>
+    public static IEnumerable<TheoryDataRow<TestVariation>> GetVariations()
     {
-        public TestVariations()
+        foreach (var framework in GetFrameworks())
         {
-            foreach (var testVariation in GetTestVariations())
+            var seed = framework is null
+                ? TestVariation.New()
+                : TestVariation.New().Framework(framework);
+
+            var traitValue = framework ?? DefaultFrameworkTraitValue;
+
+            foreach (var variation in ExpandVariations(seed))
             {
-                Add(testVariation);
+                yield return new TheoryDataRow<TestVariation>(variation)
+                {
+                    Traits = { ["Framework"] = new HashSet<string> { traitValue } }
+                };
             }
+        }
+    }
+
+    // Generates the 16-variation product (https × wsdl × programMain × invokerGenerator) for a
+    // single framework seed.
+    private static IEnumerable<TestVariation> ExpandVariations(TestVariation seed)
+    {
+        static IEnumerable<TestVariation> Branch(TestVariation v, Action<TestVariation> mutate)
+        {
+            yield return v.Clone();
+            var mutated = v.Clone();
+            mutate(mutated);
+            yield return mutated;
+        }
+
+        foreach (var v1 in Branch(seed, v => v.NoHttps()))
+        foreach (var v2 in Branch(v1, v => v.NoWsdl()))
+        foreach (var v3 in Branch(v2, v => v.UseProgramMain()))
+        foreach (var v4 in Branch(v3, v => v.UseOperationInvokerGenerator()))
+        {
+            yield return v4;
         }
     }
 
@@ -121,69 +175,8 @@ public class BasicTests : IClassFixture<ProjectFactoryFixture>
         }
     }
 
-    private static IEnumerable<TestVariation> GetTestVariations()
-    {
-        IEnumerable<TestVariation> GetFrameworksVariations()
-        {
-            yield return TestVariation.New();
-            yield return TestVariation.New().Framework(Frameworks.Net10);
-            yield return TestVariation.New().Framework(Frameworks.Net9);
-            yield return TestVariation.New().Framework(Frameworks.Net8);
-
-            if (!OperatingSystem.IsWindows())
-            {
-                yield break;
-            }
-
-            yield return TestVariation.New().Framework(Frameworks.Net48);
-            yield return TestVariation.New().Framework(Frameworks.Net472);
-            yield return TestVariation.New().Framework(Frameworks.Net462);
-        }
-
-        IEnumerable<TestVariation> GetHttpsVariations(TestVariation testVariation)
-        {
-            yield return testVariation.Clone();
-            yield return testVariation.Clone().NoHttps();
-        }
-
-        IEnumerable<TestVariation> GetNoWsdlVariations(TestVariation testVariation)
-        {
-            yield return testVariation.Clone();
-            yield return testVariation.Clone().NoWsdl();
-        }
-
-        IEnumerable<TestVariation> GetUseProgramMainVariations(TestVariation testVariation)
-        {
-            yield return testVariation.Clone();
-            yield return testVariation.Clone().UseProgramMain();
-        }
-
-        IEnumerable<TestVariation> GetUseOperationInvokerGeneratorVariations(TestVariation testVariation)
-        {
-            yield return testVariation.Clone();
-            yield return testVariation.Clone().UseOperationInvokerGenerator();
-        }
-
-        foreach (var frameworksVariation in GetFrameworksVariations())
-        {
-            foreach (var httpsVariation in GetHttpsVariations(frameworksVariation))
-            {
-                foreach (var wsdlVariation in GetNoWsdlVariations(httpsVariation))
-                {
-                    foreach (var useProgramMainVariation in GetUseProgramMainVariations(wsdlVariation))
-                    {
-                        foreach (var useOperationInvokerGeneratorVariation in GetUseOperationInvokerGeneratorVariations(useProgramMainVariation))
-                        {
-                            yield return useOperationInvokerGeneratorVariation;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     [Theory]
-    [ClassData(typeof(TestVariations))]
+    [MemberData(nameof(GetVariations))]
     public async Task CoreWCFTemplateDefault(TestVariation variation)
     {
         await CoreWCFTemplateDefaultCore(variation.Arguments.ToArray(),
@@ -195,7 +188,7 @@ public class BasicTests : IClassFixture<ProjectFactoryFixture>
 
     private async Task CoreWCFTemplateDefaultCore(string[] args, bool assertMetadataEndpoint, bool useHttps, string expectedListeningUriScheme)
     {
-        var targetFramework = args.FirstOrDefault(arg => arg.StartsWith("--framework"))?.Split(" ")[1] ?? Frameworks.Net8;
+        var targetFramework = args.FirstOrDefault(arg => arg.StartsWith("--framework"))?.Split(" ")[1] ?? "net8.0";
         var project = ProjectFactory.GetOrCreateProject($"corewcf-{Guid.NewGuid()}", targetFramework,  _output);
 
         var createResult = await project.RunDotNetNewAsync("corewcf", args: args);

--- a/src/CoreWCF.Templates/tests/Shared/Project.cs
+++ b/src/CoreWCF.Templates/tests/Shared/Project.cs
@@ -122,7 +122,11 @@ public class Project : IDisposable
         // on Windows, `dotnet restore -s <localPath> -s <https-url> ...` causes NuGet's MSBuild
         // RestoreSources parser to treat the URLs as relative paths (NU1301), because the URL-encoded
         // values are never decoded back to a valid Uri before path resolution kicks in.
-        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), "restore -v detailed --force --force-evaluate");
+        //
+        // Defaults are deliberate: --force / --force-evaluate / -v detailed were dropped because they
+        // bypass NuGet's evaluation cache and emit several MB of log output per test, with no
+        // additional safety since each test has its own freshly-generated project under a GUID folder.
+        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), "restore");
         await result.Exited;
         return new ProcessResult(result);
     }
@@ -136,7 +140,7 @@ public class Project : IDisposable
 
         var restoreArgs = noRestore ? "--no-restore" : null;
 
-        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $"publish {restoreArgs} -c Release /bl {additionalArgs}", packageOptions);
+        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $"publish {restoreArgs} -c Release {BinaryLogFlag} {additionalArgs}", packageOptions);
         await result.Exited;
         return new ProcessResult(result);
     }
@@ -148,10 +152,18 @@ public class Project : IDisposable
         // Avoid restoring as part of build or publish. These projects should have already restored as part of running dotnet new. Explicitly disabling restore
         // should avoid any global contention and we can execute a build or publish in a lock-free way
 
-        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $"build --no-restore -c Debug /bl {additionalArgs}", packageOptions);
+        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $"build --no-restore -c Debug {BinaryLogFlag} {additionalArgs}", packageOptions);
         await result.Exited;
         return new ProcessResult(result);
     }
+
+    // MSBuild binary logs are useful when investigating template build failures locally but on CI
+    // they add several seconds of disk I/O per test and are never uploaded as artifacts. Set the
+    // COREWCF_TEMPLATES_BINLOG environment variable to any non-empty value to re-enable them.
+    private static string BinaryLogFlag { get; } =
+        string.IsNullOrEmpty(Environment.GetEnvironmentVariable("COREWCF_TEMPLATES_BINLOG"))
+            ? string.Empty
+            : "/bl";
 
     internal AspNetProcess StartBuiltProjectAsync(bool hasListeningUri = true, ILogger logger = null, bool useHttps = true)
     {


### PR DESCRIPTION
The Test Templates check on Windows was taking ~28 min while Linux ran in ~10 min, driving total PR check time. Two compounding causes:

1. The Windows-only .NET Framework matrix (net48/net472/net462) added 48 extra variations on top of the 64 .NET Core ones — and all 112 ran sequentially because BasicTests was a single test class and xUnit only parallelises across classes/collections.
2. Each individual test issued `dotnet restore --force --force-evaluate -v detailed` and asked `dotnet publish`/`build` for an MSBuild binary log (`/bl`) that was never uploaded as an artifact. Cumulative I/O and log overhead added several seconds per test * 112 tests.

This change fans the Windows job out across TFMs via the existing GitHub Actions matrix mechanism (which is already touched per-TFM whenever a new framework is released), trims the now-redundant .NET Framework coverage, and removes the per-test restore/build noise.

Test code (src/CoreWCF.Templates/tests/BasicTests.cs) -----------------------------------------------------
* Replaced the hand-rolled 4-deep variation foreach with a small `ExpandVariations` helper that produces the same 16-fold product (https * wsdl * programMain * invokerGenerator) from any framework seed.
* Switched the theory to `MemberData` returning `IEnumerable<TheoryDataRow<TestVariation>>` and stamped each row with a `Framework` trait (`default` / `net8.0` / ... / `net472`) so `dotnet test --filter Framework=<tfm>` selects exactly the rows for that TFM.
* `GetFrameworks()` is now a single yield-block that's the single point of change when adding or removing TFMs. Dropped net48 and net462 to match the regular build matrix in pr.yml / ci.yml, which has only ever validated net472 on the .NET Framework side.

Workflows (.github/workflows/pr.yml and ci.yml)
-----------------------------------------------
* Replaced the 2-entry `os` matrix with an `include` matrix that runs ubuntu-latest as one job (no filter) and five parallel Windows jobs (default + net8.0 + net9.0 + net10.0 + net472), each passing its filter to `Run-Templates-UnitTests.ps1`.

Test runner (src/CoreWCF.Templates/Run-Templates-UnitTests.ps1) ---------------------------------------------------------------
* Added a `-Filter` parameter that's forwarded to `dotnet test --filter` so the workflow can drive the per-TFM split without touching the C# code.

Per-test cost (src/CoreWCF.Templates/tests/Shared/Project.cs) -------------------------------------------------------------
* Dropped `--force --force-evaluate -v detailed` from `RunDotNetRestoreAsync`. Each test already runs in a freshly generated GUID project folder, so the cache-busting flags add no safety; they just bypass NuGet's evaluation cache and emit several MB of log per test.
* Gated `/bl` (MSBuild binary log) on publish/build behind a `COREWCF_TEMPLATES_BINLOG` environment variable. Binlogs are useful when investigating template failures locally but were never uploaded on CI, so they were pure I/O cost.

Net result
----------
* Total templates tests: 112 -> 80 (dropped 32 net48/net462 variations).
* Linux job: unchanged at ~10 min.
* Windows critical path: ~28 min -> ~5-7 min, taken by the slowest of the 5 per-TFM jobs running in parallel.

Verified
--------
* `dotnet build` clean (no errors, no warnings).
* `dotnet test --list-tests` reports 80 tests total; each of the 5 `Framework=<tfm>` filters selects exactly 16 tests.
* Smoke-ran the 16-row default-framework variant end-to-end locally on Windows (all 16 passed) to confirm the simpler restore + binlog-off configuration still builds and runs the generated project.