### PR TITLE
perf(mtom): accumulate MIME headers into a StringBuilder

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Xml/XmlMtomReader.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Xml/XmlMtomReader.cs
@@ -2099,6 +2099,14 @@ namespace CoreWCF.Xml
             EOF
         }
 
+        // Names and values are appended one buffer-full (or one folded continuation
+        // line) at a time, so they accumulate into StringBuilders rather than by string
+        // concatenation, which was O(N^2) on long or folded headers. The materialized
+        // string is cached because Name/Value are read once per Read() by the callers.
+        private readonly StringBuilder valueBuilder = new StringBuilder();
+        private readonly StringBuilder nameBuilder = new StringBuilder();
+        private bool hasValue;
+        private bool hasName;
         private string value;
         private byte[] buffer = new byte[1024];
         private int maxOffset;
@@ -2115,9 +2123,9 @@ namespace CoreWCF.Xml
             this.stream = stream;
         }
 
-        public string Value => value;
+        public string Value => hasValue ? (value ??= valueBuilder.ToString()) : null;
 
-        public string Name => name;
+        public string Name => hasName ? (name ??= nameBuilder.ToString()) : null;
 
         public void Close()
         {
@@ -2129,6 +2137,10 @@ namespace CoreWCF.Xml
         {
             name = null;
             value = null;
+            hasName = false;
+            hasValue = false;
+            nameBuilder.Clear();
+            valueBuilder.Clear();
 
             while (readState != ReadState.EOF)
             {
@@ -2143,7 +2155,7 @@ namespace CoreWCF.Xml
                     break;
             }
 
-            return value != null;
+            return hasValue;
         }
 
         private bool ProcessBuffer(int maxBuffer, ref int remaining)
@@ -2282,19 +2294,17 @@ namespace CoreWCF.Xml
         private void AppendValue(string value, int maxBuffer, ref int remaining)
         {
             XmlMtomReader.DecrementBufferQuota(maxBuffer, ref remaining, value.Length * sizeof(char));
-            if (this.value == null)
-                this.value = value;
-            else
-                this.value += value;
+            valueBuilder.Append(value);
+            hasValue = true;
+            this.value = null;
         }
 
         private void AppendName(string value, int maxBuffer, ref int remaining)
         {
             XmlMtomReader.DecrementBufferQuota(maxBuffer, ref remaining, value.Length * sizeof(char));
-            if (name == null)
-                name = value;
-            else
-                name += value;
+            nameBuilder.Append(value);
+            hasName = true;
+            name = null;
         }
 
     }

