### PR TITLE
CI: pin upstream URL in NuGet packages and signing for private-mirror determinism

### DIFF
--- a/.github/actions/dotnet-build/action.yml
+++ b/.github/actions/dotnet-build/action.yml
@@ -25,6 +25,26 @@ runs:
       shell: bash
       run: ./nbgv cloud --all-vars
 
+    # Pin the git 'origin' URL to the canonical public repo. SourceLink reads
+    # this URL out of the local git remote during the compile that runs in
+    # the build step below, and bakes it into the pdb (as the
+    # raw.githubusercontent.com base URL) and via SourceControlManager into
+    # the nuspec <repository url="..."/> element at pack time. Without this,
+    # packages produced from the public repo and from the private security-
+    # fixes mirror differ by exactly this URL string and our "republish
+    # private packages as the public release" workflow can't produce byte-
+    # identical outputs. The explicit RepositoryUrl in nuspec.props handles
+    # the nuspec, but only this git-level rewrite controls the pdb SourceLink
+    # mapping; SourceLink ignores RepositoryUrl/PrivateRepositoryUrl when
+    # constructing pdb URLs and consults Microsoft.Build.Tasks.Git directly.
+    - name: Pin git origin URL for SourceLink determinism
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "Current 'origin' URL: $(git config --get remote.origin.url || echo '(none)')"
+        git remote set-url origin https://github.com/CoreWCF/CoreWCF
+        echo "Pinned   'origin' URL: $(git config --get remote.origin.url)"
+
     - name: Restore
       shell: bash
       run: dotnet restore "${{ inputs.solution }}" --configfile NuGet.config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
             --file-list "${{ github.workspace }}/signing-config/filelist.txt" `
             --publisher-name "CoreWCF" `
             --description "CoreWCF" `
-            --description-url "https://github.com/${{ github.repository }}" `
+            --description-url "https://github.com/CoreWCF/CoreWCF" `
             --azure-key-vault-certificate "${{ vars.SIGN_KEY_VAULT_CERTIFICATE }}" `
             --azure-key-vault-url "${{ secrets.SIGN_KEY_VAULT_URL }}" `
             -v Trace
@@ -353,7 +353,7 @@ jobs:
             --file-list "${{ github.workspace }}/signing-config/filelist.txt" `
             --publisher-name "CoreWCF" `
             --description "CoreWCF" `
-            --description-url "https://github.com/${{ github.repository }}" `
+            --description-url "https://github.com/CoreWCF/CoreWCF" `
             --azure-key-vault-certificate "${{ vars.SIGN_KEY_VAULT_CERTIFICATE }}" `
             --azure-key-vault-url "${{ secrets.SIGN_KEY_VAULT_URL }}" `
             -v Trace

--- a/nuspec.props
+++ b/nuspec.props
@@ -13,7 +13,21 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <UseFullSemVerForNuGet>true</UseFullSemVerForNuGet>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Pin the repository URL embedded in the nuspec so packages produced
+         from the public repo and from the private security-fixes mirror
+         report the same upstream URL. With PublishRepositoryUrl=true (the
+         pre-existing setting) MSBuild reads this value from whatever git
+         remote SourceLink is configured to use; we'd rather not depend on
+         the build machine's remote config being correct - especially since
+         the private mirror legitimately has a different 'origin'. The
+         SourceLink URL embedded in the pdb is pinned separately by setting
+         the git remote URL up front in .github/actions/dotnet-build, which
+         is the only knob MSBuild's Microsoft.Build.Tasks.Git component
+         respects. Disable PublishRepositoryUrl so MSBuild does not overwrite
+         these, then set them explicitly. -->
+    <PublishRepositoryUrl>false</PublishRepositoryUrl>
+    <RepositoryUrl>https://github.com/CoreWCF/CoreWCF</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
We mirror this repo to a private CoreWCF/PrivateSecurityFixes repo so we can stage security fixes before publishing them publicly. The private mirror's CI is set up to produce NuGet packages that are byte-identical to the public CI's packages, so we can sign+publish the private build directly when a security release is ready, then push the same commits to public and have the artifacts already match.

Three places leak the local repository identity into the build outputs and broke that determinism:

1. nuspec.props sets PublishRepositoryUrl=true, which makes MSBuild read the value of <repository url="..."/> in every nupkg from the local git 'origin' remote at pack time. On the private mirror that resolves to github.com/CoreWCF/PrivateSecurityFixes, on the public repo to github.com/CoreWCF/CoreWCF. Disable PublishRepositoryUrl and set RepositoryUrl/RepositoryType explicitly to the canonical public URL.

2. The pdb embeds a SourceLink URL (raw.githubusercontent.com/<owner>/<repo>/<commit>/*) that is also read from the local git 'origin'. Unlike the nuspec field, SourceLink's URL is computed by Microsoft.Build.Tasks.Git directly from the git remote and ignores RepositoryUrl / PrivateRepositoryUrl. The only reliable way to fix it is to override the git remote URL itself before compile. Add a step to .github/actions/dotnet-build that runs `git remote set-url origin https://github.com/CoreWCF/CoreWCF` immediately before restore/build so the pdb that goes into bin/ (and later into snupkg) embeds the canonical URL.

3. The signing step in ci.yml passes `--description-url "https://github.com/${{ github.repository }}"` to the sign tool, which embeds the running repo's name into the Authenticode timestamped signature attribute. Hardcode it to the canonical public URL.

Verified locally by setting origin to https://github.com/CoreWCF/CoreWCF, rebuilding and repacking CoreWCF.Primitives, and confirming both the nuspec <repository url="..."/> attribute and the
raw.githubusercontent.com URL embedded in the pdb point at CoreWCF/CoreWCF regardless of which clone produced them.