### PR TITLE
Add an internal IBufferWriter<byte> adapter over BufferManager

### DIFF
--- a/src/Common/src/CoreWCF/Channels/BufferManagerBufferWriter.cs
+++ b/src/Common/src/CoreWCF/Channels/BufferManagerBufferWriter.cs
@@ -1,0 +1,293 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+
+namespace CoreWCF.Channels
+{
+    /// <summary>
+    /// An <see cref="IBufferWriter{T}"/> over a <see cref="BufferManager"/>, so buffered write and read
+    /// paths can be expressed with <see cref="Span{T}"/>/<see cref="Memory{T}"/> while the pool the
+    /// transport was configured with stays in charge of the memory.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Single use. There is no <c>Clear</c>/<c>Reinitialize</c>; create one per buffered operation.
+    /// </para>
+    /// <para>
+    /// The instance is in exactly one of three states:
+    /// <list type="bullet">
+    /// <item><description><b>Owning</b> &#8212; it holds a pooled array and owes
+    /// <see cref="BufferManager.ReturnBuffer"/> to the manager it rented from.</description></item>
+    /// <item><description><b>Detached</b> &#8212; <see cref="DetachBuffer"/> transferred that debt to the
+    /// caller.</description></item>
+    /// <item><description><b>Disposed</b> &#8212; the array went back to the pool; nobody owes anything.</description></item>
+    /// </list>
+    /// The state is carried by the array field itself rather than by a flag, so returning the same array
+    /// twice is impossible by construction. Every member except <see cref="Dispose"/> throws once the
+    /// instance leaves the Owning state.
+    /// </para>
+    /// <para>
+    /// This file is compiled into every CoreWCF assembly through the <c>$(CommonPath)</c> glob in
+    /// <c>Directory.Build.targets</c>, and is also compiled directly into CoreWCF.Primitives.Tests. It must
+    /// therefore depend on nothing beyond <c>System</c>, <c>System.Buffers</c> and
+    /// <see cref="BufferManager"/> &#8212; in particular no <c>SR</c>/<c>SRCommon</c> (test projects build with
+    /// <c>OmitResources</c>), no <c>Fx</c>, and no <c>ArrayPool</c>. That is what the injected
+    /// <c>createQuotaExceededException</c> factory buys.
+    /// </para>
+    /// </remarks>
+    internal sealed class BufferManagerBufferWriter : IBufferWriter<byte>, IDisposable
+    {
+        private readonly BufferManager _bufferManager;
+        private readonly int _maxSizeQuota;
+        private readonly Func<int, Exception> _createQuotaExceededException;
+        private byte[] _buffer;
+        private int _capacity;
+        private int _writtenCount;
+        private bool _detached;
+
+        /// <param name="bufferManager">The pool to rent from and return to. Never replaced by
+        /// <see cref="ArrayPool{T}"/>: honouring the transport's configured <c>MaxBufferPoolSize</c> is the
+        /// point of this type.</param>
+        /// <param name="initialSize">Size requested from <paramref name="bufferManager"/> up front. The pool
+        /// may hand back a larger array; the extra is used.</param>
+        /// <param name="maxSizeQuota">The quota value reported in the exception message. This is what the
+        /// user configured (for example <c>MaxReceivedMessageSize</c>).</param>
+        /// <param name="effectiveMaxSize">The byte count actually enforced. It differs from
+        /// <paramref name="maxSizeQuota"/> when a caller reserves a prefix &#8212; see
+        /// <c>BufferedMessageWriter</c>, which enforces <c>maxSizeQuota + initialOffset</c> while still
+        /// reporting <c>maxSizeQuota</c>.</param>
+        /// <param name="createQuotaExceededException">Builds the exception thrown when
+        /// <paramref name="effectiveMaxSize"/> would be exceeded; it is handed
+        /// <paramref name="maxSizeQuota"/>. Injected so this type stays free of <c>SR</c> and of the
+        /// diagnostics helpers, which differ per assembly.</param>
+        internal BufferManagerBufferWriter(BufferManager bufferManager, int initialSize, int maxSizeQuota,
+            int effectiveMaxSize, Func<int, Exception> createQuotaExceededException)
+        {
+            if (bufferManager == null)
+            {
+                throw new ArgumentNullException(nameof(bufferManager));
+            }
+
+            if (initialSize < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(initialSize), initialSize, "Value must be non-negative.");
+            }
+
+            if (maxSizeQuota < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxSizeQuota), maxSizeQuota, "Value must be non-negative.");
+            }
+
+            if (effectiveMaxSize < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(effectiveMaxSize), effectiveMaxSize, "Value must be non-negative.");
+            }
+
+            if (createQuotaExceededException == null)
+            {
+                throw new ArgumentNullException(nameof(createQuotaExceededException));
+            }
+
+            _bufferManager = bufferManager;
+            _maxSizeQuota = maxSizeQuota;
+            MaxSize = effectiveMaxSize;
+            _createQuotaExceededException = createQuotaExceededException;
+            _buffer = bufferManager.TakeBuffer(initialSize);
+            _capacity = Math.Min(_buffer.Length, effectiveMaxSize);
+        }
+
+        /// <summary>The hard ceiling on <see cref="WrittenCount"/>; the <c>effectiveMaxSize</c> constructor argument.</summary>
+        internal int MaxSize { get; }
+
+        /// <summary>The quota reported in the exception message; the <c>maxSizeQuota</c> constructor argument.</summary>
+        internal int MaxSizeQuota => _maxSizeQuota;
+
+        /// <summary>
+        /// Bytes usable without growing: <c>Math.Min(rentedArray.Length, MaxSize)</c>. The pool routinely
+        /// over-delivers (it buckets by size), and the surplus is used rather than wasted.
+        /// </summary>
+        internal int Capacity
+        {
+            get
+            {
+                ThrowIfUnavailable();
+                return _capacity;
+            }
+        }
+
+        /// <summary>Bytes committed so far through <see cref="Advance"/>.</summary>
+        internal int WrittenCount
+        {
+            get
+            {
+                ThrowIfUnavailable();
+                return _writtenCount;
+            }
+        }
+
+        /// <summary>Bytes writable before a grow is needed.</summary>
+        internal int FreeCapacity
+        {
+            get
+            {
+                ThrowIfUnavailable();
+                return _capacity - _writtenCount;
+            }
+        }
+
+        /// <summary>
+        /// Returns the free region, growing first if it holds fewer than <paramref name="sizeHint"/> bytes.
+        /// </summary>
+        /// <remarks>
+        /// The span is clamped to the remaining quota. That matters: an <see cref="IBufferWriter{T}"/> consumer
+        /// writes straight into the span, so an unclamped span would let it place bytes beyond
+        /// <see cref="MaxSize"/> before anything checked. When the quota leaves no room this throws the quota
+        /// exception rather than returning an empty span &#8212; an empty span breaks the
+        /// <see cref="IBufferWriter{T}"/> contract and can spin a consumer forever.
+        /// </remarks>
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            EnsureCapacityFor(sizeHint);
+            return new Span<byte>(_buffer, _writtenCount, _capacity - _writtenCount);
+        }
+
+        /// <inheritdoc cref="GetSpan"/>
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            EnsureCapacityFor(sizeHint);
+            return new Memory<byte>(_buffer, _writtenCount, _capacity - _writtenCount);
+        }
+
+        /// <summary>Commits <paramref name="count"/> bytes of the region last returned by
+        /// <see cref="GetSpan"/>/<see cref="GetMemory"/>.</summary>
+        public void Advance(int count)
+        {
+            ThrowIfUnavailable();
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count), count, "Value must be non-negative.");
+            }
+
+            if (count > _capacity - _writtenCount)
+            {
+                throw new InvalidOperationException("Cannot advance past the end of the buffer.");
+            }
+
+            _writtenCount += count;
+        }
+
+        /// <summary>
+        /// Rents a larger buffer, copies the written bytes across and returns the old one to the pool.
+        /// </summary>
+        /// <returns><see langword="false"/> when <see cref="Capacity"/> already equals <see cref="MaxSize"/>,
+        /// in which case nothing was rented and nothing changed.</returns>
+        internal bool TryGrow()
+        {
+            ThrowIfUnavailable();
+
+            if (_capacity >= MaxSize)
+            {
+                return false;
+            }
+
+            // Doubling, matching the growth the hand-written buffered-read loops used. The long arithmetic
+            // only differs from int arithmetic where the int form would have overflowed to a negative size
+            // and thrown out of TakeBuffer.
+            int requestedSize = (int)Math.Min((long)_capacity * 2, MaxSize);
+            if (requestedSize <= _capacity)
+            {
+                // _capacity is 0 because the pool handed back a zero-length array; doubling cannot make progress.
+                requestedSize = MaxSize;
+            }
+
+            byte[] newBuffer = _bufferManager.TakeBuffer(requestedSize);
+            Buffer.BlockCopy(_buffer, 0, newBuffer, 0, _writtenCount);
+            _bufferManager.ReturnBuffer(_buffer);
+            _buffer = newBuffer;
+            _capacity = Math.Min(newBuffer.Length, MaxSize);
+            return true;
+        }
+
+        /// <summary>Builds the quota exception without throwing it, for callers that enforce the ceiling themselves.</summary>
+        internal Exception CreateQuotaExceededException() => _createQuotaExceededException(_maxSizeQuota);
+
+        /// <summary>
+        /// Hands the pooled array to the caller, who from then on owes
+        /// <see cref="BufferManager.ReturnBuffer"/> to the same <see cref="BufferManager"/>.
+        /// </summary>
+        /// <remarks>
+        /// The array is returned raw, at its full <c>Length</c> &#8212; never trimmed or copied to
+        /// <paramref name="writtenCount"/> bytes. Two reasons. <c>InternalBufferManager.ReturnBuffer</c> throws
+        /// <see cref="ArgumentException"/> when the array length does not match the pool's bucket size, so a
+        /// trimmed array blows up later at <c>Message.Close()</c> time. And callers such as
+        /// <c>BinaryMessageEncoderFactory.AddSessionInformationToMessage</c> deliberately use the slack past
+        /// <paramref name="writtenCount"/>.
+        /// </remarks>
+        internal byte[] DetachBuffer(out int writtenCount)
+        {
+            ThrowIfUnavailable();
+
+            byte[] buffer = _buffer;
+            writtenCount = _writtenCount;
+            _buffer = null;
+            _detached = true;
+            return buffer;
+        }
+
+        /// <summary>
+        /// Returns the pooled array unless <see cref="DetachBuffer"/> already gave it away.
+        /// </summary>
+        /// <remarks>
+        /// Idempotent, and it raises nothing of its own - not even when the writer has already been disposed or
+        /// detached. That matters because it runs on exception unwind, where a throw would replace the
+        /// <c>QuotaExceededException</c> that callers such as <c>ProtocolException</c> handling and
+        /// <c>TransportDuplexSessionChannel</c> pattern-match on. (A <see cref="BufferManager"/> that throws
+        /// out of <see cref="BufferManager.ReturnBuffer"/> still propagates; the array handed back is always the
+        /// unmodified one that was rented, which is the condition the pooled implementation checks.)
+        /// </remarks>
+        public void Dispose()
+        {
+            byte[] buffer = _buffer;
+            if (buffer != null)
+            {
+                _buffer = null;
+                _bufferManager.ReturnBuffer(buffer);
+            }
+        }
+
+        private void EnsureCapacityFor(int sizeHint)
+        {
+            ThrowIfUnavailable();
+
+            if (sizeHint < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sizeHint), sizeHint, "Value must be non-negative.");
+            }
+
+            // IBufferWriter<T> requires a non-empty buffer, so a hint of 0 means "at least one byte".
+            int required = sizeHint == 0 ? 1 : sizeHint;
+
+            while (_capacity - _writtenCount < required)
+            {
+                if (!TryGrow())
+                {
+                    throw CreateQuotaExceededException();
+                }
+            }
+        }
+
+        private void ThrowIfUnavailable()
+        {
+            if (_buffer == null)
+            {
+                throw new ObjectDisposedException(nameof(BufferManagerBufferWriter),
+                    _detached
+                        ? "The buffer was detached; this writer cannot be used again."
+                        : "The buffer was returned to the BufferManager; this writer cannot be used again.");
+            }
+        }
+    }
+}

