### PR TITLE
Fix Activity memory leak in dispatcher under concurrency (#1677)

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ImmutableDispatchRuntime.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ImmutableDispatchRuntime.cs
@@ -27,8 +27,6 @@ namespace CoreWCF.Dispatcher
         private readonly MessageRpcErrorHandler _processMessageNonCleanupError;
         private readonly MessageRpcErrorHandler _processMessageCleanupError;
 
-        private Activity? _activity;
-
         internal ImmutableDispatchRuntime(DispatchRuntime dispatch)
         {
             _authenticationBehavior = AuthenticationBehavior.TryCreate(dispatch);
@@ -413,20 +411,20 @@ namespace CoreWCF.Dispatcher
                 }
             }
 
-            if (_activity != null)
+            if (rpc.Activity != null)
             {
                 var reply = rpc.Reply;
-                if (_activity.IsAllDataRequested && reply != null)
+                if (rpc.Activity.IsAllDataRequested && reply != null)
                 {
                     if (reply.IsFault)
                     {
-                        _activity.SetStatus(ActivityStatusCode.Error);
+                        rpc.Activity.SetStatus(ActivityStatusCode.Error);
                     }
 
-                    _activity.SetTag(WcfInstrumentationConstants.SoapReplyActionTag, reply.Headers.Action);
+                    rpc.Activity.SetTag(WcfInstrumentationConstants.SoapReplyActionTag, reply.Headers.Action);
                 }
 
-                _activity.Stop();
+                rpc.Activity.Stop();
             }
 
             BeforeSendReply(rpc, ref exception, ref thereIsAnUnhandledException);
@@ -591,7 +589,7 @@ namespace CoreWCF.Dispatcher
             TransferChannelFromPendingList(rpc);
             await AcquireDynamicInstanceContextAsync(rpc);
 
-            _activity = CreateActivity(ref rpc.Request, (IClientChannel)rpc.Channel.Proxy, rpc.InstanceContext);
+            rpc.Activity = CreateActivity(ref rpc.Request, (IClientChannel)rpc.Channel.Proxy, rpc.InstanceContext);
 
             AfterReceiveRequest(ref rpc);
 

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ImmutableDispatchRuntime.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ImmutableDispatchRuntime.cs
@@ -978,10 +978,9 @@ namespace CoreWCF.Dispatcher
                     rpc.ChannelHandler.InstanceContextServiceThrottle.DeactivateInstanceContext();
                 }
 
-                //if (rpc.Activity != null && DiagnosticUtility.ShouldUseActivity)
-                //{
-                //    rpc.Activity.Stop();
-                //}
+                // The desktop WCF stop of rpc.Activity lived here. rpc.Activity is now stopped in
+                // PrepareReplyAsync, once the reply tags are applied, with a safety net in
+                // MessageRpc.ProcessAsync for paths that never reach the reply code.
             }
 
             ErrorBehavior.HandleError(rpc);

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/MessageRpc.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/MessageRpc.cs
@@ -25,7 +25,6 @@ namespace CoreWCF.Dispatcher
         internal readonly object[] Correlation;
         internal readonly ServiceHostBase Host;
         internal readonly OperationContext OperationContext;
-        //internal ServiceModelActivity Activity;
         // The OpenTelemetry Activity for this request. Stored per-request (rather than on the
         // shared ImmutableDispatchRuntime) so concurrent requests cannot overwrite and leak each
         // other's Activity. See https://github.com/CoreWCF/CoreWCF/issues/1677.

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/MessageRpc.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/MessageRpc.cs
@@ -26,6 +26,10 @@ namespace CoreWCF.Dispatcher
         internal readonly ServiceHostBase Host;
         internal readonly OperationContext OperationContext;
         //internal ServiceModelActivity Activity;
+        // The OpenTelemetry Activity for this request. Stored per-request (rather than on the
+        // shared ImmutableDispatchRuntime) so concurrent requests cannot overwrite and leak each
+        // other's Activity. See https://github.com/CoreWCF/CoreWCF/issues/1677.
+        internal Activity Activity;
         internal Guid ResponseActivityId;
         internal IAsyncResult AsyncResult;
         internal Task TaskResult;
@@ -77,7 +81,7 @@ namespace CoreWCF.Dispatcher
             // TODO: ChannelHandler supplied an ErrorHandler, need to supply this some other way.
             //Fx.Assert(channelHandler != null, "System.ServiceModel.Dispatcher.MessageRpc.MessageRpc(), channelHandler == null");
 
