### PR TITLE
Extract W3C trace context from SOAP headers for CoreWCF server activities

### DIFF
--- a/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ImmutableDispatchRuntime.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Dispatcher/ImmutableDispatchRuntime.cs
@@ -684,9 +684,20 @@ namespace CoreWCF.Dispatcher
 
         private Activity CreateActivity(ref Message request, IClientChannel channel, InstanceContext instanceContext)
         {
-            var activity = WcfInstrumentationActivitySource.ActivitySource.StartActivity(
-                WcfInstrumentationActivitySource.IncomingRequestActivityName,
-                ActivityKind.Server);
+            Activity activity;
+            if (Activity.Current == null && W3CTraceContextMessageHeader.TryExtract(request, out ActivityContext parentContext))
+            {
+                activity = WcfInstrumentationActivitySource.ActivitySource.StartActivity(
+                    WcfInstrumentationActivitySource.IncomingRequestActivityName,
+                    ActivityKind.Server,
+                    parentContext);
+            }
+            else
+            {
+                activity = WcfInstrumentationActivitySource.ActivitySource.StartActivity(
+                    WcfInstrumentationActivitySource.IncomingRequestActivityName,
+                    ActivityKind.Server);
+            }
 
             if (activity != null)
             {

--- a/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/W3CTraceContextMessageHeader.cs
+++ b/src/CoreWCF.Primitives/src/CoreWCF/Telemetry/W3CTraceContextMessageHeader.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using CoreWCF.Channels;
+using CoreWCF.Runtime;
+
+namespace CoreWCF.Telemetry;
+
+internal static class W3CTraceContextMessageHeader
+{
+    internal const string Namespace = "https://www.w3.org/TR/trace-context/";
+
+    private const string TraceParentHeaderName = "traceparent";
+    private const string TraceStateHeaderName = "tracestate";
+
+    public static bool TryExtract(Message message, out ActivityContext parentContext)
+    {
+        parentContext = default;
+
+        if (message.Version == MessageVersion.None)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (!TryReadHeader(message.Headers, TraceParentHeaderName, out string traceParent))
+            {
+                return false;
+            }
+
+            TryReadHeader(message.Headers, TraceStateHeaderName, out string traceState);
+            return ActivityContext.TryParse(traceParent, traceState, isRemote: true, out parentContext);
+        }
+        catch (Exception exception) when (!Fx.IsFatal(exception))
+        {
+            return false;
+        }
+    }
+
+    private static bool TryReadHeader(MessageHeaders headers, string name, out string value)
+    {
+        value = null;
+        int headerIndex = headers.FindHeader(name, Namespace);
+        if (headerIndex < 0)
+        {
+            return false;
+        }
+
+        using var reader = headers.GetReaderAtHeader(headerIndex);
+        reader.Read();
+        value = reader.ReadContentAsString();
+        return true;
+    }
+}

--- a/src/CoreWCF.Primitives/tests/TelemetryTests.cs
+++ b/src/CoreWCF.Primitives/tests/TelemetryTests.cs
@@ -22,6 +22,10 @@ namespace CoreWCF.Primitives.Tests;
 [Collection("TelemetryTests")]
 public class TelemetryTests
 {
+    private const string TraceContextNamespace = "https://www.w3.org/TR/trace-context/";
+    private const string TraceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    private const string TraceState = "vendor=value";
+
     [Fact]
     public async Task Basic_Telemetry_Test()
     {
@@ -146,6 +150,195 @@ public class TelemetryTests
         Assert.Equivalent(startedTags[4], stoppedTags[4]);
         Assert.Equivalent(startedTags[5], stoppedTags[5]);
         Assert.Equivalent(startedTags[6], stoppedTags[6]);
+    }
+
+    [Fact]
+    public async Task Soap_Trace_Context_Is_Used_As_Remote_Parent_Without_Ambient_Activity()
+    {
+        DispatchResult result = await DispatchAndCaptureActivityAsync(traceParent: TraceParent);
+        Assert.True(ActivityContext.TryParse(TraceParent, null, isRemote: true, out ActivityContext expectedParent));
+
+        Assert.Equal(expectedParent.TraceId, result.Activity.TraceId);
+        Assert.Equal(expectedParent.SpanId, result.Activity.ParentSpanId);
+        Assert.True(result.SampledParentContext.IsRemote);
+    }
+
+    [Fact]
+    public async Task Missing_Trace_Context_Creates_Root_Activity()
+    {
+        DispatchResult result = await DispatchAndCaptureActivityAsync();
+
+        Assert.Equal(default, result.Activity.ParentSpanId);
+        Assert.Equal(default, result.SampledParentContext);
+    }
+
+    [Fact]
+    public async Task Malformed_Trace_Parent_Is_Ignored()
+    {
+        DispatchResult result = await DispatchAndCaptureActivityAsync(traceParent: "not-a-trace-parent");
+
+        Assert.Equal(default, result.Activity.ParentSpanId);
+        Assert.Equal(default, result.SampledParentContext);
+    }
+
+    [Fact]
+    public async Task Ambient_Activity_Takes_Precedence_Over_Soap_Trace_Context()
+    {
+        var ambientParentContext = new ActivityContext(
+            ActivityTraceId.CreateRandom(),
+            ActivitySpanId.CreateRandom(),
+            ActivityTraceFlags.Recorded);
+
+        DispatchResult result = await DispatchAndCaptureActivityAsync(
+            traceParent: TraceParent,
+            ambientParentContext: ambientParentContext);
+
+        Assert.Equal(result.AmbientContext.TraceId, result.Activity.TraceId);
+        Assert.Equal(result.AmbientContext.SpanId, result.Activity.ParentSpanId);
+        Assert.False(result.SampledParentContext.IsRemote);
+    }
+
+    [Fact]
+    public async Task Soap_Trace_State_Is_Propagated()
+    {
+        DispatchResult result = await DispatchAndCaptureActivityAsync(
+            traceParent: TraceParent,
+            traceState: TraceState);
+
+        Assert.Equal(TraceState, result.Activity.TraceStateString);
+        Assert.Equal(TraceState, result.SampledParentContext.TraceState);
+    }
+
+    [Fact]
+    public async Task Trace_Context_In_Different_Namespace_Is_Ignored()
+    {
+        DispatchResult result = await DispatchAndCaptureActivityAsync(
+            traceParent: TraceParent,
+            headerNamespace: "urn:not-w3c-trace-context");
+
+        Assert.Equal(default, result.Activity.ParentSpanId);
+        Assert.Equal(default, result.SampledParentContext);
+    }
+
+    [Fact]
+    public async Task Duplicate_Trace_Parent_Is_Ignored()
+    {
+        DispatchResult result = await DispatchAndCaptureActivityAsync(
+            traceParent: TraceParent,
+            duplicateTraceParent: true);
+
+        Assert.Equal(default, result.Activity.ParentSpanId);
+        Assert.Equal(default, result.SampledParentContext);
+    }
+
+    private static async Task<DispatchResult> DispatchAndCaptureActivityAsync(
+        string traceParent = null,
+        string traceState = null,
+        string headerNamespace = TraceContextNamespace,
+        bool duplicateTraceParent = false,
+        ActivityContext? ambientParentContext = null)
+    {
+        const string telemetryEchoAction = "http://tempuri.org/ISimpleTelemetryService/Echo";
+        const string serviceAddress = "http://localhost/dummy";
+        var stoppedActivities = new ConcurrentBag<Activity>();
+        ActivityContext sampledParentContext = default;
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = activitySource => activitySource.Name == "CoreWCF.Primitives",
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
+            {
+                sampledParentContext = options.Parent;
+                return ActivitySamplingResult.AllData;
+            },
+            ActivityStopped = activity => stoppedActivities.Add(activity)
+        };
+
+        Activity previousActivity = Activity.Current;
+        Activity ambientActivity = null;
+        Activity.Current = null;
+
+        try
+        {
+            if (ambientParentContext.HasValue)
+            {
+                ActivityContext parent = ambientParentContext.Value;
+                ambientActivity = new Activity("ambient")
+                    .SetIdFormat(ActivityIdFormat.W3C)
+                    .SetParentId(parent.TraceId, parent.SpanId, parent.TraceFlags)
+                    .Start();
+            }
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddServiceModelServices();
+            IServer server = new MockServer();
+            services.AddSingleton(server);
+            services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+            services.RegisterApplicationLifetime();
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            IServiceBuilder serviceBuilder = serviceProvider.GetRequiredService<IServiceBuilder>();
+            serviceBuilder.BaseAddresses.Add(new Uri(serviceAddress));
+            serviceBuilder.AddService<SimpleTelemetryService>();
+            var binding = new CustomBinding("BindingName", "BindingNS");
+            binding.Elements.Add(new MockTransportBindingElement());
+            serviceBuilder.AddServiceEndpoint<SimpleTelemetryService, ISimpleTelemetryService>(binding, serviceAddress);
+            await serviceBuilder.OpenAsync(TestContext.Current.CancellationToken);
+            IDispatcherBuilder dispatcherBuilder = serviceProvider.GetRequiredService<IDispatcherBuilder>();
+            System.Collections.Generic.List<IServiceDispatcher> dispatchers =
+                dispatcherBuilder.BuildDispatchers(typeof(SimpleTelemetryService));
+            IServiceChannelDispatcher dispatcher =
+                await Assert.Single(dispatchers).CreateServiceChannelDispatcherAsync(new MockReplyChannel(serviceProvider));
+            var requestContext = TestRequestContext.Create(serviceAddress, telemetryEchoAction);
+
+            if (traceParent != null)
+            {
+                requestContext.RequestMessage.Headers.Add(
+                    MessageHeader.CreateHeader("traceparent", headerNamespace, traceParent));
+            }
+
+            if (duplicateTraceParent)
+            {
+                requestContext.RequestMessage.Headers.Add(
+                    MessageHeader.CreateHeader("traceparent", headerNamespace, traceParent));
+            }
+
+            if (traceState != null)
+            {
+                requestContext.RequestMessage.Headers.Add(
+                    MessageHeader.CreateHeader("tracestate", headerNamespace, traceState));
+            }
+
+            ActivitySource.AddActivityListener(listener);
+            await dispatcher.DispatchAsync(requestContext);
+            Assert.True(
+                await requestContext.WaitForReplyAsync(TestContext.Current.CancellationToken),
+                "Dispatcher didn't send reply");
+
+            Activity activity = Assert.Single(stoppedActivities, a => a.DisplayName == telemetryEchoAction);
+            return new DispatchResult(activity, sampledParentContext, ambientActivity?.Context ?? default);
+        }
+        finally
+        {
+            ambientActivity?.Stop();
+            Activity.Current = previousActivity;
+        }
+    }
+
+    private sealed class DispatchResult
+    {
+        public DispatchResult(Activity activity, ActivityContext sampledParentContext, ActivityContext ambientContext)
+        {
+            Activity = activity;
+            SampledParentContext = sampledParentContext;
+            AmbientContext = ambientContext;
+        }
+
+        public Activity Activity { get; }
+
+        public ActivityContext SampledParentContext { get; }
+
+        public ActivityContext AmbientContext { get; }
     }
 
     [CoreWCF.ServiceContract]

--- a/src/CoreWCF.Primitives/tests/TelemetryTests.cs
+++ b/src/CoreWCF.Primitives/tests/TelemetryTests.cs
@@ -241,14 +241,17 @@ public class TelemetryTests
         const string telemetryEchoAction = "http://tempuri.org/ISimpleTelemetryService/Echo";
         const string serviceAddress = "http://localhost/dummy";
         var stoppedActivities = new ConcurrentBag<Activity>();
-        ActivityContext sampledParentContext = default;
+
+        // ActivityListener is global, so sampling callbacks can also run for concurrent CoreWCF requests.
+        // Correlate each sampled parent with the activity created from that sampling decision.
+        var sampledParentContexts = new ConcurrentDictionary<ActivityTraceId, ActivityContext>();
 
         using var listener = new ActivityListener
         {
             ShouldListenTo = activitySource => activitySource.Name == "CoreWCF.Primitives",
             Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
             {
-                sampledParentContext = options.Parent;
+                sampledParentContexts[options.TraceId] = options.Parent;
                 return ActivitySamplingResult.AllData;
             },
             ActivityStopped = activity => stoppedActivities.Add(activity)
@@ -316,6 +319,7 @@ public class TelemetryTests
                 "Dispatcher didn't send reply");
 
             Activity activity = Assert.Single(stoppedActivities, a => a.DisplayName == telemetryEchoAction);
+            Assert.True(sampledParentContexts.TryGetValue(activity.TraceId, out ActivityContext sampledParentContext));
             return new DispatchResult(activity, sampledParentContext, ambientActivity?.Context ?? default);
         }
         finally