--- a/src/Common/src/CoreWCF/Channels/BufferedMessageStreamHelper.cs
+++ b/src/Common/src/CoreWCF/Channels/BufferedMessageStreamHelper.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace CoreWCF.Channels
+{
+    /// <summary>
+    /// Reads a message body into a single pooled buffer, for transports that buffer a stream whose length is
+    /// not known in advance (chunked HTTP being the case that reaches this today).
+    /// </summary>
+    /// <remarks>
+    /// Lives in <c>src/Common</c> because the logic is needed from more than one assembly and the repo
+    /// deliberately ships no <c>InternalsVisibleTo</c>. Like <see cref="BufferManagerBufferWriter"/> it is also
+    /// compiled straight into CoreWCF.Primitives.Tests, so it must not reference <c>SR</c>/<c>SRCommon</c> or
+    /// the per-assembly diagnostics helpers &#8212; hence the injected exception factory.
+    /// </remarks>
+    internal static class BufferedMessageStreamHelper
+    {
+        /// <summary>
+        /// Reads <paramref name="stream"/> to the end, or until <paramref name="maxBufferSize"/> is exceeded.
+        /// </summary>
+        /// <param name="stream">The body stream. It is disposed on end-of-stream, matching the behaviour of the
+        /// hand-written loops this replaces; it is left alone on the quota path.</param>
+        /// <param name="bufferManager">The transport's pool. The returned array belongs to it, and goes back to
+        /// it when the <c>Message</c> built from the segment is closed.</param>
+        /// <param name="maxBufferSize">Ceiling on the buffered body.</param>
+        /// <param name="initialBufferSize">Size requested from the pool up front.</param>
+        /// <param name="createQuotaExceededException">Builds the exception thrown when
+        /// <paramref name="maxBufferSize"/> is exceeded.</param>
+        /// <returns>The raw pooled array with the byte count read. Ownership passes to the caller, which hands
+        /// it to <c>MessageEncoder.ReadMessage</c> together with the same <paramref name="bufferManager"/>.</returns>
+        internal static async Task<ArraySegment<byte>> BufferMessageStreamAsync(Stream stream,
+            BufferManager bufferManager, int maxBufferSize, int initialBufferSize,
+            Func<int, Exception> createQuotaExceededException)
+        {
+            // The using block is the one behaviour change: the loops this replaces had no try, so a throw out
+            // of ReadAsync - or out of the quota check itself - leaked the rented buffer.
+            using (BufferManagerBufferWriter writer = new BufferManagerBufferWriter(bufferManager,
+                initialBufferSize, maxBufferSize, maxBufferSize, createQuotaExceededException))
+            {
+                // A maxBufferSize of 0 reads nothing and does not throw, as before.
+                while (writer.FreeCapacity > 0)
+                {
+                    Memory<byte> free = writer.GetMemory(1);
+                    if (!MemoryMarshal.TryGetArray<byte>(free, out ArraySegment<byte> segment))
+                    {
+                        // Unreachable: the writer is always array backed.
+                        throw new InvalidOperationException("The buffer writer did not expose an array segment.");
+                    }
+
+                    // netstandard2.0 Stream has no Memory<byte> overload, so read through the array.
+                    int count = await stream.ReadAsync(segment.Array, segment.Offset, segment.Count);
+                    if (count == 0)
+                    {
+                        stream.Dispose();
+                        break;
+                    }
+
+                    writer.Advance(count);
+
+                    // The ceiling is checked as soon as the buffer fills, before another read is attempted, so
+                    // a body of exactly maxBufferSize bytes followed by end-of-stream still throws.
+                    if (writer.FreeCapacity == 0 && !writer.TryGrow())
+                    {
+                        throw writer.CreateQuotaExceededException();
+                    }
+                }
+
+                byte[] buffer = writer.DetachBuffer(out int writtenCount);
+                return new ArraySegment<byte>(buffer, 0, writtenCount);
+            }
+        }
+    }
+}