-            //this.Activity = null;
+            Activity = null;
             //this.EventTraceActivity = eventTraceActivity;
             AsyncResult = null;
             TaskResult = null;

--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/MessageRpc.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/MessageRpc.cs
@@ -509,6 +509,27 @@ namespace CoreWCF.Dispatcher
             }
             finally
             {
+                // Safety net for the Activity owned by this rpc. It is normally stopped in
+                // ImmutableDispatchRuntime.PrepareReplyAsync, once the reply tags have been applied;
+                // this runs after that (including after the error processor above has run), so on
+                // every path that already stopped it Activity.Stop() is a no-op. It only bites when
+                // an exception escaped the pipeline without ever reaching the reply code, where the
+                // Activity would otherwise never be stopped and would live on until process exit.
+                try
+                {
+                    Activity?.Stop();
+                }
+                catch (Exception e)
+                {
+                    if (Fx.IsFatal(e))
+                    {
+#pragma warning disable CA2219 // Do not raise exceptions in finally clauses - Fx.IsFatal filters out non-process ending exceptions
+                        throw;
+#pragma warning restore CA2219 // Do not raise exceptions in finally clauses
+                    }
+                    DiagnosticUtility.TraceHandledException(e, TraceEventType.Error);
+                }
+
                 try
                 {
                     DecrementBusyCount();

--- a/src/CoreWCF.Primitives/tests/TelemetryTests.cs
+++ b/src/CoreWCF.Primitives/tests/TelemetryTests.cs
@@ -244,18 +244,23 @@ public class TelemetryTests
         // reply has arrived every Activity that is going to be stopped already has been. Filter by
         // the unique action DisplayName so activities from other tests sharing the static
         // CoreWCF.Primitives ActivitySource cannot skew the counts.
-        var startedIds = startedActivities.Where(a => a.DisplayName == echoAction).Select(a => a.SpanId).ToList();
-        var stoppedIds = stoppedActivities.Where(a => a.DisplayName == echoAction).Select(a => a.SpanId).ToHashSet();
+        //
+        // Identify activities by object reference, not SpanId: on .NET Framework the default
+        // ActivityIdFormat is Hierarchical, so Activity.SpanId is empty for every activity and
+        // cannot distinguish them. Activity does not override Equals/GetHashCode, so HashSet and
+        // Distinct() use reference equality, which is exactly the identity we want here.
+        var started = startedActivities.Where(a => a.DisplayName == echoAction).ToList();
+        var stopped = new HashSet<Activity>(stoppedActivities.Where(a => a.DisplayName == echoAction));
 
-        Assert.Equal(RequestCount, startedIds.Count);
-        Assert.Equal(RequestCount, startedIds.Distinct().Count());
+        Assert.Equal(RequestCount, started.Count);
+        Assert.Equal(RequestCount, started.Distinct().Count());
 
         // Every started Activity must also have been stopped. With the shared-field bug the
         // overwritten Activities are never passed to Stop(), so they are missing here.
-        var leaked = startedIds.Where(id => !stoppedIds.Contains(id)).ToList();
+        var leaked = started.Where(a => !stopped.Contains(a)).ToList();
         Assert.True(leaked.Count == 0,
             $"{leaked.Count} of {RequestCount} started Activities were never stopped (leaked). " +
-            $"Started: {startedIds.Count}, distinct stopped: {stoppedIds.Count}.");
+            $"Started: {started.Count}, distinct stopped: {stopped.Count}.");
     }
 
     [CoreWCF.ServiceContract]

--- a/src/CoreWCF.Primitives/tests/TelemetryTests.cs
+++ b/src/CoreWCF.Primitives/tests/TelemetryTests.cs
@@ -206,10 +206,12 @@ public class TelemetryTests
         // been created) until all RequestCount requests have arrived. This forces all the
         // Activities to be alive simultaneously, deterministically exercising the shared-field
         // race instead of relying on lucky timing.
-        using var allRequestsEntered = new CountdownEvent(RequestCount);
-        using var releaseGate = new ManualResetEventSlim(false);
-        ConcurrentTelemetryService.OnOperationEntered = allRequestsEntered;
-        ConcurrentTelemetryService.ReleaseGate = releaseGate;
+        //
+        // The operation awaits a TaskCompletionSource rather than blocking on a wait handle: a
+        // blocking wait pins one thread-pool thread per in-flight request, so the test would be
+        // gated on thread injection (roughly one thread per second above MinThreads) and time out
+        // on a runner with few cores. Awaiting parks each request without holding a thread.
+        ConcurrentTelemetryService.Reset(RequestCount);
 
         ActivitySource.AddActivityListener(listener);
 