### PR DESCRIPTION
## Related issue

Fixes #1768

## Summary

This change connects CoreWCF server traces to instrumented WCF client traces over NetNamedPipe and NetTcp.

`OpenTelemetry.Instrumentation.Wcf` propagates W3C trace context through SOAP headers, but CoreWCF previously relied exclusively on `Activity.Current` when starting `CoreWCF.Primitives.IncomingRequest`. Framed transports do not create an ambient transport activity, so the CoreWCF request activity started a new root trace.

The change extracts the standard `traceparent` and optional `tracestate` SOAP headers when no ambient activity exists and supplies the extracted remote `ActivityContext` to the existing CoreWCF activity source.

No production dependency on OpenTelemetry is added.

## Changes

- Add an internal `W3CTraceContextMessageHeader` helper in the CoreWCF telemetry area.
- Read `traceparent` and optional `tracestate` from the exact namespace:

  ```text
  https://www.w3.org/TR/trace-context/
  ```

- Parse the values with `ActivityContext.TryParse` and `isRemote: true`.
- Use the extracted context as the parent of `CoreWCF.Primitives.IncomingRequest` only when `Activity.Current` is `null`.
- Preserve the existing implicit-parent behavior when an ambient activity exists.
- Treat missing, malformed, duplicated, unreadable, and incorrectly namespaced headers as a safe fallback rather than a dispatch failure.
- Keep all existing activity naming, display-name handling, tags, status handling, sampling behavior, and activity source names unchanged.