--- a/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs
+++ b/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs
@@ -25,6 +25,12 @@ namespace CoreWCF.Channels
         private const string multipartRelatedMediaType = "multipart/related";
         private const string startInfoHeaderParam = "start-info";
         private const string defaultContentType = "application/octet-stream";
+
+        // Static so the buffered-read path does not allocate a delegate per message.
+        private static readonly Func<int, Exception> s_createMaxReceivedMessageSizeExceededException =
+            maxBufferSize => DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                MaxMessageSizeStream.CreateMaxReceivedMessageSizeExceededException(maxBufferSize));
+
         private readonly BufferManager _bufferManager;
         private readonly bool _isRequest;
         private readonly MessageEncoder _messageEncoder;
@@ -208,38 +214,10 @@ namespace CoreWCF.Channels
         }
 
         // used for buffered streaming
-        internal async Task<ArraySegment<byte>> BufferMessageStreamAsync(Stream stream, BufferManager bufferManager, int maxBufferSize)
+        internal Task<ArraySegment<byte>> BufferMessageStreamAsync(Stream stream, BufferManager bufferManager, int maxBufferSize)
         {
-            byte[] buffer = bufferManager.TakeBuffer(ConnectionOrientedTransportDefaults.ConnectionBufferSize);
-            int offset = 0;
-            int currentBufferSize = Math.Min(buffer.Length, maxBufferSize);
-
-            while (offset < currentBufferSize)
-            {
-                int count = await stream.ReadAsync(buffer, offset, currentBufferSize - offset);
-                if (count == 0)
-                {
-                    stream.Dispose();
-                    break;
-                }
-
-                offset += count;
-                if (offset == currentBufferSize)
-                {
-                    if (currentBufferSize >= maxBufferSize)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(MaxMessageSizeStream.CreateMaxReceivedMessageSizeExceededException(maxBufferSize));
-                    }
-
-                    currentBufferSize = Math.Min(currentBufferSize * 2, maxBufferSize);
-                    byte[] temp = bufferManager.TakeBuffer(currentBufferSize);
-                    Buffer.BlockCopy(buffer, 0, temp, 0, offset);
-                    bufferManager.ReturnBuffer(buffer);
-                    buffer = temp;
-                }
-            }
-
-            return new ArraySegment<byte>(buffer, 0, offset);
+            return BufferedMessageStreamHelper.BufferMessageStreamAsync(stream, bufferManager, maxBufferSize,
+                ConnectionOrientedTransportDefaults.ConnectionBufferSize, s_createMaxReceivedMessageSizeExceededException);
         }
 
         protected abstract void AddProperties(Message message);

--- a/src/CoreWCF.Primitives/src/CoreWCF/Channels/MessageEncoder.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Channels/MessageEncoder.cs
@@ -41,49 +41,6 @@ namespace CoreWCF.Channels
 
         public abstract Message ReadMessage(ArraySegment<byte> buffer, BufferManager bufferManager, string contentType);
 