@@ -221,24 +223,32 @@ public class TelemetryTests
             IServiceChannelDispatcher dispatcher = await serviceDispatcher.CreateServiceChannelDispatcherAsync(mockChannel);
             var requestContext = TestRequestContext.Create(serviceAddress, echoAction);
             contexts.Add(requestContext);
-            // Run the pipeline on the thread pool: the operation blocks on the gate below, so
-            // dispatching inline would stall this loop before every request is in flight.
+            // Start each pipeline on its own thread-pool work item so the requests do not share the
+            // loop's execution context (OperationContext.Current is ambient state the synchronous
+            // head of the pipeline writes to).
             dispatchTasks.Add(Task.Run(() => dispatcher.DispatchAsync(requestContext)));
         }
 
-        Assert.True(allRequestsEntered.Wait(TimeSpan.FromSeconds(30)),
-            $"Only {RequestCount - allRequestsEntered.CurrentCount} of {RequestCount} requests reached the service operation.");
+        bool allRequestsEntered = await CompletesWithinAsync(ConcurrentTelemetryService.AllRequestsEntered.Task,
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
         // All Activities have now been created (and, with the bug, all but one overwritten in
         // the shared field). Let the operations complete so each runs the reply path that stops
-        // the Activity.
-        releaseGate.Set();
+        // the Activity. Release unconditionally - even when the wait above timed out - and drain
+        // the pipeline before asserting, so a failure never leaves requests parked in the
+        // operation while the test tears down.
+        ConcurrentTelemetryService.ReleaseGate.TrySetResult(true);
+        bool allRequestsCompleted = await CompletesWithinAsync(Task.WhenAll(dispatchTasks),
+            TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        Assert.True(allRequestsEntered,
+            $"Only {ConcurrentTelemetryService.EnteredRequests} of {RequestCount} requests reached the service operation.");
+        Assert.True(allRequestsCompleted, "Not every dispatched request completed within 30s.");
 
         foreach (var requestContext in contexts)
         {
             Assert.True(await requestContext.WaitForReplyAsync(TestContext.Current.CancellationToken), "Dispatcher didn't send reply");
         }
-        await Task.WhenAll(dispatchTasks);
 
         // The Activity is stopped synchronously (before the reply is sent), so by the time every
         // reply has arrived every Activity that is going to be stopped already has been. Filter by
@@ -261,6 +271,23 @@ public class TelemetryTests
         Assert.True(leaked.Count == 0,
             $"{leaked.Count} of {RequestCount} started Activities were never stopped (leaked). " +
             $"Started: {started.Count}, distinct stopped: {stopped.Count}.");
+    }
+
+    // Returns true if <paramref name="task"/> completed before the timeout elapsed, false otherwise.
+    // Unlike a blocking wait this holds no thread, and unlike awaiting the task directly it turns a
+    // hang into a reportable result instead of running until the test host kills the process.
+    private static async Task<bool> CompletesWithinAsync(Task task, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        Task completed = await Task.WhenAny(task, Task.Delay(timeout, timeoutCts.Token));
+        timeoutCts.Cancel();
+        if (!ReferenceEquals(completed, task))
+        {
+            return false;
+        }
+
+        await task; // surface any faults from the awaited work
+        return true;
     }
 
     [CoreWCF.ServiceContract]
@@ -286,21 +313,43 @@ public class TelemetryTests
     {
         [CoreWCF.OperationContract]
         [System.ServiceModel.OperationContract]
-        string Echo(string echo);
+        Task<string> Echo(string echo);
     }
 
     [CoreWCF.ServiceBehavior(ConcurrencyMode = CoreWCF.ConcurrencyMode.Multiple, InstanceContextMode = CoreWCF.InstanceContextMode.Single)]
     internal class ConcurrentTelemetryService : IConcurrentTelemetryService
     {
-        internal static CountdownEvent OnOperationEntered;
-        internal static ManualResetEventSlim ReleaseGate;
+        private static int s_expectedRequests;
+        private static int s_enteredRequests;
 
-        public string Echo(string echo)
+        // Completes once s_expectedRequests requests have reached Echo.
+        internal static TaskCompletionSource<bool> AllRequestsEntered { get; private set; }
+
+        // Completed by the test to let every parked request run to completion.
+        internal static TaskCompletionSource<bool> ReleaseGate { get; private set; }
+
+        internal static int EnteredRequests => Volatile.Read(ref s_enteredRequests);
+
+        internal static void Reset(int expectedRequests)
+        {
+            s_expectedRequests = expectedRequests;
+            Volatile.Write(ref s_enteredRequests, 0);
+            // RunContinuationsAsynchronously so completing either source never runs the waiters
+            // inline on the signalling thread.
+            AllRequestsEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            ReleaseGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public async Task<string> Echo(string echo)
         {
             // Signal that this request has reached the operation (its Activity already exists),
-            // then wait until the test releases all requests at once.
-            OnOperationEntered.Signal();
-            ReleaseGate.Wait(TimeSpan.FromSeconds(30));
+            // then park - without holding a thread - until the test releases all requests at once.
+            if (Interlocked.Increment(ref s_enteredRequests) == s_expectedRequests)
+            {
+                AllRequestsEntered.TrySetResult(true);
+            }
+
+            await ReleaseGate.Task;
             return echo;
         }
     }

--- a/src/CoreWCF.Primitives/tests/TelemetryTests.cs
+++ b/src/CoreWCF.Primitives/tests/TelemetryTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -148,6 +149,110 @@ public class TelemetryTests
         Assert.Equivalent(startedTags[6], stoppedTags[6]);
     }
 
+    // Regression test for https://github.com/CoreWCF/CoreWCF/issues/1677
+    // Prior to the fix, the per-request Activity was stored in a single instance field
+    // (ImmutableDispatchRuntime._activity) shared by every request flowing through the
+    // endpoint. Under concurrency, a later request overwrote the field before an earlier
+    // request reached the code that stops the Activity, so the earlier Activity was never
+    // stopped. Those never-stopped Activity instances accumulated on the Gen2 heap and
+    // eventually exhausted memory. This test dispatches several requests concurrently and
+    // asserts that every started Activity is also stopped.
+    [Fact]
+    public async Task Concurrent_Requests_Do_Not_Leak_Activities()
+    {
+        // Kept below the default MaxConcurrentCalls floor (16 * ProcessorCount, i.e. 16 even on a
+        // single-core runner) so all requests can be in flight simultaneously without any being
+        // held back by the concurrency throttle, which would deadlock against the gate below.
+        const int RequestCount = 10;
+        string echoAction = "http://tempuri.org/IConcurrentTelemetryService/Echo";
+        var startedActivities = new ConcurrentBag<Activity>();
+        var stoppedActivities = new ConcurrentBag<Activity>();
+
+        // Filter by the unique DisplayName (the SOAP action) so activities created by other
+        // tests sharing the static CoreWCF.Primitives ActivitySource cannot skew the counts.
+        // See the detailed note in Basic_Telemetry_Test about ActivityListener attachment timing.
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = activitySource => activitySource.Name == "CoreWCF.Primitives",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => { if (activity.DisplayName == echoAction) startedActivities.Add(activity); },
+            ActivityStopped = activity => { if (activity.DisplayName == echoAction) stoppedActivities.Add(activity); }
+        };
+
+        string serviceAddress = "http://localhost/dummy";
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddServiceModelServices();
+        IServer server = new MockServer();
+        services.AddSingleton(server);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.RegisterApplicationLifetime();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+        IServiceBuilder serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
+        serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
+        serviceBuilder.AddService<ConcurrentTelemetryService>();
+        var binding = new CustomBinding("BindingName", "BindingNS");
+        binding.Elements.Add(new MockTransportBindingElement());
+        serviceBuilder.AddServiceEndpoint<ConcurrentTelemetryService, IConcurrentTelemetryService>(binding, serviceAddress);
+        await serviceBuilder.OpenAsync(TestContext.Current.CancellationToken);
+        IDispatcherBuilder dispatcherBuilder = serviceProvider.GetRequiredService<IDispatcherBuilder>();
+        List<IServiceDispatcher> dispatchers = dispatcherBuilder.BuildDispatchers(typeof(ConcurrentTelemetryService));
+        IServiceDispatcher serviceDispatcher = Assert.Single(dispatchers);
+
+        // Gate: hold every request inside the service operation (i.e. after its Activity has
+        // been created) until all RequestCount requests have arrived. This forces all the
+        // Activities to be alive simultaneously, deterministically exercising the shared-field
+        // race instead of relying on lucky timing.
+        using var allRequestsEntered = new CountdownEvent(RequestCount);
+        using var releaseGate = new ManualResetEventSlim(false);
+        ConcurrentTelemetryService.OnOperationEntered = allRequestsEntered;
+        ConcurrentTelemetryService.ReleaseGate = releaseGate;
+
+        ActivitySource.AddActivityListener(listener);
+
+        var contexts = new List<TestRequestContext>(RequestCount);
+        var dispatchTasks = new List<Task>(RequestCount);
+        for (int i = 0; i < RequestCount; i++)
+        {
+            IChannel mockChannel = new MockReplyChannel(serviceProvider);
+            IServiceChannelDispatcher dispatcher = await serviceDispatcher.CreateServiceChannelDispatcherAsync(mockChannel);
+            var requestContext = TestRequestContext.Create(serviceAddress, echoAction);
+            contexts.Add(requestContext);
+            // Run the pipeline on the thread pool: the operation blocks on the gate below, so
+            // dispatching inline would stall this loop before every request is in flight.
+            dispatchTasks.Add(Task.Run(() => dispatcher.DispatchAsync(requestContext)));
+        }
+
+        Assert.True(allRequestsEntered.Wait(TimeSpan.FromSeconds(30)),
+            $"Only {RequestCount - allRequestsEntered.CurrentCount} of {RequestCount} requests reached the service operation.");
+
+        // All Activities have now been created (and, with the bug, all but one overwritten in
+        // the shared field). Let the operations complete so each runs the reply path that stops
+        // the Activity.
+        releaseGate.Set();
+
+        foreach (var requestContext in contexts)
+        {
+            Assert.True(await requestContext.WaitForReplyAsync(TestContext.Current.CancellationToken), "Dispatcher didn't send reply");
+        }
+        await Task.WhenAll(dispatchTasks);
+
+        // The Activity is stopped synchronously (before the reply is sent), so by the time every
+        // reply has arrived every Activity that is going to be stopped already has been.
+        var startedIds = startedActivities.Select(a => a.SpanId).ToList();
+        var stoppedIds = stoppedActivities.Select(a => a.SpanId).ToHashSet();
+
+        Assert.Equal(RequestCount, startedIds.Count);
+        Assert.Equal(RequestCount, startedIds.Distinct().Count());
+
+        // Every started Activity must also have been stopped. With the shared-field bug the
+        // overwritten Activities are never passed to Stop(), so they are missing here.
+        var leaked = startedIds.Where(id => !stoppedIds.Contains(id)).ToList();
+        Assert.True(leaked.Count == 0,
+            $"{leaked.Count} of {RequestCount} started Activities were never stopped (leaked). " +
+            $"Started: {startedIds.Count}, distinct stopped: {stoppedIds.Count}.");
+    }
+
     [CoreWCF.ServiceContract]
     [System.ServiceModel.ServiceContract]
     public interface ISimpleTelemetryService