--- a/src/CoreWCF.Primitives/tests/MtomMimeHeaderTests.cs
+++ b/src/CoreWCF.Primitives/tests/MtomMimeHeaderTests.cs
@@ -1,0 +1,247 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using CoreWCF.Channels;
+using Xunit;
+
+namespace CoreWCF.Primitives.Tests
+{
+    /// <summary>
+    /// Regression tests for https://github.com/CoreWCF/CoreWCF/issues/1764.
+    ///
+    /// MimeHeaderReader accumulates a MIME-part header name or value one chunk at a
+    /// time: once per 1024-byte read buffer, and once more per folded continuation
+    /// line. It used to concatenate those chunks onto an immutable string, so an
+    /// N-char header cost O(N^2) copying. Because MimeHeaders.Add refunds the
+    /// MaxBufferSize quota for every unrecognised header name, the per-header quota
+    /// resets and the header count is unbounded, which let a small request expand into
+    /// an arbitrary amount of copying and garbage.
+    ///
+    /// MimeHeaderReader is internal and reachable only through the MTOM decode path,
+    /// so these tests drive it through MtomMessageEncoder rather than directly.
+    /// </summary>
+    public class MtomMimeHeaderTests
+    {
+        private const string CRLF = "\r\n";
+        private const int BodyByteCount = 4096;
+        private const int ReadBufferSize = 1024;
+
+        // Emitted verbatim by MtomMessageEncoder for the root (xop+xml) part.
+        private const string RootPartContentType = "Content-Type: application/xop+xml;charset=utf-8;type=\"text/xml\"";
+        private const string RootPartContentId = "Content-ID: <http://tempuri.org/0>";
+
+        /// <summary>
+        /// Exercises AppendValue across both split mechanisms at once: the value is
+        /// folded over several continuation lines and is long enough to span multiple
+        /// 1024-byte read buffers. Content-Type is used deliberately because it is one
+        /// of the few headers MimeHeaders keeps - a mis-assembled value fails to parse
+        /// instead of being silently discarded.
+        /// </summary>
+        [Fact]
+        public async Task FoldedAndBufferSpanningContentType_RoundTrips()
+        {
+            string payload = await BuildRootPartPayloadAsync(p => p.Replace(
+                RootPartContentType,
+                "Content-Type: application/xop+xml;" + CRLF +
+                " charset=utf-8;" + CRLF +
+                " x-ignored=\"" + new string('a', 2 * ReadBufferSize) + "\";" + CRLF +
+                " type=\"text/xml\""));
+
+            await AssertRoundTripsAsync(payload);
+        }
+
+        /// <summary>
+        /// A header with no value at all is still a header that was read, so Read() must
+        /// return true and header parsing must continue. Guards against treating
+        /// "nothing accumulated" as "no header", which would silently drop every header
+        /// after this one - including the Content-Type below it.
+        /// </summary>
+        [Fact]
+        public async Task EmptyHeaderValue_DoesNotStopHeaderParsing()
+        {
+            string payload = await BuildRootPartPayloadAsync(p => InsertHeaders(p, "x-empty:" + CRLF));
+
+            await AssertRoundTripsAsync(payload);
+        }
+
+        /// <summary>
+        /// Exercises AppendName across a read-buffer boundary. An unrecognised name is
+        /// discarded by MimeHeaders.Add, so the only observable assertion is that the
+        /// message still parses; the value-side tests cover assembly accuracy.
+        /// </summary>
+        [Fact]
+        public async Task HeaderNameSpanningReadBuffer_RoundTrips()
+        {
+            string payload = await BuildRootPartPayloadAsync(
+                p => InsertHeaders(p, "x-" + new string('a', 2 * ReadBufferSize) + ": v" + CRLF));
+
+            await AssertRoundTripsAsync(payload);
+        }
+
+        /// <summary>
+        /// Exercises AppendValue across a read-buffer boundary with no folding.
+        /// </summary>
+        [Fact]
+        public async Task HeaderValueSpanningReadBuffer_RoundTrips()
+        {
+            string payload = await BuildRootPartPayloadAsync(
+                p => InsertHeaders(p, "x-long: " + new string('a', 4 * ReadBufferSize) + CRLF));
+
+            await AssertRoundTripsAsync(payload);
+        }
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// The quadratic-behaviour guard. A single header folded four bytes at a time
+        /// ("\r\n a") produces one AppendValue per fold, so the concatenating
+        /// implementation allocated the sum of every intermediate string: roughly 500 MB
+        /// from a 70 KB request at the ~32K char quota limit. Accumulating into a
+        /// StringBuilder keeps it under 1 MB.
+        ///
+        /// Allocated bytes are asserted rather than wall-clock time because the counter
+        /// is deterministic and insensitive to CI machine load. The work runs on a
+        /// dedicated thread so the thread-local counter cannot be disturbed by an await
+        /// resuming elsewhere or by other tests running in parallel.
+        /// </summary>
+        [Fact]
+        public async Task HeavilyFoldedHeaderValue_DoesNotAllocateQuadratically()
+        {
+            // Each fold contributes 2 chars to the value, and
+            // MtomEncoderDefaults.MaxBufferSize (65536) caps one header at ~32768 chars,
+            // so stay just under that.
+            const int foldCount = 15000;
+            const long allocationCeiling = 20L * 1024 * 1024;
+
+            var folded = new StringBuilder("x-pad: a");
+            for (int i = 0; i < foldCount; i++)
+            {
+                folded.Append(CRLF).Append(" a");
+            }
+
+            folded.Append(CRLF);
+
+            string payload = await BuildRootPartPayloadAsync(p => InsertHeaders(p, folded.ToString()));
+            byte[] bytes = Encoding.UTF8.GetBytes(payload);
+
+            long allocated = 0;
+            Exception failure = null;
+            var worker = new Thread(() =>
+            {
+                try
+                {
+                    // Warm up first so JIT and first-use allocations are not attributed
+                    // to the measured read.
+                    ReadAndVerify(bytes);
+
+                    long before = GC.GetAllocatedBytesForCurrentThread();
+                    ReadAndVerify(bytes);
+                    allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+                }
+                catch (Exception ex)
+                {
+                    failure = ex;
+                }
+            });
+
+            worker.Start();
+            worker.Join();
+
+            Assert.Null(failure);
+            Assert.True(
+                allocated < allocationCeiling,
+                $"Reading a {bytes.Length} byte MTOM message with a {(foldCount * 2) + 1} char folded header " +
+                $"allocated {allocated / (1024.0 * 1024.0):F1} MB, exceeding the {allocationCeiling / (1024 * 1024)} MB " +
+                "ceiling. MIME header accumulation is quadratic again.");
+        }
+
+        private static void ReadAndVerify(byte[] payload)
+        {
+            MessageEncoder encoder = CreateEncoder();
+            Message message = encoder
+                .ReadMessageAsync(new MemoryStream(payload), int.MaxValue, encoder.ContentType)
+                .GetAwaiter().GetResult();
+
+            VerifyBody(message);
+        }
+#endif
+
+        private static MessageEncoder CreateEncoder() =>
+            new MtomMessageEncodingBindingElement(MessageVersion.Soap11, Encoding.UTF8)
+                .CreateMessageEncoderFactory().Encoder;
+
+        /// <summary>
+        /// Produces a genuine multipart/related MTOM payload with the encoder's own
+        /// writer, then lets the caller rewrite the root part's header block. Writing a
+        /// real message avoids hand-maintaining the boundary, start parameter and
+        /// content ids.
+        /// </summary>
+        private static async Task<string> BuildRootPartPayloadAsync(Func<string, string> rewriteHeaders)
+        {
+            MessageEncoder encoder = CreateEncoder();
+            Message message = Message.CreateMessage(
+                MessageVersion.Soap11, "http://tempuri.org/IEcho/Echo", new FixedSizeBodyWriter(BodyByteCount));
+
+            var stream = new MemoryStream();
+            await encoder.WriteMessageAsync(message, stream);
+            string payload = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.Contains(RootPartContentType, payload);
+
+            return rewriteHeaders(payload);
+        }
+
+        /// <summary>Inserts a header block at the top of the root part's headers.</summary>
+        private static string InsertHeaders(string payload, string headerBlock)
+        {
+            int index = payload.IndexOf(RootPartContentId, StringComparison.Ordinal);
+            Assert.True(index >= 0, "Root MIME part not found in the generated payload.");
+
+            return payload.Insert(index, headerBlock);
+        }
+
+        private static async Task AssertRoundTripsAsync(string payload)
+        {
+            MessageEncoder encoder = CreateEncoder();
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+            Message message = await encoder.ReadMessageAsync(stream, int.MaxValue, encoder.ContentType);
+
+            Assert.Equal("http://tempuri.org/IEcho/Echo", message.Headers.Action);
+            VerifyBody(message);
+        }
+
+        private static void VerifyBody(Message message)
+        {
+            XmlDictionaryReader reader = message.GetReaderAtBodyContents();
+            reader.ReadStartElement("Echo", "http://tempuri.org/");
+            reader.ReadStartElement("data", "http://tempuri.org/");
+            byte[] data = reader.ReadContentAsBase64();
+
+            Assert.Equal(BodyByteCount, data.Length);
+        }
+
+        private class FixedSizeBodyWriter : BodyWriter
+        {
+            private readonly int _byteCount;
+
+            public FixedSizeBodyWriter(int byteCount)
+                : base(true)
+            {
+                _byteCount = byteCount;
+            }
+
+            protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
+            {
+                writer.WriteStartElement("Echo", "http://tempuri.org/");
+                writer.WriteStartElement("data", "http://tempuri.org/");
+                writer.WriteBase64(new byte[_byteCount], 0, _byteCount);
+                writer.WriteEndElement();
+                writer.WriteEndElement();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1764

## The bug

`MimeHeaderReader.AppendName` / `AppendValue` concatenated each chunk onto an immutable string. Both are called once per 1024-byte read buffer, and once more per folded continuation line, so an N-char MIME-part header cost O(N²) copying.

Two things make this cheaper to trigger than the issue describes:

**Folding, not buffer chunking, is the cheap path.** `ReadWS` jumps back to `ReadValue` on a leading space or tab, so every folded continuation line is its own `AppendValue`. A minimal fold is 4 bytes (`\r\n a`), so N bytes of input produce N/4 appends rather than N/1024.

**The buffer quota does not contain it.** `DecrementBufferQuota` caps a single header at `MaxBufferSize / 2` chars (~32K at the default 65536), but `MimeHeaders.Add` refunds the quota for every *unrecognised* header name. The budget therefore resets per header while the header count stays unbounded.

## Measured impact

MTOM decode path, default `MaxBufferSize` of 65536, net8.0:

| Payload | Before | After |
| --- | --- | --- |
| 65 KB message, one ~30 000-char folded header | 430 MB allocated | 0.7 MB |
| 1.3 MB message, 20 such headers | 10.2 GB allocated, 1.1 s | 11.4 MB, 74 ms |

Scaling linearly in header count, a request at Kestrel's default 28.6 MB body limit reaches a few hundred GB of copying — matching the reporter's estimate. This only affects endpoints using MTOM message encoding; `MimeHeaderReader` has no other caller.

## The change

`MimeHeaderReader` accumulates into two reusable `StringBuilder`s and materialises the string lazily in `Name` / `Value`. That is the whole fix — quadratic to linear, and no quota-accounting change is needed once accumulation is linear.

Deliberately unchanged:

- The `DecrementBufferQuota` call stays first and identical in both helpers, so quota accounting and the exact point at which it throws are unaffected.
- The per-chunk `new string((sbyte*)start, 0, len)` temporaries stay. They are bounded by the 1024-byte read buffer and so linear in total, and removing them would mean hand-widening bytes to chars — that would change how header-value bytes ≥ 0x80 decode (`new string(sbyte*, …)` already resolves differently on net472 vs net8, and this fix should not inherit that).
- Explicit `hasName` / `hasValue` flags rather than builder length. `x:<CRLF>` legitimately produces an empty value and must still count as a header that was read; length-based logic would return `false` from `Read` and silently drop every remaining header in the part.

## Tests

New `src/CoreWCF.Primitives/tests/MtomMimeHeaderTests.cs`. `MimeHeaderReader` is internal and the repo has no `InternalsVisibleTo`, so the tests drive it through `MtomMessageEncoder` — the payload is generated by the encoder's own writer, then the root part's header block is rewritten, so there is no hand-maintained boundary or content-id.

- Four correctness tests: a `Content-Type` that is both folded and long enough to span several read buffers (a recognised header, so mis-assembly fails to parse rather than being discarded), an empty header value, a header name spanning a read buffer, and a header value spanning a read buffer.
- One guard test, `HeavilyFoldedHeaderValue_DoesNotAllocateQuadratically` (net8.0+): asserts allocated bytes stay under 20 MB for a ~30 000-char header folded 4 bytes at a time. On the previous code this reports 430 MB. Allocated bytes rather than wall-clock time keeps it deterministic under CI load, and the measured read runs on a dedicated thread so the thread-local counter is not disturbed by an `await` resuming elsewhere or by parallel tests.

Verified the correctness tests pass identically before and after the change (including the pre-existing rejection of a fold placed immediately after the colon, which is unchanged), and that the guard test fails only on the old code.

`dotnet test src/CoreWCF.Primitives/tests` — 148 passing on net8.0/net9.0/net10.0, 145 on net472 (the guard test is net8.0+).
`dotnet test src/CoreWCF.Http/tests --filter "MessageEncoding|Streaming"` — 31 passing, covering MTOM end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