-        // used for buffered streaming
-        internal async Task<ArraySegment<byte>> BufferMessageStreamAsync(Stream stream, BufferManager bufferManager, int maxBufferSize)
-        {
-            byte[] buffer = bufferManager.TakeBuffer(ConnectionOrientedTransportDefaults.ConnectionBufferSize);
-            int offset = 0;
-            int currentBufferSize = Math.Min(buffer.Length, maxBufferSize);
-
-            while (offset < currentBufferSize)
-            {
-                int count = await stream.ReadAsync(buffer, offset, currentBufferSize - offset);
-                if (count == 0)
-                {
-                    stream.Dispose();
-                    break;
-                }
-
-                offset += count;
-                if (offset == currentBufferSize)
-                {
-                    if (currentBufferSize >= maxBufferSize)
-                    {
-                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                            MaxMessageSizeStream.CreateMaxReceivedMessageSizeExceededException(maxBufferSize));
-                    }
-
-                    currentBufferSize = Math.Min(currentBufferSize * 2, maxBufferSize);
-                    byte[] temp = bufferManager.TakeBuffer(currentBufferSize);
-                    Buffer.BlockCopy(buffer, 0, temp, 0, offset);
-                    bufferManager.ReturnBuffer(buffer);
-                    buffer = temp;
-                }
-            }
-
-            return new ArraySegment<byte>(buffer, 0, offset);
-        }
-
-        // used for buffered streaming
-        internal virtual async Task<Message> ReadMessageAsync(Stream stream, BufferManager bufferManager, int maxBufferSize,
-            string contentType)
-        {
-            return ReadMessage(await BufferMessageStreamAsync(stream, bufferManager, maxBufferSize), bufferManager, contentType);
-        }
-
         public override string ToString()
         {
             return ContentType;

--- a/src/CoreWCF.Primitives/tests/Channels/BufferManagerBufferWriterTests.cs
+++ b/src/CoreWCF.Primitives/tests/Channels/BufferManagerBufferWriterTests.cs
@@ -1,0 +1,909 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CoreWCF.Channels;
+using Xunit;
+
+// Not namespaced ...Tests.Channels on purpose: that would shadow CoreWCF.Channels for every other file in
+// CoreWCF.Primitives.Tests that resolves it as a relative "Channels.".
+namespace CoreWCF.Primitives.Tests
+{
+    /// <summary>
+    /// Covers <see cref="BufferManagerBufferWriter"/> and <see cref="BufferedMessageStreamHelper"/>, both of
+    /// which are compiled into this assembly from <c>$(CommonPath)</c> by the test csproj.
+    /// </summary>
+    /// <remarks>
+    /// The highest value tests here are <see cref="BufferMessageStreamAsync_MatchesLegacyLoop"/> and friends:
+    /// they run the loop that <c>HttpInput.BufferMessageStreamAsync</c> used before this refactor, verbatim,
+    /// against the new helper and compare payloads, exceptions and pool traffic.
+    /// </remarks>
+    public class BufferManagerBufferWriterTests
+    {
+        private const int InitialBufferSize = 8192; // ConnectionOrientedTransportDefaults.ConnectionBufferSize
+
+        private static readonly Func<int, Exception> s_quotaFactory =
+            quota => new InvalidOperationException("quota exceeded: " + quota.ToString());
+
+        #region Construction and basic state
+
+        [Fact]
+        public void Constructor_RentsFromTheSuppliedManager()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 65536))
+            {
+                Assert.Equal(new[] { InitialBufferSize }, manager.Requests);
+                Assert.Equal(1, manager.TakeCount);
+                Assert.Equal(InitialBufferSize, writer.Capacity);
+                Assert.Equal(0, writer.WrittenCount);
+                Assert.Equal(InitialBufferSize, writer.FreeCapacity);
+                Assert.Equal(65536, writer.MaxSize);
+                Assert.Equal(65536, writer.MaxSizeQuota);
+            }
+        }
+
+        [Fact]
+        public void Constructor_UsesTheSurplusWhenThePoolOverDelivers()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager(padding: 512);
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 65536))
+            {
+                // The pool buckets by size, so it routinely hands back more than was asked for. Use it.
+                Assert.Equal(InitialBufferSize + 512, writer.Capacity);
+            }
+        }
+
+        [Fact]
+        public void Constructor_ClampsCapacityToMaxSize()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 100))
+            {
+                Assert.Equal(100, writer.Capacity);
+                Assert.Equal(100, writer.FreeCapacity);
+            }
+        }
+
+        [Fact]
+        public void Constructor_RejectsInvalidArguments()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            Assert.Throws<ArgumentNullException>(() => { new BufferManagerBufferWriter(null, 1, 1, 1, s_quotaFactory).Dispose(); });
+            Assert.Throws<ArgumentNullException>(() => { new BufferManagerBufferWriter(manager, 1, 1, 1, null).Dispose(); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new BufferManagerBufferWriter(manager, -1, 1, 1, s_quotaFactory).Dispose(); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new BufferManagerBufferWriter(manager, 1, -1, 1, s_quotaFactory).Dispose(); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new BufferManagerBufferWriter(manager, 1, 1, -1, s_quotaFactory).Dispose(); });
+            Assert.Equal(0, manager.TakeCount);
+        }
+
+        #endregion
+
+        #region IBufferWriter behaviour
+
+        [Fact]
+        public void GetSpanAndAdvance_WriteThroughTheInterface()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 65536))
+            {
+                IBufferWriter<byte> bufferWriter = writer;
+                Span<byte> span = bufferWriter.GetSpan(4);
+                span[0] = 1;
+                span[1] = 2;
+                span[2] = 3;
+                span[3] = 4;
+                bufferWriter.Advance(4);
+
+                Assert.Equal(4, writer.WrittenCount);
+                Assert.Equal(writer.Capacity - 4, writer.FreeCapacity);
+
+                byte[] buffer = writer.DetachBuffer(out int writtenCount);
+                Assert.Equal(4, writtenCount);
+                Assert.Equal(new byte[] { 1, 2, 3, 4 }, buffer.Take(4).ToArray());
+                manager.ReturnBuffer(buffer);
+            }
+        }
+
+        [Fact]
+        public void GetSpan_ReturnsTheWholeFreeRegion()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 65536))
+            {
+                Assert.Equal(InitialBufferSize, writer.GetSpan().Length);
+                Assert.Equal(InitialBufferSize, writer.GetMemory().Length);
+                writer.Advance(100);
+                Assert.Equal(InitialBufferSize - 100, writer.GetSpan().Length);
+                Assert.Equal(InitialBufferSize - 100, writer.GetMemory(1).Length);
+            }
+        }
+
+        [Fact]
+        public void GetSpan_GrowsWhenTheHintDoesNotFit()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, 16, 65536))
+            {
+                writer.Advance(16);
+                Assert.Equal(0, writer.FreeCapacity);
+
+                Span<byte> span = writer.GetSpan(100);
+                Assert.True(span.Length >= 100);
+                // 16 -> 32 -> 64 -> 128: doubling, one rent per step.
+                Assert.Equal(new[] { 16, 32, 64, 128 }, manager.Requests);
+            }
+        }
+
+        [Fact]
+        public void GetSpan_ThrowsTheQuotaExceptionRatherThanReturningAnEmptySpan()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, 16, maxSize: 16))
+            {
+                writer.Advance(16);
+                Assert.Equal(0, writer.FreeCapacity);
+
+                // An empty span would violate the IBufferWriter<T> contract and can spin a consumer forever.
+                InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => { writer.GetSpan(); });
+                Assert.Equal("quota exceeded: 16", exception.Message);
+                Assert.Throws<InvalidOperationException>(() => { writer.GetMemory(); });
+            }
+        }
+
+        [Fact]
+        public void GetSpan_RejectsNegativeHints()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 65536))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { writer.GetSpan(-1); });
+                Assert.Throws<ArgumentOutOfRangeException>(() => { writer.GetMemory(-1); });
+            }
+        }
+
+        [Fact]
+        public void Advance_RejectsNegativeAndOverlongCounts()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 65536))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { writer.Advance(-1); });
+                Assert.Throws<InvalidOperationException>(() => { writer.Advance(writer.Capacity + 1); });
+                Assert.Equal(0, writer.WrittenCount);
+            }
+        }
+
+        [Fact]
+        public void MaxSizeQuota_IsReportedWhileEffectiveMaxSizeIsEnforced()
+        {
+            // BufferedMessageWriter enforces maxSizeQuota + initialOffset but reports maxSizeQuota, so the two
+            // values genuinely differ and must not be collapsed into one.
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer =
+                new BufferManagerBufferWriter(manager, 16, maxSizeQuota: 100, effectiveMaxSize: 150, createQuotaExceededException: s_quotaFactory))
+            {
+                writer.GetSpan(150);
+                Assert.Equal(150, writer.Capacity);
+                writer.Advance(150);
+
+                InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => { writer.GetSpan(); });
+                Assert.Equal("quota exceeded: 100", exception.Message);
+            }
+        }
+
+        #endregion
+
+        #region Growth and pool traffic
+
+        [Fact]
+        public void TryGrow_DoublesAndReturnsTheSupersededBuffer()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, 16, 65536))
+            {
+                writer.GetSpan(4)[0] = 42;
+                writer.Advance(4);
+                byte[] first = manager.Taken[0];
+
+                Assert.True(writer.TryGrow());
+
+                Assert.Equal(new[] { 16, 32 }, manager.Requests);
+                Assert.Same(first, Assert.Single(manager.Returned));
+                Assert.Equal(1, manager.Outstanding);
+                Assert.Equal(32, writer.Capacity);
+                Assert.Equal(4, writer.WrittenCount);
+                // The bytes written before the grow survived it.
+                Assert.Equal(42, manager.Taken[1][0]);
+            }
+        }
+
+        [Fact]
+        public void TryGrow_ReturnsFalseAtMaxSizeWithoutRenting()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, 64, maxSize: 64))
+            {
+                Assert.False(writer.TryGrow());
+                Assert.Equal(1, manager.TakeCount);
+                Assert.Equal(0, manager.ReturnCount);
+            }
+        }
+
+        [Fact]
+        public void TryGrow_MakesProgressWhenThePoolHandsBackAZeroLengthArray()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, 0, maxSize: 64))
+            {
+                Assert.Equal(0, writer.Capacity);
+                Assert.True(writer.TryGrow());
+                Assert.Equal(64, writer.Capacity);
+            }
+        }
+
+        [Fact]
+        public void TryGrow_NeverExceedsMaxSize()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, 16, maxSize: 40))
+            {
+                Assert.True(writer.TryGrow());  // 16 -> 32
+                Assert.True(writer.TryGrow());  // 32 -> 40, clamped
+                Assert.Equal(40, writer.Capacity);
+                Assert.False(writer.TryGrow());
+                Assert.Equal(new[] { 16, 32, 40 }, manager.Requests);
+            }
+        }
+
+        #endregion
+
+        #region Ownership
+
+        [Fact]
+        public void Dispose_ReturnsTheBufferExactlyOnce()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 65536);
+            writer.Dispose();
+            writer.Dispose();
+
+            Assert.Equal(1, manager.ReturnCount);
+            Assert.Equal(0, manager.Outstanding);
+        }
+
+        [Fact]
+        public void DetachBuffer_TransfersOwnershipSoDisposeDoesNothing()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+            byte[] detached;
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 65536))
+            {
+                writer.Advance(10);
+                detached = writer.DetachBuffer(out int writtenCount);
+                Assert.Equal(10, writtenCount);
+            }
+
+            Assert.Equal(0, manager.ReturnCount);
+            Assert.Equal(1, manager.Outstanding);
+            Assert.Same(manager.Taken[0], detached);
+
+            // The caller owes the return, and the manager accepts it.
+            manager.ReturnBuffer(detached);
+            Assert.Equal(0, manager.Outstanding);
+        }
+
+        [Fact]
+        public void DetachBuffer_HandsBackTheRawPooledArrayAtItsFullLength()
+        {
+            // InternalBufferManager.ReturnBuffer throws when the array length does not match its bucket size,
+            // so the array must never be trimmed or copied down to WrittenCount.
+            RecordingBufferManager manager = new RecordingBufferManager(padding: 512);
+
+            using (BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 65536))
+            {
+                writer.Advance(10);
+                byte[] detached = writer.DetachBuffer(out int writtenCount);
+
+                Assert.Equal(InitialBufferSize + 512, detached.Length);
+                Assert.Equal(10, writtenCount);
+                manager.ReturnBuffer(detached);
+            }
+        }
+
+        [Fact]
+        public void UseAfterDetach_Throws()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 65536);
+            byte[] detached = writer.DetachBuffer(out int _);
+
+            Assert.Throws<ObjectDisposedException>(() => { writer.DetachBuffer(out int _); });
+            Assert.Throws<ObjectDisposedException>(() => { writer.GetSpan(); });
+            Assert.Throws<ObjectDisposedException>(() => { writer.GetMemory(); });
+            Assert.Throws<ObjectDisposedException>(() => { writer.Advance(0); });
+            Assert.Throws<ObjectDisposedException>(() => { writer.TryGrow(); });
+            Assert.Throws<ObjectDisposedException>(() => { _ = writer.Capacity; });
+            Assert.Throws<ObjectDisposedException>(() => { _ = writer.WrittenCount; });
+            Assert.Throws<ObjectDisposedException>(() => { _ = writer.FreeCapacity; });
+
+            writer.Dispose();
+            Assert.Equal(0, manager.ReturnCount);
+            manager.ReturnBuffer(detached);
+        }
+
+        [Fact]
+        public void UseAfterDispose_Throws()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+
+            BufferManagerBufferWriter writer = CreateWriter(manager, InitialBufferSize, 65536);
+            writer.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => { writer.GetSpan(); });
+            Assert.Throws<ObjectDisposedException>(() => { writer.DetachBuffer(out int _); });
+            Assert.Throws<ObjectDisposedException>(() => { writer.TryGrow(); });
+        }
+
+        #endregion
+
+        #region BufferedMessageStreamHelper: pool accounting
+
+        [Fact]
+        public async Task BufferMessageStreamAsync_BodyThatFits_RentsOnce()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+            ChunkedStream stream = new ChunkedStream(CreateBody(100), int.MaxValue);
+
+            ArraySegment<byte> result = await BufferedMessageStreamHelper.BufferMessageStreamAsync(
+                stream, manager, maxBufferSize: 65536, initialBufferSize: InitialBufferSize,
+                createQuotaExceededException: s_quotaFactory);
+
+            Assert.Equal(100, result.Count);
+            Assert.Equal(1, manager.TakeCount);
+            Assert.Equal((long)InitialBufferSize, manager.TotalBytesRented);
+            Assert.Equal((long)InitialBufferSize, manager.PeakOutstandingBytes);
+
+            // Ownership passed to the caller with the segment: exactly one buffer is still out, and it is
+            // the one the segment points at.
+            Assert.Equal(0, manager.ReturnCount);
+            Assert.Equal(1, manager.Outstanding);
+            Assert.Same(manager.Taken[0], result.Array);
+        }
+
+        [Fact]
+        public async Task BufferMessageStreamAsync_TwoGrowths_HoldsAtMostTwoBuffersAtOnce()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+            ChunkedStream stream = new ChunkedStream(CreateBody(20000), int.MaxValue);
+
+            ArraySegment<byte> result = await BufferedMessageStreamHelper.BufferMessageStreamAsync(
+                stream, manager, maxBufferSize: 1 << 20, initialBufferSize: InitialBufferSize,
+                createQuotaExceededException: s_quotaFactory);
+
+            Assert.Equal(20000, result.Count);
+            Assert.Equal(3, manager.TakeCount);
+            Assert.Equal(new[] { 8192, 16384, 32768 }, manager.Requests);
+            Assert.Equal(8192L + 16384L + 32768L, manager.TotalBytesRented);
+
+            // The superseded buffer is returned right after the copy, so old and new coexist only across the
+            // BlockCopy - never three at once. This is what pins the growth policy: if chunk-list growth were
+            // ever reintroduced, or a superseded buffer left unreturned, this number changes.
+            Assert.Equal(16384L + 32768L, manager.PeakOutstandingBytes);
+            Assert.Equal(1, manager.Outstanding);
+        }
+
+        [Fact]
+        public async Task BufferMessageStreamAsync_QuotaExceeded_ReturnsEveryBufferItRented()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+            ChunkedStream stream = new ChunkedStream(CreateBody(8192), int.MaxValue);
+
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => BufferedMessageStreamHelper.BufferMessageStreamAsync(stream, manager, maxBufferSize: 4096,
+                    initialBufferSize: InitialBufferSize, createQuotaExceededException: s_quotaFactory));
+
+            Assert.Equal("quota exceeded: 4096", exception.Message);
+
+            // The loop this replaces had no try, so it leaked the rented buffer on this path.
+            Assert.Equal(manager.TakeCount, manager.ReturnCount);
+            Assert.Equal(0, manager.Outstanding);
+        }
+
+        [Fact]
+        public async Task BufferMessageStreamAsync_ReadFailure_ReturnsEveryBufferItRented()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+            ChunkedStream stream = new ChunkedStream(CreateBody(100), int.MaxValue) { FailAfterBytes = 50 };
+
+            await Assert.ThrowsAsync<IOException>(
+                () => BufferedMessageStreamHelper.BufferMessageStreamAsync(stream, manager, maxBufferSize: 65536,
+                    initialBufferSize: InitialBufferSize, createQuotaExceededException: s_quotaFactory));
+
+            Assert.Equal(manager.TakeCount, manager.ReturnCount);
+            Assert.Equal(0, manager.Outstanding);
+        }
+
+        [Fact]
+        public async Task LegacyLoop_LeakedOnTheQuotaPath()
+        {
+            // Documents the bug the using block in BufferedMessageStreamHelper fixes. If this ever starts
+            // failing the legacy oracle has drifted and the parity tests below are no longer meaningful.
+            RecordingBufferManager manager = new RecordingBufferManager();
+            ChunkedStream stream = new ChunkedStream(CreateBody(8192), int.MaxValue);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => LegacyBufferMessageStreamAsync(stream, manager, 4096, InitialBufferSize));
+
+            Assert.Equal(1, manager.TakeCount);
+            Assert.Equal(0, manager.ReturnCount);
+            Assert.Equal(1, manager.Outstanding);
+        }
+
+        #endregion
+
+        #region BufferedMessageStreamHelper: parity with the loop it replaces
+
+        public static IEnumerable<object[]> ParityCases()
+        {
+            int[] maxBufferSizes = { 0, 100, 4096, 8192, 65536, 1000000 };
+            int[] bodySizes = { 0, 1, 99, 100, 101, 4095, 4096, 4097, 8192, 8193, 20000, 65536, 65537 };
+            int[] chunkSizes = { 1, 7, 4096, int.MaxValue };
+            int[] paddings = { 0, 7 };
+
+            foreach (int maxBufferSize in maxBufferSizes)
+            {
+                foreach (int bodySize in bodySizes)
+                {
+                    foreach (int chunkSize in chunkSizes)
+                    {
+                        // One byte at a time over a 64 KB body adds nothing the 7 byte case does not already
+                        // cover, and it dominates the run time of this theory.
+                        if (chunkSize == 1 && bodySize > 8193)
+                        {
+                            continue;
+                        }
+
+                        foreach (int padding in paddings)
+                        {
+                            yield return new object[] { maxBufferSize, bodySize, chunkSize, padding };
+                        }
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ParityCases))]
+        public async Task BufferMessageStreamAsync_MatchesLegacyLoop(int maxBufferSize, int bodySize, int chunkSize, int padding)
+        {
+            byte[] body = CreateBody(bodySize);
+
+            RecordingBufferManager legacyManager = new RecordingBufferManager(padding);
+            ChunkedStream legacyStream = new ChunkedStream(body, chunkSize);
+            (ArraySegment<byte> Segment, Exception Exception) legacy =
+                await RunAsync(() => LegacyBufferMessageStreamAsync(legacyStream, legacyManager, maxBufferSize, InitialBufferSize));
+
+            RecordingBufferManager manager = new RecordingBufferManager(padding);
+            ChunkedStream stream = new ChunkedStream(body, chunkSize);
+            (ArraySegment<byte> Segment, Exception Exception) actual =
+                await RunAsync(() => BufferedMessageStreamHelper.BufferMessageStreamAsync(stream, manager,
+                    maxBufferSize, InitialBufferSize, s_quotaFactory));
+
+            if (legacy.Exception != null)
+            {
+                Assert.NotNull(actual.Exception);
+                Assert.Equal(legacy.Exception.GetType(), actual.Exception.GetType());
+                Assert.Equal(legacy.Exception.Message, actual.Exception.Message);
+                Assert.Equal(legacy.Exception.InnerException?.GetType(), actual.Exception.InnerException?.GetType());
+                return;
+            }
+
+            Assert.Null(actual.Exception);
+            Assert.Equal(legacy.Segment.Count, actual.Segment.Count);
+            Assert.Equal(Payload(legacy.Segment), Payload(actual.Segment));
+            Assert.Equal(legacyStream.Disposed, stream.Disposed);
+
+            if (padding == 0)
+            {
+                // With a pool that hands back exactly what was asked for, the rent sequence is identical too.
+                Assert.Equal(legacyManager.Requests, manager.Requests);
+                Assert.Equal(legacyManager.TotalBytesRented, manager.TotalBytesRented);
+            }
+        }
+
+        [Theory]
+        [InlineData(100)]
+        [InlineData(4096)]
+        [InlineData(8192)]
+        public async Task BufferMessageStreamAsync_BodyOfExactlyMaxBufferSize_Throws(int maxBufferSize)
+        {
+            // The ceiling is checked as soon as the buffer fills, before another read is attempted, so a body
+            // that is exactly maxBufferSize bytes long throws even though nothing follows it.
+            RecordingBufferManager manager = new RecordingBufferManager();
+            ChunkedStream stream = new ChunkedStream(CreateBody(maxBufferSize), int.MaxValue);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => BufferedMessageStreamHelper.BufferMessageStreamAsync(stream, manager, maxBufferSize,
+                    InitialBufferSize, s_quotaFactory));
+        }
+
+        [Fact]
+        public async Task BufferMessageStreamAsync_ZeroMaxBufferSize_ReadsNothingAndDoesNotThrow()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+            ChunkedStream stream = new ChunkedStream(CreateBody(100), int.MaxValue);
+
+            ArraySegment<byte> result = await BufferedMessageStreamHelper.BufferMessageStreamAsync(
+                stream, manager, maxBufferSize: 0, initialBufferSize: InitialBufferSize,
+                createQuotaExceededException: s_quotaFactory);
+
+            Assert.Equal(0, result.Count);
+            Assert.False(stream.Disposed);
+            Assert.Equal(0, stream.Position);
+            Assert.Equal(1, manager.Outstanding);
+        }
+
+        [Fact]
+        public async Task BufferMessageStreamAsync_DisposesTheStreamOnEndOfStream()
+        {
+            RecordingBufferManager manager = new RecordingBufferManager();
+            ChunkedStream stream = new ChunkedStream(CreateBody(10), int.MaxValue);
+
+            await BufferedMessageStreamHelper.BufferMessageStreamAsync(stream, manager, 65536, InitialBufferSize, s_quotaFactory);
+
+            Assert.True(stream.Disposed);
+        }
+
+        [Fact]
+        public async Task BufferMessageStreamAsync_UsesTheSuppliedManagerAndNotASharedPool()
+        {
+            // The defect in the abandoned draft was rewiring this path onto ArrayPool<byte>.Shared, which
+            // silently bypasses the transport's configured BufferManager and its MaxBufferPoolSize.
+            RecordingBufferManager manager = new RecordingBufferManager();
+            ChunkedStream stream = new ChunkedStream(CreateBody(20000), 1);
+
+            ArraySegment<byte> result = await BufferedMessageStreamHelper.BufferMessageStreamAsync(
+                stream, manager, 1 << 20, InitialBufferSize, s_quotaFactory);
+
+            Assert.Same(manager.Taken[manager.Taken.Count - 1], result.Array);
+            Assert.All(manager.Returned, buffer => Assert.Contains(buffer, manager.Taken));
+        }
+
+        #endregion
+
+        #region Managed-heap allocation
+
+        // GC.GetAllocatedBytesForCurrentThread is not part of the net472 surface, so this has to be compiled
+        // out rather than merely skipped - compiling a net472-unavailable API into a multi-targeted test
+        // project is what red-lit the earlier attempt at this refactor.
+#if !NETFRAMEWORK
+        [NetCoreOnlyFact]
+        public void WriteOperations_DoNotAllocateOnTheManagedHeap()
+        {
+            // A smoke alarm, not a benchmark: it catches per-call garbage that pool accounting cannot see -
+            // a lambda allocated per GetSpan, a boxed Memory<byte>, an ArraySegment promoted to the heap.
+            // It deliberately measures the synchronous surface only; the async helper allocates one state
+            // machine per call by design, which would make the test about the compiler rather than this code.
+            const int Iterations = 10_000;
+            PreallocatedBufferManager manager = new PreallocatedBufferManager(1 << 20);
+
+            RunWriteLoop(manager, 1000); // warm up: JIT and let tiered compilation settle before measuring
+
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            RunWriteLoop(manager, Iterations);
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            // Divided by the iteration count so a stray one-off allocation rounds away instead of flaking the
+            // build. If this ever proves noisy in CI, raise the ceiling - do not delete the test.
+            Assert.Equal(0L, allocated / Iterations);
+        }
+
+        private static void RunWriteLoop(BufferManager manager, int iterations)
+        {
+            using (BufferManagerBufferWriter writer =
+                new BufferManagerBufferWriter(manager, 1 << 20, 1 << 20, 1 << 20, s_quotaFactory))
+            {
+                for (int i = 0; i < iterations; i++)
+                {
+                    Span<byte> span = writer.GetSpan(16);
+                    span[0] = (byte)i;
+                    Memory<byte> memory = writer.GetMemory(16);
+                    memory.Span[1] = (byte)i;
+                    writer.Advance(2);
+                    _ = writer.Capacity;
+                    _ = writer.WrittenCount;
+                    _ = writer.FreeCapacity;
+                }
+            }
+        }
+#endif
+
+        #endregion
+
+        #region Helpers
+
+        private static BufferManagerBufferWriter CreateWriter(BufferManager manager, int initialSize, int maxSize) =>
+            new BufferManagerBufferWriter(manager, initialSize, maxSize, maxSize, s_quotaFactory);
+
+        private static byte[] CreateBody(int size)
+        {
+            byte[] body = new byte[size];
+            for (int i = 0; i < size; i++)
+            {
+                body[i] = (byte)(i % 251);
+            }
+
+            return body;
+        }
+
+        private static byte[] Payload(ArraySegment<byte> segment)
+        {
+            byte[] payload = new byte[segment.Count];
+            Buffer.BlockCopy(segment.Array, segment.Offset, payload, 0, segment.Count);
+            return payload;
+        }
+
+        private static async Task<(ArraySegment<byte> Segment, Exception Exception)> RunAsync(
+            Func<Task<ArraySegment<byte>>> operation)
+        {
+            try
+            {
+                return (await operation(), null);
+            }
+            catch (Exception exception)
+            {
+                return (default, exception);
+            }
+        }
+
+        /// <summary>
+        /// The body of <c>HttpInput.BufferMessageStreamAsync</c> as it stood before this refactor, copied
+        /// verbatim apart from the injected initial size and exception factory. It is the oracle the parity
+        /// tests compare against; do not "clean it up".
+        /// </summary>
+        private static async Task<ArraySegment<byte>> LegacyBufferMessageStreamAsync(Stream stream,
+            BufferManager bufferManager, int maxBufferSize, int initialBufferSize)
+        {
+            byte[] buffer = bufferManager.TakeBuffer(initialBufferSize);
+            int offset = 0;
+            int currentBufferSize = Math.Min(buffer.Length, maxBufferSize);
+
+            while (offset < currentBufferSize)
+            {
+                int count = await stream.ReadAsync(buffer, offset, currentBufferSize - offset);
+                if (count == 0)
+                {
+                    stream.Dispose();
+                    break;
+                }
+
+                offset += count;
+                if (offset == currentBufferSize)
+                {
+                    if (currentBufferSize >= maxBufferSize)
+                    {
+                        throw s_quotaFactory(maxBufferSize);
+                    }
+
+                    currentBufferSize = Math.Min(currentBufferSize * 2, maxBufferSize);
+                    byte[] temp = bufferManager.TakeBuffer(currentBufferSize);
+                    Buffer.BlockCopy(buffer, 0, temp, 0, offset);
+                    bufferManager.ReturnBuffer(buffer);
+                    buffer = temp;
+                }
+            }
+
+            return new ArraySegment<byte>(buffer, 0, offset);
+        }
+
+        /// <summary>
+        /// A <see cref="BufferManager"/> that accounts for every rent and return, and fails loudly on a double
+        /// return or on a return of an array it never issued.
+        /// </summary>
+        /// <remarks>
+        /// <c>SimpleBufferManager</c> in tests/Helpers/MessageTestUtilities.cs records nothing, and
+        /// <c>GCBufferManager</c> makes <c>ReturnBuffer</c> a no-op, so neither would notice any of the bugs
+        /// these tests are here to catch. Hence the extra type.
+        /// </remarks>
+        private sealed class RecordingBufferManager : BufferManager
+        {
+            private readonly int _padding;
+            private readonly List<byte[]> _outstanding = new List<byte[]>();
+
+            internal RecordingBufferManager(int padding = 0)
+            {
+                _padding = padding;
+            }
+
+            /// <summary>Sizes asked for, in order.</summary>
+            internal List<int> Requests { get; } = new List<int>();
+
+            /// <summary>Arrays handed out, in order.</summary>
+            internal List<byte[]> Taken { get; } = new List<byte[]>();
+
+            /// <summary>Arrays handed back, in order.</summary>
+            internal List<byte[]> Returned { get; } = new List<byte[]>();
+
+            internal int TakeCount => Taken.Count;
+
+            internal int ReturnCount => Returned.Count;
+
+            /// <summary>Arrays rented but not yet given back.</summary>
+            internal int Outstanding => _outstanding.Count;
+
+            internal long TotalBytesRented { get; private set; }
+
+            internal long OutstandingBytes { get; private set; }
+
+            /// <summary>The high-water mark of <see cref="OutstandingBytes"/>; what pins the growth policy.</summary>
+            internal long PeakOutstandingBytes { get; private set; }
+
+            public override byte[] TakeBuffer(int bufferSize)
+            {
+                if (bufferSize < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(bufferSize));
+                }
+
+                byte[] buffer = new byte[bufferSize + _padding];
+                Requests.Add(bufferSize);
+                Taken.Add(buffer);
+                _outstanding.Add(buffer);
+                TotalBytesRented += buffer.Length;
+                OutstandingBytes += buffer.Length;
+                if (OutstandingBytes > PeakOutstandingBytes)
+                {
+                    PeakOutstandingBytes = OutstandingBytes;
+                }
+
+                return buffer;
+            }
+
+            public override void ReturnBuffer(byte[] buffer)
+            {
+                if (buffer == null)
+                {
+                    throw new ArgumentNullException(nameof(buffer));
+                }
+
+                if (!Taken.Any(taken => ReferenceEquals(taken, buffer)))
+                {
+                    throw new InvalidOperationException("Returned an array this BufferManager never issued.");
+                }
+
+                int index = _outstanding.FindIndex(outstanding => ReferenceEquals(outstanding, buffer));
+                if (index < 0)
+                {
+                    throw new InvalidOperationException("Returned the same array twice.");
+                }
+
+                _outstanding.RemoveAt(index);
+                Returned.Add(buffer);
+                OutstandingBytes -= buffer.Length;
+            }
+
+            public override void Clear()
+            {
+            }
+        }
+
+        /// <summary>
+        /// Hands out one array created up front, so a measured region can rent without allocating.
+        /// </summary>
+        private sealed class PreallocatedBufferManager : BufferManager
+        {
+            private readonly byte[] _buffer;
+
+            internal PreallocatedBufferManager(int size)
+            {
+                _buffer = new byte[size];
+            }
+
+            public override byte[] TakeBuffer(int bufferSize) => _buffer;
+
+            public override void ReturnBuffer(byte[] buffer)
+            {
+            }
+
+            public override void Clear()
+            {
+            }
+        }
+
+        /// <summary>A body stream that hands out at most <c>maxChunk</c> bytes per read, and can be made to fail.</summary>
+        private sealed class ChunkedStream : Stream
+        {
+            private readonly byte[] _data;
+            private readonly int _maxChunk;
+            private int _position;
+
+            internal ChunkedStream(byte[] data, int maxChunk)
+            {
+                _data = data;
+                _maxChunk = maxChunk;
+            }
+
+            internal bool Disposed { get; private set; }
+
+            /// <summary>When set, the read that would take the position past this many bytes throws instead.</summary>
+            internal int FailAfterBytes { get; set; } = -1;
+
+            public override bool CanRead => true;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => false;
+
+            public override long Length => _data.Length;
+
+            public override long Position
+            {
+                get => _position;
+                set => throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (FailAfterBytes >= 0 && _position >= FailAfterBytes)
+                {
+                    throw new IOException("Simulated read failure.");
+                }
+
+                int available = _data.Length - _position;
+                int toRead = Math.Min(Math.Min(count, available), _maxChunk);
+                if (FailAfterBytes >= 0)
+                {
+                    toRead = Math.Min(toRead, FailAfterBytes - _position);
+                }
+
+                Buffer.BlockCopy(_data, _position, buffer, offset, toRead);
+                _position += toRead;
+                return toRead;
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+                Task.FromResult(Read(buffer, offset, count));
+
+            protected override void Dispose(bool disposing)
+            {
+                Disposed = true;
+                base.Dispose(disposing);
+            }
+
+            public override void Flush() => throw new NotSupportedException();
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+
+        #endregion
+    }
+}