@@ -161,6 +266,31 @@ public class TelemetryTests
     {
         public string Echo(string echo)
         {
+            return echo;
+        }
+    }
+
+    [CoreWCF.ServiceContract]
+    [System.ServiceModel.ServiceContract]
+    public interface IConcurrentTelemetryService
+    {
+        [CoreWCF.OperationContract]
+        [System.ServiceModel.OperationContract]
+        string Echo(string echo);
+    }
+
+    [CoreWCF.ServiceBehavior(ConcurrencyMode = CoreWCF.ConcurrencyMode.Multiple, InstanceContextMode = CoreWCF.InstanceContextMode.Single)]
+    internal class ConcurrentTelemetryService : IConcurrentTelemetryService
+    {
+        internal static CountdownEvent OnOperationEntered;
+        internal static ManualResetEventSlim ReleaseGate;
+
+        public string Echo(string echo)
+        {
+            // Signal that this request has reached the operation (its Activity already exists),
+            // then wait until the test releases all requests at once.
+            OnOperationEntered.Signal();
+            ReleaseGate.Wait(TimeSpan.FromSeconds(30));
             return echo;
         }
     }

--- a/src/CoreWCF.Primitives/tests/TelemetryTests.cs
+++ b/src/CoreWCF.Primitives/tests/TelemetryTests.cs
@@ -168,15 +168,18 @@ public class TelemetryTests
         var startedActivities = new ConcurrentBag<Activity>();
         var stoppedActivities = new ConcurrentBag<Activity>();
 