## Parent selection

The request activity now selects its parent in this order:

1. Existing ambient `Activity.Current`, when present.
2. A valid remote W3C context extracted from the SOAP message.
3. Existing root activity behavior when neither parent is available.

Keeping the ambient activity first is important for HTTP hosting, where the ASP.NET Core transport activity should remain between the remote client span and the CoreWCF server span.

## Why this belongs in CoreWCF

The built-in request activity is created in `ImmutableDispatchRuntime` before `IDispatchMessageInspector.AfterReceiveRequest` runs. Application-level message inspectors cannot retroactively change the parent of that activity.

CoreWCF already owns the SOAP message and the server activity creation point, so it can perform the extraction before the activity starts without requiring an OpenTelemetry SDK dependency.

## Tests

Dispatcher-level telemetry tests cover the real CoreWCF activity creation path for:

- valid SOAP `traceparent` without an ambient activity;
- remote parent interpretation through the activity listener's sampling context;
- requests without propagation headers;
- malformed `traceparent`;
- ambient activity precedence over a different SOAP context;
- `tracestate` propagation;
- a valid header in the wrong namespace;
- duplicate `traceparent` headers.

Validation performed:

```text
CoreWCF.Primitives.Tests, net10.0
Passed: 150, Failed: 0, Skipped: 0

TelemetryTests, net472
Passed: 8, Failed: 0, Skipped: 0
```

An end-to-end .NET 10 NetNamedPipe repro was also executed with an instrumented WCF client:

```text
CoreWCF 1.9.1 package:
  WCF client traceId != CoreWCF server traceId
  CoreWCF parentSpanId = 0000000000000000
  extracted parentIsRemote = False

Local CoreWCF with this change:
  WCF client traceId == CoreWCF server traceId
  CoreWCF parentSpanId == WCF client spanId
  extracted parentIsRemote = True
```

## Compatibility and security

- No public API changes.
- No new production package dependencies.
- No OpenTelemetry SDK dependency.
- Non-SOAP messages retain the existing behavior.
- Invalid or hostile propagation input does not escape into request processing as an exception.
- Duplicate propagation headers are rejected through the safe fallback path.
- Extracted contexts are explicitly marked as remote.
- Baggage extraction is intentionally out of scope.

## Checklist

- [x] Existing HTTP ambient-parent behavior is preserved.
- [x] NetNamedPipe trace continuity is verified end to end.
- [x] The shared dispatcher path used by NetTcp consumes the same extracted context.
- [x] Missing and invalid headers do not fail dispatch.
- [x] Existing telemetry names, tags, and status handling are unchanged.
- [x] Tests pass on .NET 10 and .NET Framework 4.7.2.