--- a/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
+++ b/src/CoreWCF.Primitives/tests/CoreWCF.Primitives.Tests.csproj
@@ -22,6 +22,19 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <!-- BufferManagerBufferWriter and BufferedMessageStreamHelper are internal, and are compiled into each
+       CoreWCF assembly through the $(CommonPath) glob in Directory.Build.targets. Test projects set
+       IncludeCommonCode=false, the repo deliberately ships no InternalsVisibleTo, and product assemblies are
+       strong-named while test assemblies are not - so compile the same sources into the test assembly instead
+       of reaching for reflection. This works because neither file references SR/SRCommon (test projects build
+       with OmitResources=true, so neither class is generated). -->
+  <ItemGroup>
+    <Compile Include="$(CommonPath)CoreWCF/Channels/BufferManagerBufferWriter.cs"
+             Link="shared/CoreWCF/Channels/BufferManagerBufferWriter.cs" />
+    <Compile Include="$(CommonPath)CoreWCF/Channels/BufferedMessageStreamHelper.cs"
+             Link="shared/CoreWCF/Channels/BufferedMessageStreamHelper.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="../src/CoreWCF.Primitives.csproj" />
     <ProjectReference Include="$(SourceDir)CoreWCF.Http/src/CoreWCF.Http.csproj" />