-        // Filter by the unique DisplayName (the SOAP action) so activities created by other
-        // tests sharing the static CoreWCF.Primitives ActivitySource cannot skew the counts.
+        // Capture every activity here and filter by DisplayName only at assertion time. The
+        // DisplayName (the SOAP action) is assigned inside CreateActivity *after* StartActivity
+        // returns, but ActivityStarted fires *during* StartActivity, so at that moment DisplayName
+        // is still the raw activity name. Filtering inside the callback would therefore drop every
+        // activity. Activity is a reference type, so reading DisplayName later sees the final value.
         // See the detailed note in Basic_Telemetry_Test about ActivityListener attachment timing.
         using var listener = new ActivityListener
         {
             ShouldListenTo = activitySource => activitySource.Name == "CoreWCF.Primitives",
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
-            ActivityStarted = activity => { if (activity.DisplayName == echoAction) startedActivities.Add(activity); },
-            ActivityStopped = activity => { if (activity.DisplayName == echoAction) stoppedActivities.Add(activity); }
+            ActivityStarted = activity => startedActivities.Add(activity),
+            ActivityStopped = activity => stoppedActivities.Add(activity)
         };
 
         string serviceAddress = "http://localhost/dummy";
@@ -238,9 +241,11 @@ public class TelemetryTests
         await Task.WhenAll(dispatchTasks);
 
         // The Activity is stopped synchronously (before the reply is sent), so by the time every