### PR DESCRIPTION
Implements steps 1 and 2 of #1750.

Adds `BufferManagerBufferWriter`, an internal `IBufferWriter<byte>` over `BufferManager`, and migrates the one live call site that buffers a body stream whose length is not known in advance (chunked HTTP).

**No pooling behaviour change.** The caller's `BufferManager` stays the pool everywhere, so the transport's configured `MaxBufferPoolSize` keeps applying — no `ArrayPool<byte>.Shared`. The public API surface is unchanged. Steps 3 and 4 of the issue are deliberately left out so this lands as a pure refactor.

## Why the cut is this narrow

The `BufferedOutputStream`/`BufferManagerOutputStream` sites are not touched, because three things make them a much riskier first move:

1. `using (BufferManagerOutputStream …)` releases nothing, **by design** — `BufferedOutputStream` overrides neither `Dispose(bool)` nor `Close()`, and the commented-out `Close()` it was ported with was an empty override in the first place. Release is carried by `Clear()`, and `ToArray()` transfers ownership of one array; disposal was never part of the contract. Swapping in a type whose `Dispose` is real is therefore a semantic change, not a bug fix, and it lands at five sites at once, invisibly, because the `using` blocks look identical before and after. It would also reach two paths that dispose the stream with no visible `using` — `XmlBuffer` builds its writer with `ownsStream: true`, and `StreamBodyWriter` hands the stream to a user-supplied `Action<Stream>` — both of which would then clear it *before* `ToArray()` runs.
2. `InternalBufferManager.ReturnBuffer` throws when `buffer.Length` does not match the pool's bucket size — and that is a no-op under `GCBufferManager`, so a naive test suite passes.
3. The incumbent's invariant checks are all `Fx.Assert`, which is `[Conditional("DEBUG")]`.