-        // reply has arrived every Activity that is going to be stopped already has been.
-        var startedIds = startedActivities.Select(a => a.SpanId).ToList();
-        var stoppedIds = stoppedActivities.Select(a => a.SpanId).ToHashSet();
+        // reply has arrived every Activity that is going to be stopped already has been. Filter by
+        // the unique action DisplayName so activities from other tests sharing the static
+        // CoreWCF.Primitives ActivitySource cannot skew the counts.
+        var startedIds = startedActivities.Where(a => a.DisplayName == echoAction).Select(a => a.SpanId).ToList();
+        var stoppedIds = stoppedActivities.Where(a => a.DisplayName == echoAction).Select(a => a.SpanId).ToHashSet();
 
         Assert.Equal(RequestCount, startedIds.Count);
         Assert.Equal(RequestCount, startedIds.Distinct().Count());

--- a/src/CoreWCF.Primitives/tests/TelemetryTests.cs
+++ b/src/CoreWCF.Primitives/tests/TelemetryTests.cs
@@ -226,7 +226,7 @@ public class TelemetryTests
             // Start each pipeline on its own thread-pool work item so the requests do not share the
             // loop's execution context (OperationContext.Current is ambient state the synchronous
             // head of the pipeline writes to).
-            dispatchTasks.Add(Task.Run(() => dispatcher.DispatchAsync(requestContext)));
+            dispatchTasks.Add(Task.Run(() => dispatcher.DispatchAsync(requestContext), TestContext.Current.CancellationToken));
         }
 
         bool allRequestsEntered = await CompletesWithinAsync(ConcurrentTelemetryService.AllRequestsEntered.Task,
@@ -247,7 +247,13 @@ public class TelemetryTests
 
         foreach (var requestContext in contexts)
         {
-            Assert.True(await requestContext.WaitForReplyAsync(TestContext.Current.CancellationToken), "Dispatcher didn't send reply");
+            // Bound the wait: WaitForReplyAsync only observes the test host's cancellation token, so
+            // a pipeline that completed without replying would otherwise park here until the whole
+            // run is cancelled instead of failing with a usable message.
+            Task<bool> replyTask = requestContext.WaitForReplyAsync(TestContext.Current.CancellationToken);
+            Assert.True(await CompletesWithinAsync(replyTask, TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken),
+                "Dispatcher didn't send reply within 30s.");
+            Assert.True(await replyTask, "Dispatcher didn't send reply");
         }
 
         // The Activity is stopped synchronously (before the reply is sent), so by the time every


### PR DESCRIPTION
The OpenTelemetry Activity for a request was stored in a single instance field (ImmutableDispatchRuntime._activity) that is shared by every request flowing through an endpoint's dispatch runtime. Under concurrent load a later request overwrote the field before an earlier request reached the code that stops the Activity, so the earlier Activity was never stopped. The never-stopped Activity instances accumulated on the Gen2 heap and eventually exhausted memory. This only manifested when an ActivityListener was registered for the CoreWCF ActivitySource.

Move the Activity to per-request state on MessageRpc so each request owns and stops its own Activity, eliminating the cross-request race. This mirrors the original WCF design, which carried the activity on the RPC.

Add a regression test that dispatches several requests concurrently, holds them all inside the operation via a gate so their Activities are alive simultaneously, and asserts every started Activity is also stopped. The test fails before the fix (only the last Activity is stopped) and passes after it.