The buffered-read path touches none of that, which is why the issue nominates it as the starting point.

## Changes

- **`src/Common/src/CoreWCF/Channels/BufferManagerBufferWriter.cs`** (new) — `internal sealed class … : IBufferWriter<byte>, IDisposable`. Owning/Detached/Disposed state is carried by the array field itself, so returning the same array twice is impossible by construction. `GetSpan`/`GetMemory` clamp to the remaining quota and throw rather than returning an empty span (an empty span breaks the `IBufferWriter<T>` contract and can spin a consumer forever). `DetachBuffer` hands back the raw pooled array at its full `Length` — never trimmed, per point 2 above.
- **`src/Common/src/CoreWCF/Channels/BufferedMessageStreamHelper.cs`** (new) — the take/grow/hand-off loop.
- **`HttpChannelHelpers.cs`** — `HttpInput.BufferMessageStreamAsync` delegates to the helper, still passing `_bufferManager`.
- **`MessageEncoder.cs`** — deletes `BufferMessageStreamAsync` and the four-argument `ReadMessageAsync`. Both are `internal` with zero callers and zero overrides, and with no `InternalsVisibleTo` nothing outside CoreWCF.Primitives can reach them. (The duplication could not be resolved the other way round: `CoreWCF.Http` cannot call the Primitives copy, which is exactly why the duplicate existed and why the shared logic goes in `src/Common`.)

Both new files live in `src/Common` because the logic is needed from more than one assembly. They depend on nothing beyond `System`, `System.Buffers` and `BufferManager` — the quota exception arrives as an injected `Func<int, Exception>` — which keeps them free of the per-assembly `SR`/diagnostics helpers.

## Why the writer's surface is wider than step 2 consumes

`GetSpan`, `MaxSize`, `MaxSizeQuota` and `Capacity` have no product caller in this PR — only tests. They are not speculative: they are the contract the `MessageEncoder` write path needs, and they are shaped by two incumbent behaviours that would be lost if the type were trimmed to what the read path uses.

The mapping, operation by operation:

| `BufferedOutputStream` / `BufferedMessageWriter` | Writer member |
|---|---|
| `_stream.Init(predictedMessageSize, maxSizeQuota, effectiveMaxSize, bufferManager)` | ctor `(bufferManager, initialSize, maxSizeQuota, effectiveMaxSize, factory)` |
| `_stream.Skip(initialOffset)` | `GetSpan(initialOffset)` + `Advance(initialOffset)` |
| `Stream.Write(buf, off, cnt)` from the `XmlDictionaryWriter` | `GetSpan(cnt)` + copy + `Advance(cnt)` |
| quota trip inside `WriteCore` | thrown implicitly by `GetSpan` (`EnsureCapacityFor` → `TryGrow` → `CreateQuotaExceededException`) |
| `AllocNextChunk` | `TryGrow` |
| `ToArray(out int size)` | `DetachBuffer(out int writtenCount)` |
| `_stream.Clear()` in `finally` | `Dispose()` |
| `_totalSize`, for `RecordActualMessageSize` | `WrittenCount` |

**`maxSizeQuota` vs `effectiveMaxSize`** reproduces `BufferedMessageWriter.WriteMessage` (`BufferedMessageWriter.cs:33-40`) exactly. The buffer has to hold the transport prefix reserved by `Skip(initialOffset)`, so the ceiling *enforced* is `maxSizeQuota + initialOffset`, while the value *reported* in the `QuotaExceededException` stays `maxSizeQuota` — what the user configured. `BufferedOutputStream.Reinitialize` already carries both, as `_maxSize` (enforced) and `_maxSizeQuota` (reported). `MaxSizeQuota_IsReportedWhileEffectiveMaxSizeIsEnforced` pins it.

**`DetachBuffer` returns the raw array at its full `Length`** for a second reason beyond the `ReturnBuffer` bucket-size check: `BinaryMessageEncoderFactory.AddSessionInformationToMessage:470` tests `buffer.Length < requiredBufferSize` — not `writtenCount` — and writes the session dictionary into the slack past the written bytes whenever the pool over-delivered. A trimmed or copied array would force a fresh rental on every session message. `DetachBuffer_HandsBackTheRawPooledArrayAtItsFullLength` pins it.

**Why that migration is not in this PR.** Every encoder writes through an `XmlDictionaryWriter` constructed over a `Stream` — text (`CreateTextWriter`), binary (`CreateBinaryWriter`), MTOM (`XmlMtomWriter.Create`), JSON (`CreateJsonWriter`), byte-stream (`XmlByteStreamWriter`). So `IBufferWriter<byte>` alone is not enough: consuming it at the `MessageEncoder` level needs a `Stream` façade over this writer, replacing `BufferManagerOutputStream`. That is a piece of work in its own right, and it changes the growth policy from "keep every chunk, consolidate in `ToArray`" to "copy and return the superseded buffer" — not something to smuggle into a PR presented as a pure refactor.

## One behaviour change, in the right direction

The loop now runs inside a `using`. The hand-written loop it replaces had no `try`, so a throw out of `stream.ReadAsync` — or out of the max-size check itself — leaked the rented buffer. `LegacyLoop_LeakedOnTheQuotaPath` runs the old loop and asserts that it really did leak, so the fix is pinned rather than merely claimed.

## Tests

`BufferManagerBufferWriter` and `BufferedMessageStreamHelper` are compiled straight into `CoreWCF.Primitives.Tests` through `$(CommonPath)`. That avoids reflection, and avoids `ArrayBufferWriter<T>`, which is `internal` on net472.

- **Parity** — the pre-change loop is copied verbatim into the test as an oracle. A theory runs both against the same body and compares payload, exception type/message/inner type, and stream disposal across a matrix of `maxBufferSize`, body size, read chunk size and pool over-delivery. With a pool that hands back exactly what was asked for, the `TakeBuffer` request sequence is asserted identical too. Two easy-to-"fix"-by-accident quirks are pinned: `maxBufferSize == 0` reads nothing and does **not** throw, and a body of exactly `maxBufferSize` followed by EOF **does** throw.
- **Allocation, deterministic** — a `RecordingBufferManager` that fails loudly on a double return or a return of an array it never issued, asserting exact numbers: a body that fits rents once; two growths rent `8192 + 16384 + 32768` with an outstanding high-water mark of `16384 + 32768`. That last figure is what pins the growth policy — it proves at most two buffers are alive at once and fails if chunk-list growth is ever reintroduced or a superseded buffer is left unreturned.
- **Allocation, managed heap** — a net-core-only test asserting `GC.GetAllocatedBytesForCurrentThread()` reports 0 bytes per iteration over the synchronous writer surface. A smoke alarm for boxing and per-call lambdas, not a benchmark; it deliberately excludes the async helper, whose state machine allocates by design. Compiled out on net472, where the API is not available.

## Verification

| Gate | Result |
|---|---|
| `dotnet build CoreWCF.sln -c Release` | succeeded |
| New tests, net8.0 | 620 passed |
| New tests, net472 | 619 passed (allocation test compiled out) |
| CoreWCF.Primitives.Tests, net8.0 | 763 passed |
| CoreWCF.Http.Tests, net8.0 | 391 passed, 3 skipped |
| CoreWCF.Http.Tests, net472 | 391 passed, 5 skipped |
| CoreWCF.NetTcp.Tests, net8.0 | 93 passed, 2 skipped |
| CoreWCF.WebHttp.Tests, net8.0 | 80 passed |
| public/protected diff against `main` | no output — public surface unchanged |

No new end-to-end HTTP test: `Issue1382Test.cs` and `HttpClientTests.cs` carry live `FIXME`s stating that chunked `Transfer-Encoding` currently breaks message parsing in the ASP.NET Core pre-read path, so a new test there would fail for unrelated reasons. `LargeRequestTests` (1 KB / 1 MB / 10 MB round-trips) is the existing regression gate for the growth loop.

## Relationship to #1751

That draft attempted all four steps at once and is superseded by this. For the record, the problems it ran into and that this avoids: it hardcoded `ArrayPool<byte>.Shared` into the live buffered-read path, bypassing the configured `BufferManager` while the sibling `ReadBufferedMessageAsync` still used it; it added two public `MessageEncoder` methods while stating the public surface was unchanged; it migrated the dead `MessageEncoder` members rather than the live `HttpInput` duplicate; and it was red on net472 because of `ArrayBufferWriter<T>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

